### PR TITLE
Consume latest stdlib and apt modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,20 +1,10 @@
 fixtures:
-  repositories:
-    apt:
-      repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
-      ref: 2.3.0
-    stdlib:
-      repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref: 4.11.0
-    epel:
-      repo: 'https://github.com/stahnma/puppet-module-epel.git'
-      ref: 1.2.2
-    augeasproviders_sysctl:
-      repo: "git://github.com/hercules-team/augeasproviders_sysctl.git"
-      tag: v2.1.0
-    augeasproviders_core:
-      repo: "git://github.com/hercules-team/augeasproviders_core.git"
-      tag: v2.1.0
+  forge_modules:
+    apt: puppetlabs/apt
+    stdlib: puppetlabs/stdlib
+    epel: stahnma/epel
+    augeasproviders_sysctl: herculesteam/augeasproviders_sysctl
+    augeasproviders_core: herculesteam/augeasproviders_core
   symlinks:
     redis: "#{source_dir}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,63 +1,40 @@
 ---
+sudo: false
+dist: trusty
 language: ruby
-bundler_args: --without system_tests
-script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
+cache: bundler
 before_install:
-  - gem install bundler # -v x.x.x if a specific version is needed
+
+before_install:
+  - bundle -v
+  - gem install bundler -v "< 2" --no-ri --no-rdoc || true
+  - rm Gemfile.lock || true
+  - gem --version
+  - bundle -v
+script:
+  - 'bundle exec rake $CHECK'
+bundler_args: --without system_tests
+rvm:
+  - 2.4.4
+env:
+  global:
+    - BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_GEM_VERSION="~> 5.0"
 matrix:
   fast_finish: true
   include:
-  - sudo: required
-    dist: trusty
-    rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes" ORDERING="random"
-  - sudo: required
-    dist: trusty
-    rvm: 2.2.2
-    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" ORDERING="random"
-  - sudo: required
-    dist: trusty
-    rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" ORDERING="random"
-  - sudo: required
-    services: docker
-    rvm: '2.3.3'
-    env: PUPPET_INSTALL_VERSION="1.10.8" PUPPET_INSTALL_TYPE=agent BEAKER_set="centos-6-docker"
-    script: bundle exec rake beaker:suites['default',$BEAKER_set]
-    bundler_args: --without development
-  - sudo: required
-    services: docker
-    rvm: '2.3.3'
-    env: PUPPET_INSTALL_VERSION="1.10.8" PUPPET_INSTALL_TYPE=agent BEAKER_set="centos-7-docker"
-    script: bundle exec rake beaker:suites['default',$BEAKER_set]
-    bundler_args: --without development
-  - sudo: required
-    services: docker
-    rvm: '2.3.3'
-    env: PUPPET_INSTALL_VERSION="1.10.8" PUPPET_INSTALL_TYPE=agent BEAKER_set="debian-8-docker"
-    script: bundle exec rake beaker:suites['default',$BEAKER_set]
-    bundler_args: --without development
-  - sudo: required
-    services: docker
-    rvm: '2.3.3'
-    env: PUPPET_INSTALL_VERSION="1.10.8" PUPPET_INSTALL_TYPE=agent BEAKER_set="ubuntu-1604-docker"
-    script: bundle exec rake beaker:suites['default',$BEAKER_set]
-    bundler_args: --without development
-  - sudo: required
-    services: docker
-    rvm: '2.3.3'
-    env: PUPPET_INSTALL_VERSION="1.5.2" PUPPET_INSTALL_TYPE=agent BEAKER_set="ubuntu-1404-docker"
-    script: bundle exec rake beaker:suites['default',$BEAKER_set]
-    bundler_args: --without development
-  - sudo: required
-    rvm: '2.4.0'
-    env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
-    script: bundle exec rake build
-    bundler_args: --without development
+    -
+      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file"
+    -
+      env: CHECK=parallel_spec
+    -
+      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
+      rvm: 2.1.9
 branches:
   only:
-  - master
-  - /^v\d/
+    - master
+    - /^v\d/
+notifications:
+  email: false
 deploy:
   provider: puppetforge
   user: arioch

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'puppetlabs_spec_helper', '~> 1.2.2',                         :require => false
-  gem 'rspec-puppet',                                               :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem 'puppetlabs_spec_helper',                                     :require => false
+  gem 'rspec-puppet',                                               :require => false
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec-puppet-utils',                                         :require => false
   gem 'puppet-lint-absolute_classname-check',                       :require => false
@@ -28,13 +28,13 @@ group :test do
   gem 'rubocop-rspec', '~> 1.6',                                    :require => false if RUBY_VERSION >= '2.3.0'
   gem 'json_pure', '<= 2.0.1',                                      :require => false if RUBY_VERSION < '2.0.0'
   gem 'safe_yaml', '~> 1.0.4',                                      :require => false
-  gem 'puppet-syntax',                                              :require => false, git: 'https://github.com/gds-operations/puppet-syntax.git'
+  gem 'puppet-syntax',                                              :require => false
   gem 'pry',                                                        :require => false
   gem 'rb-readline',                                                :require => false
   gem 'redis', '3.3.3',                                             :require => false
   gem 'mock_redis',                                                 :require => false
   gem 'rack', '1.6.8',                                              :require => false
-  gem 'simp-rake-helpers', '3.6.0',                                 :require => false
+  gem 'parallel_tests',                                             :require => false
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,6 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet-strings/tasks'
-require 'simp/rake/pupmod/helpers'
-
-Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
 
 # These two gems aren't always present, for instance
 # on Travis with --without development

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -209,6 +209,10 @@ class redis::sentinel (
       ) {
       package { $package_name:
         ensure => $package_ensure,
+        before => File[$config_file_orig],
+      }
+      if $init_script {
+        Package[$package_name] -> File[$init_script]
       }
     }
   }
