### PR TITLE
Test bumping versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,8 +8,8 @@
   "project_page": "http://arioch.github.io/puppet-redis/",
   "issues_url": "https://github.com/arioch/puppet-redis/issues",
   "dependencies": [
-    {"name":"puppetlabs/apt","version_requirement":">= 2.3.0 <6.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.2 <5.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">= 2.3.0 <7.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.2 <7.0.0"},
     {"name":"stahnma/epel","version_requirement":">= 1.2.2 <2.0.0"},
     {
       "name": "herculesteam/augeasproviders_sysctl",


### PR DESCRIPTION
It works well for me on Debian 9 and puppet 5, but obviously it would be a good idea if more people can test and confirm before merging.