### PR TITLE
use redis 3.2 template for redis 4.x

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -336,6 +336,9 @@ define redis::instance(
       /^3.2./: {
         File[$redis_file_name_orig] { content => template('redis/redis.conf.3.2.erb') }
       }
+      /^4./: {
+        File[$redis_file_name_orig] { content => template('redis/redis.conf.3.2.erb') }
+      }
       default: {
         File[$redis_file_name_orig] { content => template($conf_template) }
       }


### PR DESCRIPTION
this would allow usage of protected_mode in 4.x, too