### PR TITLE
Make bind optional

### DIFF
--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -156,6 +156,14 @@ describe 'redis', :type => :class do
         it { is_expected.to contain_file(config_file_orig).with_content(/bind.*_VALUE_/) }
       end
 
+      describe 'without parameter bind' do
+        let (:params) {
+          {}
+        }
+
+        it { is_expected.not_to contain_file(config_file_orig).with_content(/^bind/) }
+      end
+
       describe 'with parameter output_buffer_limit_slave' do
         let (:params) {
           {

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -36,7 +36,7 @@ tcp-backlog <%= @tcp_backlog %>
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
 #
-bind <%= @bind %>
+<% if @bind -%>bind <%= @bind %><% end -%>
 
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen


### PR DESCRIPTION
This PR makes bind optional, allowing redis to listen on all interfaces