@@ -220,7 +224,6 @@ class redis::sentinel (
       group   => $service_group,
       mode    => $config_file_mode,
       content => template($conf_template),
-      require => Package[$package_name];
   }
 
   exec {
@@ -240,7 +243,6 @@ class redis::sentinel (
         group   => 'root',
         mode    => '0755',
         content => template($init_template),
-        require => Package[$package_name];
     }
 
     exec {

--- a/manifests/ulimit.pp
+++ b/manifests/ulimit.pp
@@ -47,7 +47,7 @@ class redis::ulimit {
       lens    => 'Systemd.lns',
       changes => [
         "defnode nofile Service/LimitNOFILE \"\"",
-        "set \$nofile/value \"${::redis::ulimit}\""
+        "set \$nofile/value \"${::redis::ulimit}\"",
         ],
       notify  => [
         Exec['systemd-reload-redis'],

--- a/metadata.json
+++ b/metadata.json
@@ -8,17 +8,11 @@
   "project_page": "http://arioch.github.io/puppet-redis/",
   "issues_url": "https://github.com/arioch/puppet-redis/issues",
   "dependencies": [
-    {"name":"puppetlabs/apt","version_requirement":">= 2.3.0 <6.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.2 <5.0.0"},
-    {"name":"stahnma/epel","version_requirement":">= 1.2.2 <2.0.0"},
-    {
-      "name": "herculesteam/augeasproviders_sysctl",
-      "version_requirement": ">=2.1.0 < 3.0.0"
-    },
-    {
-      "name": "herculesteam/augeasproviders_core",
-      "version_requirement": ">=2.1.0 < 3.0.0"
-    }
+    {"name": "puppetlabs/apt",    "version_requirement": ">= 2.3.0 <7.0.0"},
+    {"name": "puppetlabs/stdlib", "version_requirement": ">= 1.0.2 <6.0.0"},
+    {"name": "stahnma/epel",      "version_requirement": ">= 1.2.2 <2.0.0"},
+    {"name": "herculesteam/augeasproviders_sysctl", "version_requirement": ">=2.1.0 <3.0.0"},
+    {"name": "herculesteam/augeasproviders_core",   "version_requirement": ">=2.1.0 <3.0.0"}
   ],
   "data_provider": null,
   "description": "Redis module with cluster support",

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -39,29 +39,29 @@ describe 'redis', :type => :class do
         case facts[:operatingsystem]
           when 'Debian'
 
-          context 'on Debian' do
+            context 'on Debian' do
+
+              it do
+                is_expected.to contain_file('/var/run/redis').with({
+                  :ensure => 'directory',
+                  :owner  => 'redis',
+                  :group  => 'root',
+                  :mode   => '2775',
+                })
+              end
+
+            end
+
+          when 'Ubuntu'
 
             it do
               is_expected.to contain_file('/var/run/redis').with({
                 :ensure => 'directory',
                 :owner  => 'redis',
-                :group  => 'root',
+                :group  => 'redis',
                 :mode   => '2775',
               })
             end
-
-          end
-
-        when 'Ubuntu'
-
-          it do
-            is_expected.to contain_file('/var/run/redis').with({
-              :ensure => 'directory',
-              :owner  => 'redis',
-              :group  => 'redis',
-              :mode   => '0755',
-            })
-          end
 
         end
       end

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -87,9 +87,8 @@ describe 'redis::ulimit' do
     it do
       is_expected.to contain_augeas("Systemd redis ulimit").with(
       {
-        'incl'     => '/etc/systemd/system/redis-server.service.d/limits.conf',
+        'incl'     => '/etc/systemd/system/redis-server.service.d/limit.conf',
         'lens'     => 'Systemd.lns',
-        'context'  => '/etc/systemd/system/redis-server.service.d/limits.conf',
         'changes'  => [
           "defnode nofile Service/LimitNOFILE \"\"",
           "set $nofile/value \"7777\""


### PR DESCRIPTION
commit 1bf9c9afa5a936fcac4db36bf0d92557e602120f (HEAD -> alexharvey/fix_up_tests, origin/alexharvey/fix_up_tests)
Author: Alex Harvey <alexharv074@gmail.com>
Date:   Mon Mar 4 13:05:13 2019 +1100

    Modernise the build pipeline
    
    The motivation for this change was to support latest stdlib since the
    requirement for stdlib < 5 conflicted with another requirement for
    stdlib >= 5 in a project that I maintain.
    
    Changes I made here are:
    
    - Pull rspec-puppet and puppet-syntax from the Forge rather than their
      Git master branches.
    
    - Use the latest puppetlabs_spec_helper.

    - Removes simp-rake-helpers as these broke the latest
      puppetlabs_spec_helper's ability to pull modules from Forge.

    - Fixed a minor lint warning.

    - Rewrite .travis.yml based on "suggestions" from pdk convert.

    - Update metadata.json to specify latest stdlib and apt.

    Note that this commit drops Puppet 3 support.

commit 69e1a31acbee46a138d5baf062ea1d2898fc6a4a
Author: Alex Harvey <alexharv074@gmail.com>
Date:   Mon Mar 4 18:05:19 2019 +1100

    Ordering bug in sentinel.pp

    The change in 0ecda71563486dd4039d4f731bdc4436cdaef00f
    introduced an ordering bug. This fixes that.

commit 1ac33af61a2d788cbbbead4b128f89a393f2fdcb
Author: Alex Harvey <alexharv074@gmail.com>
Date:   Mon Mar 4 15:17:12 2019 +1100

    Corrections for Ubuntu in tests

    The tests appear to have not been updated for the correct file mode on
    Ubuntu.

