### PR TITLE
Initial rhel 8 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -207,6 +207,11 @@ class redis::params {
 
           $service_group             = 'redis'
         }
+        '8': {
+          $minimum_version           = '3.2.3'
+
+          $service_group             = 'redis'
+        }
         default: {
           fail("Not sure what Redis version is avaliable upstream on your release: ${::operatingsystemmajrelease}")
         }


### PR DESCRIPTION
Let's start supporting RHEL 8 as a distribution. For the time being
let's keep the same version of redis as RHEL 7.
This is needed for us deploying openstack on top of RHEL8.