### PR TITLE
add extra config file parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class redis (
   $daemonize                   = $::redis::params::daemonize,
   $databases                   = $::redis::params::databases,
   $dbfilename                  = $::redis::params::dbfilename,
+  $extra_config_file           = $::redis::params::extra_config_file,
   $hash_max_ziplist_entries    = $::redis::params::hash_max_ziplist_entries,
   $hash_max_ziplist_value      = $::redis::params::hash_max_ziplist_value,
   $list_max_ziplist_entries    = $::redis::params::list_max_ziplist_entries,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class redis::params {
   $daemonize                   = true
   $databases                   = 16
   $dbfilename                  = 'dump.rdb'
+  $extra_config_file           = undef
   $hash_max_ziplist_entries    = 512
   $hash_max_ziplist_value      = 64
   $list_max_ziplist_entries    = 512

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -541,3 +541,7 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 #
 # include /path/to/local.conf
 # include /path/to/other.conf
+<% if @extra_config_file -%>
+include <%= @extra_config_file %>
+<% end -%>
+


### PR DESCRIPTION
Add an extra config file parameter at the end of the template redis.conf.erb.
It is undefined by default, but if you add the parameter in your puppetdb or elsewhere (e.g. redis::extra_config_file: '/etc/redis/rename-command.conf' in hiera) , you will have "include /etc/redis/rename-command.conf" at the end of your /etc/redis.conf file.
It could be very useful if like me, you want to rename and/or disable some commands.
