### PR TITLE
Fixed #246: 2.8 version of Redis on Debian 8 errors out

### DIFF
--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -21,12 +21,11 @@ class redis::preinstall {
             source => 'http://www.dotdeb.org/dotdeb.gpg',
           },
           include  => { 'src' => true },
-          before   => [
-            Class['apt::update'],
-            Package[$::redis::package_name],
-          ],
-        }
-
+        } -> apt::pin { $::redis::package_name:
+          packages => $::redis::package_name,
+          origin => "packages.dotdeb.org",
+          priority => 1000
+        } ~> Class['apt::update'] -> Package[$::redis::package_name]
       }
 
       'Ubuntu': {


### PR DESCRIPTION
On Debian 8, the `apt-policy` still keeps outdated `2.8.17` preferable, so the outdated version gets installed. This fix makes sure the right version will be installed.

See #246 