### PR TITLE
Lint and rubocop (autofixes only)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,545 @@
+require: rubocop-rspec
+AllCops:
+  TargetRubyVersion: 2.1
+  Include:
+    - ./**/*.rb
+  Exclude:
+    - files/**/*
+    - vendor/**/*
+    - .vendor/**/*
+    - pkg/**/*
+    - spec/fixtures/**/*
+    - Gemfile
+    - Rakefile
+    - Guardfile
+    - Vagrantfile
+Lint/ConditionPosition:
+  Enabled: True
+
+Lint/ElseLayout:
+  Enabled: True
+
+Lint/UnreachableCode:
+  Enabled: True
+
+Lint/UselessComparison:
+  Enabled: True
+
+Lint/EnsureReturn:
+  Enabled: True
+
+Lint/HandleExceptions:
+  Enabled: True
+
+Lint/LiteralInCondition:
+  Enabled: True
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: True
+
+Lint/LiteralInInterpolation:
+  Enabled: True
+
+Style/HashSyntax:
+  Enabled: True
+
+Style/RedundantReturn:
+  Enabled: True
+
+Layout/EndOfLine:
+  Enabled: False
+
+Lint/AmbiguousOperator:
+  Enabled: True
+
+Lint/AssignmentInCondition:
+  Enabled: True
+
+Layout/SpaceBeforeComment:
+  Enabled: True
+
+Style/AndOr:
+  Enabled: True
+
+Style/RedundantSelf:
+  Enabled: True
+
+Metrics/BlockLength:
+  Enabled: False
+
+# Method length is not necessarily an indicator of code quality
+Metrics/MethodLength:
+  Enabled: False
+
+# Module length is not necessarily an indicator of code quality
+Metrics/ModuleLength:
+  Enabled: False
+
+Style/WhileUntilModifier:
+  Enabled: True
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: True
+
+Security/Eval:
+  Enabled: True
+
+Lint/BlockAlignment:
+  Enabled: True
+
+Lint/DefEndAlignment:
+  Enabled: True
+
+Lint/EndAlignment:
+  Enabled: True
+
+Lint/DeprecatedClassMethods:
+  Enabled: True
+
+Lint/Loop:
+  Enabled: True
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: True
+
+Lint/RescueException:
+  Enabled: True
+
+Lint/StringConversionInInterpolation:
+  Enabled: True
+
+Lint/UnusedBlockArgument:
+  Enabled: True
+
+Lint/UnusedMethodArgument:
+  Enabled: True
+
+Lint/UselessAccessModifier:
+  Enabled: True
+
+Lint/UselessAssignment:
+  Enabled: True
+
+Lint/Void:
+  Enabled: True
+
+Layout/AccessModifierIndentation:
+  Enabled: True
+
+Style/AccessorMethodName:
+  Enabled: True
+
+Style/Alias:
+  Enabled: True
+
+Layout/AlignArray:
+  Enabled: True
+
+Layout/AlignHash:
+  Enabled: True
+
+Layout/AlignParameters:
+  Enabled: True
+
+Metrics/BlockNesting:
+  Enabled: True
+
+Style/AsciiComments:
+  Enabled: True
+
+Style/Attr:
+  Enabled: True
+
+Style/BracesAroundHashParameters:
+  Enabled: True
+
+Style/CaseEquality:
+  Enabled: True
+
+Layout/CaseIndentation:
+  Enabled: True
+
+Style/CharacterLiteral:
+  Enabled: True
+
+Style/ClassAndModuleCamelCase:
+  Enabled: True
+
+Style/ClassAndModuleChildren:
+  Enabled: False
+
+Style/ClassCheck:
+  Enabled: True
+
+# Class length is not necessarily an indicator of code quality
+Metrics/ClassLength:
+  Enabled: False
+
+Style/ClassMethods:
+  Enabled: True
+
+Style/ClassVars:
+  Enabled: True
+
+Style/WhenThen:
+  Enabled: True
+
+Style/WordArray:
+  Enabled: True
+
+Style/UnneededPercentQ:
+  Enabled: True
+
+Layout/Tab:
+  Enabled: True
+
+Layout/SpaceBeforeSemicolon:
+  Enabled: True
+
+Layout/TrailingBlankLines:
+  Enabled: True
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: True
+
+Layout/SpaceInsideBrackets:
+  Enabled: True
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: True
+
+Layout/SpaceInsideParens:
+  Enabled: True
+
+Layout/LeadingCommentSpace:
+  Enabled: True
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: True
+
+Layout/SpaceAfterColon:
+  Enabled: True
+
+Layout/SpaceAfterComma:
+  Enabled: True
+
+Layout/SpaceAfterMethodName:
+  Enabled: True
+
+Layout/SpaceAfterNot:
+  Enabled: True
+
+Layout/SpaceAfterSemicolon:
+  Enabled: True
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: True
+
+Layout/SpaceAroundOperators:
+  Enabled: True
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: True
+
+Layout/SpaceBeforeComma:
+  Enabled: True
+
+Style/CollectionMethods:
+  Enabled: True
+
+Layout/CommentIndentation:
+  Enabled: True
+
+Style/ColonMethodCall:
+  Enabled: True
+
+Style/CommentAnnotation:
+  Enabled: True
+
+# 'Complexity' is very relative
+Metrics/CyclomaticComplexity:
+  Enabled: False
+
+Style/ConstantName:
+  Enabled: True
+
+Style/Documentation:
+  Enabled: False
+
+Style/DefWithParentheses:
+  Enabled: True
+
+Style/PreferredHashMethods:
+  Enabled: True
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Style/DoubleNegation:
+  Enabled: True
+
+Style/EachWithObject:
+  Enabled: True
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: True
+
+Layout/IndentArray:
+  Enabled: True
+
+Layout/IndentHash:
+  Enabled: True
+
+Layout/IndentationConsistency:
+  Enabled: True
+
+Layout/IndentationWidth:
+  Enabled: True
+
+Layout/EmptyLines:
+  Enabled: True
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: True
+
+Style/EmptyLiteral:
+  Enabled: True
+
+# Configuration parameters: AllowURI, URISchemes.
+Metrics/LineLength:
+  Enabled: False
+
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: True
+
+Style/MethodDefParentheses:
+  Enabled: True
+
+Style/LineEndConcatenation:
+  Enabled: True
+
+Layout/TrailingWhitespace:
+  Enabled: True
+
+Style/StringLiterals:
+  Enabled: True
+
+Style/TrailingCommaInArguments:
+  Enabled: True
+
+Style/TrailingCommaInLiteral:
+  Enabled: True
+
+Style/GlobalVars:
+  Enabled: True
+
+Style/GuardClause:
+  Enabled: True
+
+Style/IfUnlessModifier:
+  Enabled: True
+
+Style/MultilineIfThen:
+  Enabled: True
+
+Style/NegatedIf:
+  Enabled: True
+
+Style/NegatedWhile:
+  Enabled: True
+
+Style/Next:
+  Enabled: True
+
+Style/SingleLineBlockParams:
+  Enabled: True
+
+Style/SingleLineMethods:
+  Enabled: True
+
+Style/SpecialGlobalVars:
+  Enabled: True
+
+Style/TrivialAccessors:
+  Enabled: True
+
+Style/UnlessElse:
+  Enabled: True
+
+Style/VariableInterpolation:
+  Enabled: True
+
+Style/VariableName:
+  Enabled: True
+
+Style/WhileUntilDo:
+  Enabled: True
+
+Style/EvenOdd:
+  Enabled: True
+
+Style/FileName:
+  Enabled: True
+
+Style/For:
+  Enabled: True
+
+Style/Lambda:
+  Enabled: True
+
+Style/MethodName:
+  Enabled: True
+
+Style/MultilineTernaryOperator:
+  Enabled: True
+
+Style/NestedTernaryOperator:
+  Enabled: True
+
+Style/NilComparison:
+  Enabled: True
+
+Style/FormatString:
+  Enabled: True
+
+Style/MultilineBlockChain:
+  Enabled: True
+
+Style/Semicolon:
+  Enabled: True
+
+Style/SignalException:
+  Enabled: True
+
+Style/NonNilCheck:
+  Enabled: True
+
+Style/Not:
+  Enabled: True
+
+Style/NumericLiterals:
+  Enabled: True
+
+Style/OneLineConditional:
+  Enabled: True
+
+Style/OpMethod:
+  Enabled: True
+
+Style/ParenthesesAroundCondition:
+  Enabled: True
+
+Style/PercentLiteralDelimiters:
+  Enabled: True
+
+Style/PerlBackrefs:
+  Enabled: True
+
+Style/PredicateName:
+  Enabled: True
+
+Style/RedundantException:
+  Enabled: True
+
+Style/SelfAssignment:
+  Enabled: True
+
+Style/Proc:
+  Enabled: True
+
+Style/RaiseArgs:
+  Enabled: True
+
+Style/RedundantBegin:
+  Enabled: True
+
+Style/RescueModifier:
+  Enabled: True
+
+# based on https://github.com/voxpupuli/modulesync_config/issues/168
+Style/RegexpLiteral:
+  EnforcedStyle: percent_r
+  Enabled: True
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: True
+
+Metrics/ParameterLists:
+  Enabled: False
+
+Lint/RequireParentheses:
+  Enabled: True
+
+Style/ModuleFunction:
+  Enabled: True
+
+Lint/Debugger:
+  Enabled: True
+
+Style/IfWithSemicolon:
+  Enabled: True
+
+Style/Encoding:
+  Enabled: True
+
+Style/BlockDelimiters:
+  Enabled: True
+
+Layout/MultilineBlockLayout:
+  Enabled: True
+
+# 'Complexity' is very relative
+Metrics/AbcSize:
+  Enabled: False
+
+# 'Complexity' is very relative
+Metrics/PerceivedComplexity:
+  Enabled: False
+
+Lint/UselessAssignment:
+  Enabled: True
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: True
+
+# RSpec
+
+RSpec/BeforeAfterAll:
+  Exclude:
+    - spec/acceptance/**/*
+
+# We don't use rspec in this way
+RSpec/DescribeClass:
+  Enabled: False
+
+# Example length is not necessarily an indicator of code quality
+RSpec/ExampleLength:
+  Enabled: False
+
+RSpec/NamedSubject:
+  Enabled: False
+
+# disabled for now since they cause a lot of issues
+# these issues aren't easy to fix
+RSpec/RepeatedDescription:
+  Enabled: False
+
+RSpec/NestedGroups:
+  Enabled: False
+
+# this is broken on ruby1.9
+Layout/IndentHeredoc:
+  Enabled: False
+
+# disable Yaml safe_load. This is needed to support ruby2.0.0 development envs
+Security/YAMLLoad:
+  Enabled: false
+
+# This affects hiera interpolation, as well as some configs that we push.
+Style/FormatStringToken:
+  Enabled: false
+
+# This is useful, but sometimes a little too picky about where unit tests files
+# are located.
+RSpec/FilePath:
+  Enabled: false

--- a/lib/facter/redis_server_version.rb
+++ b/lib/facter/redis_server_version.rb
@@ -6,12 +6,12 @@ Facter.add(:redis_server_version) do
   setcode do
     if Facter::Util::Resolution.which('redis-server')
       redis_server_version_output = Facter::Util::Resolution.exec('redis-server -v')
-      if redis_server_version_output =~ /v=([\w\.]+)/
+      if redis_server_version_output =~ %r{v=([\w\.]+)}
         # Redis server v=2.8.17 sha=00000000:0 malloc=jemalloc-3.6.0 bits=64 build=4c1d5710660b9479
-        redis_server_version_output.match(/Redis server v=([\w\.]+).+/)[1]
-      elsif redis_server_version_output =~ /version ([\w\.]+)/
+        redis_server_version_output.match(%r{Redis server v=([\w\.]+).+})[1]
+      elsif redis_server_version_output =~ %r{version ([\w\.]+)}
         # Redis server version 2.4.10 (00000000:0)
-        redis_server_version_output.match(/Redis server version ([\w\.]+).+/)[1]
+        redis_server_version_output.match(%r{Redis server version ([\w\.]+).+})[1]
       end
     end
   end

--- a/lib/facter/redis_server_version.rb
+++ b/lib/facter/redis_server_version.rb
@@ -3,7 +3,6 @@
 # Purpose: Retrieve redis-server version if installed
 #
 Facter.add(:redis_server_version) do
-
   setcode do
     if Facter::Util::Resolution.which('redis-server')
       redis_server_version_output = Facter::Util::Resolution.exec('redis-server -v')

--- a/lib/puppet/parser/functions/redisget.rb
+++ b/lib/puppet/parser/functions/redisget.rb
@@ -40,6 +40,5 @@ DOC
       debug "Connection to redis failed with #{e} - Returning default value of #{default}"
       default
     end
-
   end
 end

--- a/lib/puppet/parser/functions/redisget.rb
+++ b/lib/puppet/parser/functions/redisget.rb
@@ -1,7 +1,7 @@
 require 'redis'
 
 module Puppet::Parser::Functions
-  newfunction(:redisget, :type => :rvalue, :doc => <<-DOC
+  newfunction(:redisget, type: :rvalue, doc: <<-DOC
 Returns the value of the key being looked up or nil if the key does not
 exist. Takes two arguments with an optional third. The first being a string
 value of the key to be looked up, the second is the URL to the Redis service
@@ -34,7 +34,7 @@ DOC
     raise(Puppet::ParseError, "redisget(): Wrong argument type given (#{url.class} for String) for arg2 (url)") if url.is_a?(String) == false
 
     begin
-      Redis.new(:url => url).get(key) || default
+      Redis.new(url: url).get(key) || default
     rescue Redis::CannotConnectError, SocketError => e
       raise Puppet::Error, "connection to redis server failed - #{e}" unless default
       debug "Connection to redis failed with #{e} - Returning default value of #{default}"

--- a/lib/puppet/parser/functions/redisget.rb
+++ b/lib/puppet/parser/functions/redisget.rb
@@ -20,7 +20,7 @@ fails.
 DOC
   ) do |args|
 
-    raise(Puppet::ParseError, "redisget(): Wrong number of arguments given (#{args.size} for 2 or 3)") if args.size !=2 && args.size !=3
+    raise(Puppet::ParseError, "redisget(): Wrong number of arguments given (#{args.size} for 2 or 3)") if args.size != 2 && args.size != 3
 
     key = args[0]
     url = args[1]

--- a/lib/puppet/parser/functions/redisget.rb
+++ b/lib/puppet/parser/functions/redisget.rb
@@ -18,7 +18,7 @@ fails.
 @example Calling the function with a default if failure occurs
   $version = redisget('version.myapp', 'redis://redis.example.com:6379', $::myapp_version)
 DOC
-  ) do |args|
+             ) do |args|
 
     raise(Puppet::ParseError, "redisget(): Wrong number of arguments given (#{args.size} for 2 or 3)") if args.size != 2 && args.size != 3
 

--- a/lib/puppet/parser/functions/redisget.rb
+++ b/lib/puppet/parser/functions/redisget.rb
@@ -20,7 +20,7 @@ fails.
 DOC
   ) do |args|
 
-    raise(Puppet::ParseError, "redisget(): Wrong number of arguments given (#{args.size} for 2 or 3)") if args.size != 2 and args.size != 3
+    raise(Puppet::ParseError, "redisget(): Wrong number of arguments given (#{args.size} for 2 or 3)") if args.size !=2 && args.size !=3
 
     key = args[0]
     url = args[1]

--- a/manifests/ulimit.pp
+++ b/manifests/ulimit.pp
@@ -47,8 +47,8 @@ class redis::ulimit {
       lens    => 'Systemd.lns',
       changes => [
         "defnode nofile Service/LimitNOFILE \"\"",
-        "set \$nofile/value \"${::redis::ulimit}\""
-        ],
+        "set \$nofile/value \"${::redis::ulimit}\"",
+      ],
       notify  => [
         Exec['systemd-reload-redis'],
       ],

--- a/spec/acceptance/redis_cli_task_spec.rb
+++ b/spec/acceptance/redis_cli_task_spec.rb
@@ -2,7 +2,6 @@
 require 'spec_helper_acceptance'
 
 describe 'redis-cli task' do
-
   it 'install redis-cli with the class' do
     pp = <<-EOS
     Exec {

--- a/spec/acceptance/redis_cli_task_spec.rb
+++ b/spec/acceptance/redis_cli_task_spec.rb
@@ -15,7 +15,7 @@ describe 'redis-cli task' do
     EOS
 
     # Apply twice to ensure no errors the second time.
-    apply_manifest(pp, :catch_failures => true)
+    apply_manifest(pp, catch_failures: true)
   end
 
   describe 'ping' do

--- a/spec/acceptance/suites/default/redis_adminstration_spec.rb
+++ b/spec/acceptance/suites/default/redis_adminstration_spec.rb
@@ -29,7 +29,7 @@ unless default['hypervisor'] =~ /docker/
       end
     end
     it 'should show no warnings about kernel settings in logs' do
-      shell('timeout 1s redis-server --port 7777 --loglevel verbose', { acceptable_exit_codes: [0,124] }) do |result|
+      shell('timeout 1s redis-server --port 7777 --loglevel verbose', { acceptable_exit_codes: [0, 124] }) do |result|
         expect(result.stdout).not_to match(/WARNING/)
         expect(result.exit_code).to match(124)
       end

--- a/spec/acceptance/suites/default/redis_adminstration_spec.rb
+++ b/spec/acceptance/suites/default/redis_adminstration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 # systcl settings are untestable in docker
-unless default['hypervisor'] =~ /docker/
+unless default['hypervisor'] =~ %r{docker}
   describe 'redis::administration' do
     it 'runs successfully' do
       pp = <<-EOS
@@ -15,22 +15,22 @@ unless default['hypervisor'] =~ /docker/
     end
     it 'sets overcommit_memory to 1 in a seperate sysctl file' do
       shell('/bin/cat /proc/sys/vm/overcommit_memory') do |result|
-        expect(result.stdout).to match(/^1$/)
+        expect(result.stdout).to match(%r{^1$})
       end
     end
     it 'disables thp' do
       shell('/bin/cat /sys/kernel/mm/transparent_hugepage/enabled') do |result|
-        expect(result.stdout).to match(/^always madvise \[never\]$/)
+        expect(result.stdout).to match(%r{^always madvise \[never\]$})
       end
     end
     it 'sets somaxconn to 65535' do
       shell('/bin/cat /proc/sys/net/core/somaxconn') do |result|
-        expect(result.stdout).to match(/^65535$/)
+        expect(result.stdout).to match(%r{^65535$})
       end
     end
     it 'shows no warnings about kernel settings in logs' do
       shell('timeout 1s redis-server --port 7777 --loglevel verbose', acceptable_exit_codes: [0, 124]) do |result|
-        expect(result.stdout).not_to match(/WARNING/)
+        expect(result.stdout).not_to match(%r{WARNING})
         expect(result.exit_code).to match(124)
       end
     end

--- a/spec/acceptance/suites/default/redis_adminstration_spec.rb
+++ b/spec/acceptance/suites/default/redis_adminstration_spec.rb
@@ -10,8 +10,8 @@ unless default['hypervisor'] =~ /docker/
       EOS
 
       # Apply twice to ensure no errors the second time.
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
     end
     it 'should set overcommit_memory to 1 in a seperate sysctl file' do
       shell('/bin/cat /proc/sys/vm/overcommit_memory') do |result|
@@ -29,7 +29,7 @@ unless default['hypervisor'] =~ /docker/
       end
     end
     it 'should show no warnings about kernel settings in logs' do
-      shell('timeout 1s redis-server --port 7777 --loglevel verbose', { :acceptable_exit_codes => [0,124] }) do |result|
+      shell('timeout 1s redis-server --port 7777 --loglevel verbose', { acceptable_exit_codes: [0,124] }) do |result|
         expect(result.stdout).not_to match(/WARNING/)
         expect(result.exit_code).to match(124)
       end

--- a/spec/acceptance/suites/default/redis_adminstration_spec.rb
+++ b/spec/acceptance/suites/default/redis_adminstration_spec.rb
@@ -29,7 +29,7 @@ unless default['hypervisor'] =~ /docker/
       end
     end
     it 'shows no warnings about kernel settings in logs' do
-      shell('timeout 1s redis-server --port 7777 --loglevel verbose', { acceptable_exit_codes: [0, 124] }) do |result|
+      shell('timeout 1s redis-server --port 7777 --loglevel verbose', acceptable_exit_codes: [0, 124]) do |result|
         expect(result.stdout).not_to match(/WARNING/)
         expect(result.exit_code).to match(124)
       end

--- a/spec/acceptance/suites/default/redis_adminstration_spec.rb
+++ b/spec/acceptance/suites/default/redis_adminstration_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper_acceptance'
 # systcl settings are untestable in docker
 unless default['hypervisor'] =~ /docker/
   describe 'redis::administration' do
-    it 'should run successfully' do
+    it 'runs successfully' do
       pp = <<-EOS
       include redis
       include redis::administration
@@ -13,22 +13,22 @@ unless default['hypervisor'] =~ /docker/
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
-    it 'should set overcommit_memory to 1 in a seperate sysctl file' do
+    it 'sets overcommit_memory to 1 in a seperate sysctl file' do
       shell('/bin/cat /proc/sys/vm/overcommit_memory') do |result|
         expect(result.stdout).to match(/^1$/)
       end
     end
-    it 'should disable thp' do
+    it 'disables thp' do
       shell('/bin/cat /sys/kernel/mm/transparent_hugepage/enabled') do |result|
         expect(result.stdout).to match(/^always madvise \[never\]$/)
       end
     end
-    it 'should set somaxconn to 65535' do
+    it 'sets somaxconn to 65535' do
       shell('/bin/cat /proc/sys/net/core/somaxconn') do |result|
         expect(result.stdout).to match(/^65535$/)
       end
     end
-    it 'should show no warnings about kernel settings in logs' do
+    it 'shows no warnings about kernel settings in logs' do
       shell('timeout 1s redis-server --port 7777 --loglevel verbose', { acceptable_exit_codes: [0, 124] }) do |result|
         expect(result.stdout).not_to match(/WARNING/)
         expect(result.exit_code).to match(124)

--- a/spec/acceptance/suites/default/redis_debian_run_dir_spec.rb
+++ b/spec/acceptance/suites/default/redis_debian_run_dir_spec.rb
@@ -42,13 +42,13 @@ if ENV['RUN_BACKPORT_TEST'] == 'yes'
 
     context 'redis should respond to ping command' do
       describe command('redis-cli ping') do
-        its(:stdout) { is_expected.to match /PONG/ }
+        its(:stdout) { is_expected.to match %r{PONG} }
       end
     end
 
     context 'redis log should be clean' do
       describe command('journalctl --no-pager') do
-        its(:stdout) { is_expected.not_to match /Failed at step RUNTIME_DIRECTORY/ }
+        its(:stdout) { is_expected.not_to match %r{Failed at step RUNTIME_DIRECTORY} }
       end
     end
   end

--- a/spec/acceptance/suites/default/redis_debian_run_dir_spec.rb
+++ b/spec/acceptance/suites/default/redis_debian_run_dir_spec.rb
@@ -33,22 +33,22 @@ if ENV['RUN_BACKPORT_TEST'] == 'yes'
     end
 
     describe package('redis-server') do
-      it { should be_installed }
+      it { is_expected.to be_installed }
     end
 
     describe service('redis-server') do
-      it { should be_running }
+      it { is_expected.to be_running }
     end
 
     context 'redis should respond to ping command' do
       describe command('redis-cli ping') do
-        its(:stdout) { should match /PONG/ }
+        its(:stdout) { is_expected.to match /PONG/ }
       end
     end
 
     context 'redis log should be clean' do
       describe command('journalctl --no-pager') do
-        its(:stdout) { should_not match /Failed at step RUNTIME_DIRECTORY/ }
+        its(:stdout) { is_expected.not_to match /Failed at step RUNTIME_DIRECTORY/ }
       end
     end
   end

--- a/spec/acceptance/suites/default/redis_debian_run_dir_spec.rb
+++ b/spec/acceptance/suites/default/redis_debian_run_dir_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper_acceptance'
 # since this test polutes others, we'll only run it if specifically asked
 if ENV['RUN_BACKPORT_TEST'] == 'yes'
   describe 'redis', if: (fact('operatingsystem') == 'Debian') do
-    it 'should run with newer Debian package' do
+    it 'runs with newer Debian package' do
       pp = <<-EOS
 
       include ::apt

--- a/spec/acceptance/suites/default/redis_debian_run_dir_spec.rb
+++ b/spec/acceptance/suites/default/redis_debian_run_dir_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 # since this test polutes others, we'll only run it if specifically asked
 if ENV['RUN_BACKPORT_TEST'] == 'yes'
-  describe 'redis', :if => (fact('operatingsystem') == 'Debian') do
+  describe 'redis', if: (fact('operatingsystem') == 'Debian') do
     it 'should run with newer Debian package' do
       pp = <<-EOS
 
@@ -28,8 +28,8 @@ if ENV['RUN_BACKPORT_TEST'] == 'yes'
       }
       EOS
 
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_change   => true)
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_change: true)
     end
 
     describe package('redis-server') do

--- a/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
@@ -13,7 +13,7 @@ describe 'redis::instance', unless: (fact('operatingsystem') == 'Debian') do
     manage_repo  = true
   end
 
-  it 'should run successfully' do
+  it 'runs successfully' do
     pp = <<-EOS
     Exec {
       path => [ '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', ]

--- a/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
@@ -52,20 +52,20 @@ describe 'redis::instance', unless: (fact('operatingsystem') == 'Debian') do
   end
 
   describe file("#{config_path}/redis-server-redis1.conf") do
-    its(:content) { is_expected.to match /port 7777/ }
+    its(:content) { is_expected.to match %r{port 7777} }
   end
 
   describe file("#{config_path}/redis-server-redis2.conf") do
-    its(:content) { is_expected.to match /port 8888/ }
+    its(:content) { is_expected.to match %r{port 8888} }
   end
 
   context 'redis should respond to ping command' do
     describe command('redis-cli -h 127.0.0.1 -p 7777 ping') do
-      its(:stdout) { is_expected.to match /PONG/ }
+      its(:stdout) { is_expected.to match %r{PONG} }
     end
 
     describe command('redis-cli -h 127.0.0.1 -p 8888 ping') do
-      its(:stdout) { is_expected.to match /PONG/ }
+      its(:stdout) { is_expected.to match %r{PONG} }
     end
   end
 end

--- a/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
@@ -40,32 +40,32 @@ describe 'redis::instance', unless: (fact('operatingsystem') == 'Debian') do
   end
 
   describe package(redis_name) do
-    it { should be_installed }
+    it { is_expected.to be_installed }
   end
 
   describe service('redis-server-redis1') do
-    it { should be_running }
+    it { is_expected.to be_running }
   end
 
   describe service('redis-server-redis2') do
-    it { should be_running }
+    it { is_expected.to be_running }
   end
 
   describe file("#{config_path}/redis-server-redis1.conf") do
-    its(:content) { should match /port 7777/ }
+    its(:content) { is_expected.to match /port 7777/ }
   end
 
   describe file("#{config_path}/redis-server-redis2.conf") do
-    its(:content) { should match /port 8888/ }
+    its(:content) { is_expected.to match /port 8888/ }
   end
 
   context 'redis should respond to ping command' do
     describe command('redis-cli -h 127.0.0.1 -p 7777 ping') do
-      its(:stdout) { should match /PONG/ }
+      its(:stdout) { is_expected.to match /PONG/ }
     end
 
     describe command('redis-cli -h 127.0.0.1 -p 8888 ping') do
-      its(:stdout) { should match /PONG/ }
+      its(:stdout) { is_expected.to match /PONG/ }
     end
   end
 end

--- a/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 # Cant get this to work on Debian, add exception for now
-describe 'redis::instance', :unless => (fact('operatingsystem') == 'Debian') do
+describe 'redis::instance', unless: (fact('operatingsystem') == 'Debian') do
   case fact('osfamily')
   when 'Debian'
     config_path  = '/etc/redis'
@@ -35,8 +35,8 @@ describe 'redis::instance', :unless => (fact('operatingsystem') == 'Debian') do
     EOS
 
     # Apply twice to ensure no errors the second time.
-    apply_manifest(pp, :catch_failures => true)
-    apply_manifest(pp, :catch_changes => true)
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
   end
 
   describe package(redis_name) do

--- a/spec/acceptance/suites/default/redis_multi_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_node_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper_acceptance'
 
 if hosts.length >= 3
   describe 'configuring master and slave redis hosts' do
-
     let(:master_ip_address) do
       # hosts_as('master').inject({}) do |memo,host|
       #   memo[host] = fact_on host, "ipaddress_enp0s8"
@@ -32,7 +31,6 @@ if hosts.length >= 3
           on host, command_to_check do
             expect(stdout).to match(/^role:master/)
           end
-
         end
       end
     end
@@ -54,7 +52,6 @@ if hosts.length >= 3
           on host, 'redis-cli -h $(facter ipaddress_enp0s8) info replication' do
             expect(stdout).to match(/^role:slave/)
           end
-
         end
       end
     end
@@ -69,10 +66,8 @@ if hosts.length >= 3
           on host, command_to_check do
             expect(stdout).to match(/^connected_slaves:2/)
           end
-
         end
       end
     end
-
   end
 end

--- a/spec/acceptance/suites/default/redis_multi_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_node_spec.rb
@@ -12,7 +12,7 @@ if hosts.length >= 3
 
     hosts_as('master').each do |host|
       context "should be able to configure a host as master on #{host}" do
-        it 'should work idempotently with no errors' do
+        it 'works idempotently with no errors' do
           pp = <<-EOS
           # Stop firewall so we can easily connect
           service {'firewalld':
@@ -39,7 +39,7 @@ if hosts.length >= 3
 
     hosts_as('slave').each do |host|
       context "should be able to configure a host as master on #{host}" do
-        it 'should work idempotently with no errors' do
+        it 'works idempotently with no errors' do
           pp = <<-EOS
           class { 'redis':
             manage_repo => true,
@@ -61,7 +61,7 @@ if hosts.length >= 3
 
     hosts_as('master').each do |host|
       context "should be able to configure a host as master on #{host}" do
-        it 'should work idempotently with no errors' do
+        it 'works idempotently with no errors' do
           command_to_check = "redis-cli -h #{master_ip_address} -a foobared info replication"
 
           sleep(5)

--- a/spec/acceptance/suites/default/redis_multi_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_node_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 if hosts.length >= 3
-  describe "configuring master and slave redis hosts" do
+  describe 'configuring master and slave redis hosts' do
 
     let(:master_ip_address) do
       # hosts_as('master').inject({}) do |memo,host|

--- a/spec/acceptance/suites/default/redis_multi_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_node_spec.rb
@@ -29,7 +29,7 @@ if hosts.length >= 3
           command_to_check = "redis-cli -h #{master_ip_address} -a foobared info replication"
 
           on host, command_to_check do
-            expect(stdout).to match(/^role:master/)
+            expect(stdout).to match(%r{^role:master})
           end
         end
       end
@@ -50,7 +50,7 @@ if hosts.length >= 3
           apply_manifest_on(host, pp, catch_failures: true)
 
           on host, 'redis-cli -h $(facter ipaddress_enp0s8) info replication' do
-            expect(stdout).to match(/^role:slave/)
+            expect(stdout).to match(%r{^role:slave})
           end
         end
       end
@@ -64,7 +64,7 @@ if hosts.length >= 3
           sleep(5)
 
           on host, command_to_check do
-            expect(stdout).to match(/^connected_slaves:2/)
+            expect(stdout).to match(%r{^connected_slaves:2})
           end
         end
       end

--- a/spec/acceptance/suites/default/redis_multi_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_node_spec.rb
@@ -25,7 +25,7 @@ if hosts.length >= 3
             requirepass => 'foobared',
           }
           EOS
-          apply_manifest_on(host, pp, :catch_failures => true)
+          apply_manifest_on(host, pp, catch_failures: true)
 
           command_to_check = "redis-cli -h #{master_ip_address} -a foobared info replication"
 
@@ -49,7 +49,7 @@ if hosts.length >= 3
           }
 
           EOS
-          apply_manifest_on(host, pp, :catch_failures => true)
+          apply_manifest_on(host, pp, catch_failures: true)
 
           on host, 'redis-cli -h $(facter ipaddress_enp0s8) info replication' do
             expect(stdout).to match(/^role:slave/)

--- a/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper_acceptance'
 # CentOS 6 Redis package is too old for Sentinel (2.4.10, needs 2.8+)
 describe 'redis::sentinel', unless: (fact('osfamily') == 'RedHat' && (fact('operatingsystemmajrelease') == '6')) do
   redis_name = case fact('osfamily')
-  when 'Debian'
+               when 'Debian'
     'redis-server'
-  else
+               else
     'redis'
                end
 

--- a/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper_acceptance'
 
 # CentOS 6 Redis package is too old for Sentinel (2.4.10, needs 2.8+)
 describe 'redis::sentinel', unless: (fact('osfamily') == 'RedHat' && (fact('operatingsystemmajrelease') == '6')) do
-  case fact('osfamily')
+  redis_name = case fact('osfamily')
   when 'Debian'
-    redis_name = 'redis-server'
+    'redis-server'
   else
-    redis_name = 'redis'
-  end
+    'redis'
+               end
 
   it 'should run successfully' do
     pp = <<-EOS

--- a/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
@@ -51,13 +51,13 @@ describe 'redis::sentinel', unless: (fact('osfamily') == 'RedHat' && (fact('oper
 
   context 'redis should respond to ping command' do
     describe command('redis-cli ping') do
-      its(:stdout) { is_expected.to match /PONG/ }
+      its(:stdout) { is_expected.to match %r{PONG} }
     end
   end
 
   context 'redis-sentinel should return correct sentinel master' do
     describe command('redis-cli -p 26379 SENTINEL masters') do
-      its(:stdout) { is_expected.to match /^mymaster/ }
+      its(:stdout) { is_expected.to match %r{^mymaster} }
     end
   end
 end

--- a/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
@@ -31,33 +31,33 @@ describe 'redis::sentinel', unless: (fact('osfamily') == 'RedHat' && (fact('oper
   end
 
   describe package(redis_name) do
-    it { should be_installed }
+    it { is_expected.to be_installed }
   end
 
   describe service(redis_name) do
-    it { should be_running }
+    it { is_expected.to be_running }
   end
 
   describe service('redis-sentinel') do
-    it { should be_running }
+    it { is_expected.to be_running }
   end
 
   case fact('osfamily')
   when 'Debian'
     describe package('redis-sentinel') do
-      it { should be_installed }
+      it { is_expected.to be_installed }
     end
   end
 
   context 'redis should respond to ping command' do
     describe command('redis-cli ping') do
-      its(:stdout) { should match /PONG/ }
+      its(:stdout) { is_expected.to match /PONG/ }
     end
   end
 
   context 'redis-sentinel should return correct sentinel master' do
     describe command('redis-cli -p 26379 SENTINEL masters') do
-      its(:stdout) { should match /^mymaster/ }
+      its(:stdout) { is_expected.to match /^mymaster/ }
     end
   end
 end

--- a/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper_acceptance'
 describe 'redis::sentinel', unless: (fact('osfamily') == 'RedHat' && (fact('operatingsystemmajrelease') == '6')) do
   redis_name = case fact('osfamily')
                when 'Debian'
-    'redis-server'
+                 'redis-server'
                else
-    'redis'
+                 'redis'
                end
 
   it 'should run successfully' do

--- a/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
@@ -60,5 +60,4 @@ describe 'redis::sentinel', unless: (fact('osfamily') == 'RedHat' && (fact('oper
       its(:stdout) { should match /^mymaster/ }
     end
   end
-
 end

--- a/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 # CentOS 6 Redis package is too old for Sentinel (2.4.10, needs 2.8+)
-describe 'redis::sentinel', :unless => (fact('osfamily') == 'RedHat' && (fact('operatingsystemmajrelease') == '6')) do
+describe 'redis::sentinel', unless: (fact('osfamily') == 'RedHat' && (fact('operatingsystemmajrelease') == '6')) do
   case fact('osfamily')
   when 'Debian'
     redis_name = 'redis-server'
@@ -27,7 +27,7 @@ describe 'redis::sentinel', :unless => (fact('osfamily') == 'RedHat' && (fact('o
     }
     EOS
 
-    apply_manifest(pp, :catch_failures => true)
+    apply_manifest(pp, catch_failures: true)
   end
 
   describe package(redis_name) do

--- a/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
@@ -9,7 +9,7 @@ describe 'redis::sentinel', unless: (fact('osfamily') == 'RedHat' && (fact('oper
                  'redis'
                end
 
-  it 'should run successfully' do
+  it 'runs successfully' do
     pp = <<-EOS
 
     $master_name      = 'mymaster'

--- a/spec/acceptance/suites/default/redis_spec.rb
+++ b/spec/acceptance/suites/default/redis_spec.rb
@@ -38,16 +38,16 @@ describe 'redis' do
   end
 
   describe package(redis_name) do
-    it { should be_installed }
+    it { is_expected.to be_installed }
   end
 
   describe service(redis_name) do
-    it { should be_running }
+    it { is_expected.to be_running }
   end
 
   context 'redis should respond to ping command' do
     describe command('redis-cli ping') do
-      its(:stdout) { should match /PONG/ }
+      its(:stdout) { is_expected.to match /PONG/ }
     end
   end
 end

--- a/spec/acceptance/suites/default/redis_spec.rb
+++ b/spec/acceptance/suites/default/redis_spec.rb
@@ -22,8 +22,8 @@ describe 'redis' do
     EOS
 
     # Apply twice to ensure no errors the second time.
-    apply_manifest(pp, :catch_failures => true)
-    apply_manifest(pp, :catch_changes => true)
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
   end
 
   it 'should return a fact' do
@@ -32,7 +32,7 @@ describe 'redis' do
     EOS
 
     # Check output for fact string
-    apply_manifest(pp, :catch_failures => true) do |r|
+    apply_manifest(pp, catch_failures: true) do |r|
       expect(r.stdout).to match(/Redis Version: [\d+.]+/)
     end
   end

--- a/spec/acceptance/suites/default/redis_spec.rb
+++ b/spec/acceptance/suites/default/redis_spec.rb
@@ -10,7 +10,7 @@ describe 'redis' do
     manage_repo = true
   end
 
-  it 'should run successfully' do
+  it 'runs successfully' do
     pp = <<-EOS
     Exec {
       path => [ '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', ]
@@ -26,7 +26,7 @@ describe 'redis' do
     apply_manifest(pp, catch_changes: true)
   end
 
-  it 'should return a fact' do
+  it 'returns a fact' do
     pp = <<-EOS
     notify{"Redis Version: ${::redis_server_version}":}
     EOS

--- a/spec/acceptance/suites/default/redis_spec.rb
+++ b/spec/acceptance/suites/default/redis_spec.rb
@@ -33,7 +33,7 @@ describe 'redis' do
 
     # Check output for fact string
     apply_manifest(pp, catch_failures: true) do |r|
-      expect(r.stdout).to match(/Redis Version: [\d+.]+/)
+      expect(r.stdout).to match(%r{Redis Version: [\d+.]+})
     end
   end
 
@@ -47,7 +47,7 @@ describe 'redis' do
 
   context 'redis should respond to ping command' do
     describe command('redis-cli ping') do
-      its(:stdout) { is_expected.to match /PONG/ }
+      its(:stdout) { is_expected.to match %r{PONG} }
     end
   end
 end

--- a/spec/acceptance/suites/default/redisget_spec.rb
+++ b/spec/acceptance/suites/default/redisget_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 describe 'redisget() function' do
 
-  it 'should run successfully' do
+  it 'runs successfully' do
     pp = <<-EOS
     Exec {
       path => [ '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', ]
@@ -33,7 +33,7 @@ describe 'redisget() function' do
     end
   end
 
-  it 'should return a value from MyKey with the redisget() function' do
+  it 'returns a value from MyKey with the redisget() function' do
     pp = <<-EOS
     $mykey = redisget('mykey', 'redis://127.0.0.1:6379')
 
@@ -46,7 +46,7 @@ describe 'redisget() function' do
     end
   end
 
-  it 'should return a value from valid MyKey with the redisget() function while specifying a default' do
+  it 'returns a value from valid MyKey with the redisget() function while specifying a default' do
     pp = <<-EOS
     $mykey = redisget('mykey', 'redis://127.0.0.1:6379', 'default_value')
 
@@ -59,7 +59,7 @@ describe 'redisget() function' do
     end
   end
 
-  it 'should return an empty string when value not present with redisget() function' do
+  it 'returns an empty string when value not present with redisget() function' do
     pp = <<-EOS
     $foo_key = redisget('foo', 'redis://127.0.0.1:6379')
 
@@ -74,7 +74,7 @@ describe 'redisget() function' do
     end
   end
 
-  it 'should return the specified default value when key not present with redisget() function' do
+  it 'returns the specified default value when key not present with redisget() function' do
     pp = <<-EOS
     $foo_key = redisget('foo', 'redis://127.0.0.1:6379', 'default_value')
 
@@ -87,7 +87,7 @@ describe 'redisget() function' do
     end
   end
 
-  it 'should return the specified default value when connection to redis server fails' do
+  it 'returns the specified default value when connection to redis server fails' do
     pp = <<-EOS
     # Bogus port for redis server
     $foo_key = redisget('foo', 'redis://127.0.0.1:12345', 'default_value')
@@ -101,7 +101,7 @@ describe 'redisget() function' do
     end
   end
 
-  it 'should return an error when specifying a non connectable redis server' do
+  it 'returns an error when specifying a non connectable redis server' do
     pp = <<-EOS
     # Bogus port for redis server
     $foo_key = redisget('foo', 'redis://127.0.0.1:12345')

--- a/spec/acceptance/suites/default/redisget_spec.rb
+++ b/spec/acceptance/suites/default/redisget_spec.rb
@@ -41,7 +41,7 @@ describe 'redisget() function' do
 
     # Check output for function return value
     apply_manifest(pp, catch_failures: true) do |r|
-      expect(r.stdout).to match(/mykey value: Hello/)
+      expect(r.stdout).to match(%r{mykey value: Hello})
     end
   end
 
@@ -54,7 +54,7 @@ describe 'redisget() function' do
 
     # Check output for function return value
     apply_manifest(pp, catch_failures: true) do |r|
-      expect(r.stdout).to match(/mykey value: Hello/)
+      expect(r.stdout).to match(%r{mykey value: Hello})
     end
   end
 
@@ -69,7 +69,7 @@ describe 'redisget() function' do
 
     # Check output for function return value
     apply_manifest(pp, catch_failures: true) do |r|
-      expect(r.stdout).to match(/foo_key value was empty string/)
+      expect(r.stdout).to match(%r{foo_key value was empty string})
     end
   end
 
@@ -82,7 +82,7 @@ describe 'redisget() function' do
 
     # Check output for function return value
     apply_manifest(pp, catch_failures: true) do |r|
-      expect(r.stdout).to match(/default_value/)
+      expect(r.stdout).to match(%r{default_value})
     end
   end
 
@@ -96,7 +96,7 @@ describe 'redisget() function' do
 
     # Check output for function return value
     apply_manifest(pp, catch_failures: true) do |r|
-      expect(r.stdout).to match(/default_value/)
+      expect(r.stdout).to match(%r{default_value})
     end
   end
 
@@ -110,7 +110,7 @@ describe 'redisget() function' do
 
     # Check output for error when can't connect to bogus redis
     apply_manifest(pp, acceptable_exit_codes: [1]) do |r|
-      expect(r.stderr).to match(/Error connecting to Redis on 127.0.0.1:12345 \(Errno::ECONNREFUSED\)/)
+      expect(r.stderr).to match(%r{Error connecting to Redis on 127.0.0.1:12345 \(Errno::ECONNREFUSED\)})
     end
   end
 end

--- a/spec/acceptance/suites/default/redisget_spec.rb
+++ b/spec/acceptance/suites/default/redisget_spec.rb
@@ -21,8 +21,8 @@ describe 'redisget() function' do
     EOS
 
     # Apply twice to ensure no errors the second time.
-    apply_manifest(pp, :catch_failures => true)
-    apply_manifest(pp, :catch_changes => true)
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
 
     shell('redis-cli SET mykey "Hello"') do |result|
       expect(result.stdout).to match('OK')
@@ -41,7 +41,7 @@ describe 'redisget() function' do
     EOS
 
     # Check output for function return value
-    apply_manifest(pp, :catch_failures => true) do |r|
+    apply_manifest(pp, catch_failures: true) do |r|
       expect(r.stdout).to match(/mykey value: Hello/)
     end
   end
@@ -54,7 +54,7 @@ describe 'redisget() function' do
     EOS
 
     # Check output for function return value
-    apply_manifest(pp, :catch_failures => true) do |r|
+    apply_manifest(pp, catch_failures: true) do |r|
       expect(r.stdout).to match(/mykey value: Hello/)
     end
   end
@@ -69,7 +69,7 @@ describe 'redisget() function' do
     EOS
 
     # Check output for function return value
-    apply_manifest(pp, :catch_failures => true) do |r|
+    apply_manifest(pp, catch_failures: true) do |r|
       expect(r.stdout).to match(/foo_key value was empty string/)
     end
   end
@@ -82,7 +82,7 @@ describe 'redisget() function' do
     EOS
 
     # Check output for function return value
-    apply_manifest(pp, :catch_failures => true) do |r|
+    apply_manifest(pp, catch_failures: true) do |r|
       expect(r.stdout).to match(/default_value/)
     end
   end
@@ -96,7 +96,7 @@ describe 'redisget() function' do
     EOS
 
     # Check output for function return value
-    apply_manifest(pp, :catch_failures => true) do |r|
+    apply_manifest(pp, catch_failures: true) do |r|
       expect(r.stdout).to match(/default_value/)
     end
   end
@@ -110,7 +110,7 @@ describe 'redisget() function' do
     EOS
 
     # Check output for error when can't connect to bogus redis
-    apply_manifest(pp, :acceptable_exit_codes => [1]) do |r|
+    apply_manifest(pp, acceptable_exit_codes: [1]) do |r|
       expect(r.stderr).to match(/Error connecting to Redis on 127.0.0.1:12345 \(Errno::ECONNREFUSED\)/)
     end
   end

--- a/spec/acceptance/suites/default/redisget_spec.rb
+++ b/spec/acceptance/suites/default/redisget_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'redisget() function' do
-
   it 'runs successfully' do
     pp = <<-EOS
     Exec {
@@ -114,5 +113,4 @@ describe 'redisget() function' do
       expect(r.stderr).to match(/Error connecting to Redis on 127.0.0.1:12345 \(Errno::ECONNREFUSED\)/)
     end
   end
-
 end

--- a/spec/classes/redis_administration_spec.rb
+++ b/spec/classes/redis_administration_spec.rb
@@ -6,8 +6,8 @@ describe 'redis::administration' do
     it do
       is_expected.to contain_sysctl('vm.overcommit_memory').with(
         {
-          'ensure'=>'present',
-          'value'=>'1'
+          'ensure' => 'present',
+          'value' => '1'
         }
       )
     end

--- a/spec/classes/redis_administration_spec.rb
+++ b/spec/classes/redis_administration_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe 'redis::administration' do
   context 'should set kernel and system values' do
-
     it do
       is_expected.to contain_sysctl('vm.overcommit_memory').with(
         'ensure' => 'present',
@@ -25,7 +24,5 @@ describe 'redis::administration' do
         'value' => '65535'
       )
     end
-
   end
-
 end

--- a/spec/classes/redis_administration_spec.rb
+++ b/spec/classes/redis_administration_spec.rb
@@ -5,24 +5,24 @@ describe 'redis::administration' do
 
     it do
       is_expected.to contain_sysctl('vm.overcommit_memory').with(
-                  'ensure' => 'present',
-                  'value' => '1'
+        'ensure' => 'present',
+        'value' => '1'
       )
     end
 
     it do
       is_expected.to contain_exec('Disable Hugepages').with(
-                  'command' => 'echo never > /sys/kernel/mm/transparent_hugepage/enabled',
-                  'path' => ['/sbin', '/usr/sbin', '/bin', '/usr/bin'],
-                  'onlyif' => 'test -f /sys/kernel/mm/transparent_hugepage/enabled',
-                  'unless' => 'cat /sys/kernel/mm/transparent_hugepage/enabled | grep "\\[never\\]"'
+        'command' => 'echo never > /sys/kernel/mm/transparent_hugepage/enabled',
+        'path' => ['/sbin', '/usr/sbin', '/bin', '/usr/bin'],
+        'onlyif' => 'test -f /sys/kernel/mm/transparent_hugepage/enabled',
+        'unless' => 'cat /sys/kernel/mm/transparent_hugepage/enabled | grep "\\[never\\]"'
       )
     end
 
     it do
       is_expected.to contain_sysctl('net.core.somaxconn').with(
-                  'ensure' => 'present',
-                  'value' => '65535'
+        'ensure' => 'present',
+        'value' => '65535'
       )
     end
 

--- a/spec/classes/redis_administration_spec.rb
+++ b/spec/classes/redis_administration_spec.rb
@@ -11,18 +11,18 @@ describe 'redis::administration' do
     end
 
     it do
-      is_expected.to contain_exec("Disable Hugepages").with(
-                  "command" => "echo never > /sys/kernel/mm/transparent_hugepage/enabled",
-                  "path" => ["/sbin", "/usr/sbin", "/bin", "/usr/bin"],
-                  "onlyif" => "test -f /sys/kernel/mm/transparent_hugepage/enabled",
-                  "unless" => "cat /sys/kernel/mm/transparent_hugepage/enabled | grep \"\\[never\\]\""
+      is_expected.to contain_exec('Disable Hugepages').with(
+                  'command' => 'echo never > /sys/kernel/mm/transparent_hugepage/enabled',
+                  'path' => ['/sbin', '/usr/sbin', '/bin', '/usr/bin'],
+                  'onlyif' => 'test -f /sys/kernel/mm/transparent_hugepage/enabled',
+                  'unless' => 'cat /sys/kernel/mm/transparent_hugepage/enabled | grep "\\[never\\]"'
       )
     end
 
     it do
-      is_expected.to contain_sysctl("net.core.somaxconn").with(
-                  "ensure" => "present",
-                  "value" => "65535"
+      is_expected.to contain_sysctl('net.core.somaxconn').with(
+                  'ensure' => 'present',
+                  'value' => '65535'
       )
     end
 

--- a/spec/classes/redis_administration_spec.rb
+++ b/spec/classes/redis_administration_spec.rb
@@ -5,30 +5,24 @@ describe 'redis::administration' do
 
     it do
       is_expected.to contain_sysctl('vm.overcommit_memory').with(
-        {
-          'ensure' => 'present',
-          'value' => '1'
-        }
+                  'ensure' => 'present',
+                  'value' => '1'
       )
     end
 
     it do
       is_expected.to contain_exec("Disable Hugepages").with(
-        {
-          "command" => "echo never > /sys/kernel/mm/transparent_hugepage/enabled",
-          "path" => ["/sbin", "/usr/sbin", "/bin", "/usr/bin"],
-          "onlyif" => "test -f /sys/kernel/mm/transparent_hugepage/enabled",
-          "unless" => "cat /sys/kernel/mm/transparent_hugepage/enabled | grep \"\\[never\\]\"",
-        }
+                  "command" => "echo never > /sys/kernel/mm/transparent_hugepage/enabled",
+                  "path" => ["/sbin", "/usr/sbin", "/bin", "/usr/bin"],
+                  "onlyif" => "test -f /sys/kernel/mm/transparent_hugepage/enabled",
+                  "unless" => "cat /sys/kernel/mm/transparent_hugepage/enabled | grep \"\\[never\\]\""
       )
     end
 
     it do
       is_expected.to contain_sysctl("net.core.somaxconn").with(
-        {
-          "ensure" => "present",
-          "value" => "65535",
-        }
+                  "ensure" => "present",
+                  "value" => "65535"
       )
     end
 

--- a/spec/classes/redis_centos_6_spec.rb
+++ b/spec/classes/redis_centos_6_spec.rb
@@ -2,15 +2,12 @@ require 'spec_helper'
 
 describe 'redis' do
   context 'on CentOS 6' do
-
     let(:facts) {
       centos_6_facts
     }
 
     context 'should set CentOS specific values' do
-
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3.2.1) (older features enabled)' do
-
         let(:facts) {
           centos_6_facts.merge(redis_server_version: nil,
                                puppetversion: Puppet.version)
@@ -24,7 +21,6 @@ describe 'redis' do
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
-
         let(:facts) {
           centos_6_facts.merge(redis_server_version: nil,
                                puppetversion: Puppet.version)
@@ -38,7 +34,6 @@ describe 'redis' do
       end
 
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
-
         let(:facts) {
           centos_6_facts.merge(redis_server_version: '2.4.10',
                                puppetversion: Puppet.version)
@@ -48,11 +43,9 @@ describe 'redis' do
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^tcp-backlog/) }
-
       end
 
       context 'when $::redis_server_version fact is present but a newer version (older features enabled)' do
-
         let(:facts) {
           centos_6_facts.merge(redis_server_version: '3.2.1',
                                puppetversion: Puppet.version)
@@ -62,10 +55,7 @@ describe 'redis' do
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
-
       end
     end
-
   end
-
 end

--- a/spec/classes/redis_centos_6_spec.rb
+++ b/spec/classes/redis_centos_6_spec.rb
@@ -14,10 +14,10 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '3.2.1' } }
 
-        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
-        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^protected-mode/) }
-        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
@@ -27,10 +27,10 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '4.0-rc3' } }
 
-        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
-        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^protected-mode/) }
-        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
       end
 
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
@@ -39,10 +39,10 @@ describe 'redis' do
                                puppetversion: Puppet.version)
         end
 
-        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-zipmap-entries/) }
-        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^protected-mode/) }
-        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-zipmap-entries/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-ziplist-entries/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^tcp-backlog/) }
       end
 
       context 'when $::redis_server_version fact is present but a newer version (older features enabled)' do
@@ -51,10 +51,10 @@ describe 'redis' do
                                puppetversion: Puppet.version)
         end
 
-        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
-        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^protected-mode/) }
-        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
       end
     end
   end

--- a/spec/classes/redis_centos_6_spec.rb
+++ b/spec/classes/redis_centos_6_spec.rb
@@ -2,16 +2,16 @@ require 'spec_helper'
 
 describe 'redis' do
   context 'on CentOS 6' do
-    let(:facts) {
+    let(:facts) do
       centos_6_facts
-    }
+    end
 
     context 'should set CentOS specific values' do
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3.2.1) (older features enabled)' do
-        let(:facts) {
+        let(:facts) do
           centos_6_facts.merge(redis_server_version: nil,
                                puppetversion: Puppet.version)
-        }
+        end
         let (:params) { { package_ensure: '3.2.1' } }
 
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
@@ -21,10 +21,10 @@ describe 'redis' do
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
-        let(:facts) {
+        let(:facts) do
           centos_6_facts.merge(redis_server_version: nil,
                                puppetversion: Puppet.version)
-        }
+        end
         let (:params) { { package_ensure: '4.0-rc3' } }
 
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
@@ -34,10 +34,10 @@ describe 'redis' do
       end
 
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
-        let(:facts) {
+        let(:facts) do
           centos_6_facts.merge(redis_server_version: '2.4.10',
                                puppetversion: Puppet.version)
-        }
+        end
 
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-zipmap-entries/) }
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-ziplist-entries/) }
@@ -46,10 +46,10 @@ describe 'redis' do
       end
 
       context 'when $::redis_server_version fact is present but a newer version (older features enabled)' do
-        let(:facts) {
+        let(:facts) do
           centos_6_facts.merge(redis_server_version: '3.2.1',
                                puppetversion: Puppet.version)
-        }
+        end
 
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }

--- a/spec/classes/redis_centos_6_spec.rb
+++ b/spec/classes/redis_centos_6_spec.rb
@@ -12,10 +12,8 @@ describe 'redis' do
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3.2.1) (older features enabled)' do
 
         let(:facts) {
-          centos_6_facts.merge({
-            redis_server_version: nil,
-            puppetversion: Puppet.version,
-          })
+          centos_6_facts.merge(redis_server_version: nil,
+                               puppetversion: Puppet.version)
         }
         let (:params) { { package_ensure: '3.2.1' } }
 
@@ -28,10 +26,8 @@ describe 'redis' do
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
 
         let(:facts) {
-          centos_6_facts.merge({
-            redis_server_version: nil,
-            puppetversion: Puppet.version,
-          })
+          centos_6_facts.merge(redis_server_version: nil,
+                               puppetversion: Puppet.version)
         }
         let (:params) { { package_ensure: '4.0-rc3' } }
 
@@ -44,10 +40,8 @@ describe 'redis' do
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
 
         let(:facts) {
-          centos_6_facts.merge({
-            redis_server_version: '2.4.10',
-            puppetversion: Puppet.version,
-          })
+          centos_6_facts.merge(redis_server_version: '2.4.10',
+                               puppetversion: Puppet.version)
         }
 
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-zipmap-entries/) }
@@ -60,10 +54,8 @@ describe 'redis' do
       context 'when $::redis_server_version fact is present but a newer version (older features enabled)' do
 
         let(:facts) {
-          centos_6_facts.merge({
-            redis_server_version: '3.2.1',
-            puppetversion: Puppet.version,
-          })
+          centos_6_facts.merge(redis_server_version: '3.2.1',
+                               puppetversion: Puppet.version)
         }
 
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }

--- a/spec/classes/redis_centos_6_spec.rb
+++ b/spec/classes/redis_centos_6_spec.rb
@@ -13,11 +13,11 @@ describe 'redis' do
 
         let(:facts) {
           centos_6_facts.merge({
-            :redis_server_version => nil,
-            :puppetversion        => Puppet.version,
+            redis_server_version: nil,
+            puppetversion: Puppet.version,
           })
         }
-        let (:params) { { :package_ensure => '3.2.1' } }
+        let (:params) { { package_ensure: '3.2.1' } }
 
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
@@ -29,11 +29,11 @@ describe 'redis' do
 
         let(:facts) {
           centos_6_facts.merge({
-            :redis_server_version => nil,
-            :puppetversion        => Puppet.version,
+            redis_server_version: nil,
+            puppetversion: Puppet.version,
           })
         }
-        let (:params) { { :package_ensure => '4.0-rc3' } }
+        let (:params) { { package_ensure: '4.0-rc3' } }
 
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
@@ -45,8 +45,8 @@ describe 'redis' do
 
         let(:facts) {
           centos_6_facts.merge({
-            :redis_server_version => '2.4.10',
-            :puppetversion        => Puppet.version,
+            redis_server_version: '2.4.10',
+            puppetversion: Puppet.version,
           })
         }
 
@@ -61,8 +61,8 @@ describe 'redis' do
 
         let(:facts) {
           centos_6_facts.merge({
-            :redis_server_version => '3.2.1',
-            :puppetversion        => Puppet.version,
+            redis_server_version: '3.2.1',
+            puppetversion: Puppet.version,
           })
         }
 

--- a/spec/classes/redis_centos_6_spec.rb
+++ b/spec/classes/redis_centos_6_spec.rb
@@ -14,10 +14,10 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '3.2.1' } }
 
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^protected-mode/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => %r{^hash-max-zipmap-entries}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => %r{^hash-max-ziplist-entries}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => %r{^protected-mode}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => %r{^tcp-backlog}) }
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
@@ -27,10 +27,10 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '4.0-rc3' } }
 
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^protected-mode/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => %r{^hash-max-zipmap-entries}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => %r{^hash-max-ziplist-entries}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => %r{^protected-mode}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => %r{^tcp-backlog}) }
       end
 
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
@@ -39,10 +39,10 @@ describe 'redis' do
                                puppetversion: Puppet.version)
         end
 
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-zipmap-entries/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-ziplist-entries/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^protected-mode/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => %r{^hash-max-zipmap-entries}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => %r{^hash-max-ziplist-entries}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => %r{^protected-mode}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => %r{^tcp-backlog}) }
       end
 
       context 'when $::redis_server_version fact is present but a newer version (older features enabled)' do
@@ -51,10 +51,10 @@ describe 'redis' do
                                puppetversion: Puppet.version)
         end
 
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^protected-mode/) }
-        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').without('content' => %r{^hash-max-zipmap-entries}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => %r{^hash-max-ziplist-entries}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => %r{^protected-mode}) }
+        it { is_expected.to contain_file('/etc/redis.conf.puppet').with('content' => %r{^tcp-backlog}) }
       end
     end
   end

--- a/spec/classes/redis_debian_wheezy_spec.rb
+++ b/spec/classes/redis_debian_wheezy_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe 'redis' do
   context 'on Debian Wheezy' do
-    let(:facts) {
+    let(:facts) do
       debian_wheezy_facts
-    }
+    end
 
     context 'should set Wheezy specific values' do
       context 'should set redis rundir correctly to Wheezy requirements' do

--- a/spec/classes/redis_debian_wheezy_spec.rb
+++ b/spec/classes/redis_debian_wheezy_spec.rb
@@ -8,8 +8,8 @@ describe 'redis' do
 
     context 'should set Wheezy specific values' do
       context 'should set redis rundir correctly to Wheezy requirements' do
-        it { should contain_file('/var/run/redis').with('mode' => '2755') }
-        it { should contain_file('/var/run/redis').with('group' => 'redis') }
+        it { is_expected.to contain_file('/var/run/redis').with('mode' => '2755') }
+        it { is_expected.to contain_file('/var/run/redis').with('group' => 'redis') }
       end
     end
   end

--- a/spec/classes/redis_debian_wheezy_spec.rb
+++ b/spec/classes/redis_debian_wheezy_spec.rb
@@ -2,18 +2,15 @@ require 'spec_helper'
 
 describe 'redis' do
   context 'on Debian Wheezy' do
-
     let(:facts) {
       debian_wheezy_facts
     }
 
     context 'should set Wheezy specific values' do
-
       context 'should set redis rundir correctly to Wheezy requirements' do
         it { should contain_file('/var/run/redis').with('mode' => '2755') }
         it { should contain_file('/var/run/redis').with('group' => 'redis') }
       end
     end
   end
-
 end

--- a/spec/classes/redis_freebsd_spec.rb
+++ b/spec/classes/redis_freebsd_spec.rb
@@ -7,8 +7,8 @@ describe 'redis' do
     end
 
     context 'should set FreeBSD specific values' do
-      it { should contain_file('/usr/local/etc/redis.conf.puppet').with('content' => /dir \/var\/db\/redis/) }
-      it { should contain_file('/usr/local/etc/redis.conf.puppet').with('content' => /pidfile \/var\/run\/redis\/redis.pid/) }
+      it { is_expected.to contain_file('/usr/local/etc/redis.conf.puppet').with('content' => /dir \/var\/db\/redis/) }
+      it { is_expected.to contain_file('/usr/local/etc/redis.conf.puppet').with('content' => /pidfile \/var\/run\/redis\/redis.pid/) }
     end
   end
 end

--- a/spec/classes/redis_freebsd_spec.rb
+++ b/spec/classes/redis_freebsd_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe 'redis' do
   context 'on FreeBSD' do
-    let(:facts) {
+    let(:facts) do
       freebsd_facts
-    }
+    end
 
     context 'should set FreeBSD specific values' do
       it { should contain_file('/usr/local/etc/redis.conf.puppet').with('content' => /dir \/var\/db\/redis/) }

--- a/spec/classes/redis_freebsd_spec.rb
+++ b/spec/classes/redis_freebsd_spec.rb
@@ -11,5 +11,4 @@ describe 'redis' do
       it { should contain_file('/usr/local/etc/redis.conf.puppet').with('content' => /pidfile \/var\/run\/redis\/redis.pid/) }
     end
   end
-
 end

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -46,20 +46,22 @@ describe 'redis::sentinel', type: :class do
   describe 'without parameters' do
     it { should create_class('redis::sentinel') }
 
-    it { should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
-      'ensure'  => 'present',
-      'mode'    => '0644',
-      'owner'   => 'redis',
-      'content' => $expected_noparams_content
-    )
+    it {
+      should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
+        'ensure'  => 'present',
+        'mode'    => '0644',
+        'owner'   => 'redis',
+        'content' => $expected_noparams_content
+      )
     }
 
-    it { should contain_service('redis-sentinel').with(
-      'ensure'     => 'running',
-      'enable'     => 'true',
-      'hasrestart' => 'true',
-      'hasstatus'  => 'true'
-    )
+    it {
+      should contain_service('redis-sentinel').with(
+        'ensure'     => 'running',
+        'enable'     => 'true',
+        'hasrestart' => 'true',
+        'hasstatus'  => 'true'
+      )
     }
   end
 
@@ -79,9 +81,10 @@ describe 'redis::sentinel', type: :class do
 
     it { should create_class('redis::sentinel') }
 
-    it { should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
-      'content' => $expected_params_content
-    )
+    it {
+      should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
+        'content' => $expected_params_content
+      )
     }
   end
 

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -44,7 +44,6 @@ describe 'redis::sentinel', type: :class do
   end
 
   describe 'without parameters' do
-
     it { should create_class('redis::sentinel') }
 
     it { should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
@@ -62,7 +61,6 @@ describe 'redis::sentinel', type: :class do
       'hasstatus'  => 'true'
     )
     }
-
   end
 
   describe 'with custom parameters' do
@@ -88,7 +86,6 @@ describe 'redis::sentinel', type: :class do
   end
 
   describe 'on Debian Jessie' do
-
     let (:facts) { debian_facts.merge(operatingsystemmajrelease: '8') }
 
     it { should create_class('redis::sentinel') }
@@ -97,12 +94,10 @@ describe 'redis::sentinel', type: :class do
   end
 
   describe 'on Debian Stretch' do
-
     let (:facts) { debian_facts.merge(operatingsystemmajrelease: '9') }
 
     it { should create_class('redis::sentinel') }
 
     it { should contain_package('redis-sentinel').with_ensure('present') }
   end
-
 end

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -52,7 +52,7 @@ describe 'redis::sentinel', type: :class do
       'mode'    => '0644',
       'owner'   => 'redis',
       'content' => $expected_noparams_content
-      )
+    )
     }
 
     it { should contain_service('redis-sentinel').with(
@@ -60,7 +60,7 @@ describe 'redis::sentinel', type: :class do
       'enable'     => 'true',
       'hasrestart' => 'true',
       'hasstatus'  => 'true'
-      )
+    )
     }
 
   end
@@ -83,7 +83,7 @@ describe 'redis::sentinel', type: :class do
 
     it { should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
       'content' => $expected_params_content
-      )
+    )
     }
   end
 

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -59,7 +59,7 @@ describe 'redis::sentinel', type: :class do
         'ensure'     => 'running',
         'enable'     => 'true',
         'hasrestart' => 'true',
-        'hasstatus'  => 'true',
+        'hasstatus'  => 'true'
       )
     }
 

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -89,9 +89,7 @@ describe 'redis::sentinel', type: :class do
 
   describe 'on Debian Jessie' do
 
-    let (:facts) { debian_facts.merge({
-      operatingsystemmajrelease: '8',
-    }) }
+    let (:facts) { debian_facts.merge(operatingsystemmajrelease: '8') }
 
     it { should create_class('redis::sentinel') }
 
@@ -100,9 +98,7 @@ describe 'redis::sentinel', type: :class do
 
   describe 'on Debian Stretch' do
 
-    let (:facts) { debian_facts.merge({
-      operatingsystemmajrelease: '9',
-    }) }
+    let (:facts) { debian_facts.merge(operatingsystemmajrelease: '9') }
 
     it { should create_class('redis::sentinel') }
 

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -73,7 +73,7 @@ describe 'redis::sentinel', type: :class do
         master_name: 'cow',
         down_after: 6000,
         log_file: '/tmp/barn-sentinel.log',
-        failover_timeout: 28000,
+        failover_timeout: 28_000,
         notification_script: 'bar.sh',
         client_reconfig_script: 'foo.sh'
       }

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -66,7 +66,7 @@ describe 'redis::sentinel', type: :class do
   end
 
   describe 'with custom parameters' do
-    let (:params) {
+    let (:params) do
       {
         auth_pass: 'password',
         sentinel_bind: '1.2.3.4',
@@ -77,7 +77,7 @@ describe 'redis::sentinel', type: :class do
         notification_script: 'bar.sh',
         client_reconfig_script: 'foo.sh'
       }
-    }
+    end
 
     it { should create_class('redis::sentinel') }
 

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -39,7 +39,7 @@ describe 'redis::sentinel', type: :class do
 
   let :pre_condition do
     [
-     'class { redis: }'
+      'class { redis: }'
     ]
   end
 

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -34,7 +34,7 @@ loglevel notice
 logfile /tmp/barn-sentinel.log
 EOF
 
-describe 'redis::sentinel', :type => :class do
+describe 'redis::sentinel', type: :class do
   let (:facts) { debian_facts }
 
   let :pre_condition do
@@ -68,14 +68,14 @@ describe 'redis::sentinel', :type => :class do
   describe 'with custom parameters' do
     let (:params) {
       {
-        :auth_pass              => 'password',
-        :sentinel_bind          => '1.2.3.4',
-        :master_name            => 'cow',
-        :down_after             => 6000,
-        :log_file               => '/tmp/barn-sentinel.log',
-        :failover_timeout       => 28000,
-        :notification_script    => 'bar.sh',
-        :client_reconfig_script => 'foo.sh'
+        auth_pass: 'password',
+        sentinel_bind: '1.2.3.4',
+        master_name: 'cow',
+        down_after: 6000,
+        log_file: '/tmp/barn-sentinel.log',
+        failover_timeout: 28000,
+        notification_script: 'bar.sh',
+        client_reconfig_script: 'foo.sh'
       }
     }
 
@@ -90,7 +90,7 @@ describe 'redis::sentinel', :type => :class do
   describe 'on Debian Jessie' do
 
     let (:facts) { debian_facts.merge({
-      :operatingsystemmajrelease => '8',
+      operatingsystemmajrelease: '8',
     }) }
 
     it { should create_class('redis::sentinel') }
@@ -101,7 +101,7 @@ describe 'redis::sentinel', :type => :class do
   describe 'on Debian Stretch' do
 
     let (:facts) { debian_facts.merge({
-      :operatingsystemmajrelease => '9',
+      operatingsystemmajrelease: '9',
     }) }
 
     it { should create_class('redis::sentinel') }

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -48,18 +48,18 @@ describe 'redis::sentinel', type: :class do
     it { should create_class('redis::sentinel') }
 
     it { should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
-        'ensure'  => 'present',
-        'mode'    => '0644',
-        'owner'   => 'redis',
-        'content' => $expected_noparams_content
+      'ensure'  => 'present',
+      'mode'    => '0644',
+      'owner'   => 'redis',
+      'content' => $expected_noparams_content
       )
     }
 
     it { should contain_service('redis-sentinel').with(
-        'ensure'     => 'running',
-        'enable'     => 'true',
-        'hasrestart' => 'true',
-        'hasstatus'  => 'true'
+      'ensure'     => 'running',
+      'enable'     => 'true',
+      'hasrestart' => 'true',
+      'hasstatus'  => 'true'
       )
     }
 
@@ -82,7 +82,7 @@ describe 'redis::sentinel', type: :class do
     it { should create_class('redis::sentinel') }
 
     it { should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
-        'content' => $expected_params_content
+      'content' => $expected_params_content
       )
     }
   end

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -44,10 +44,10 @@ describe 'redis::sentinel', type: :class do
   end
 
   describe 'without parameters' do
-    it { should create_class('redis::sentinel') }
+    it { is_expected.to create_class('redis::sentinel') }
 
     it {
-      should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
+      is_expected.to contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
         'ensure'  => 'present',
         'mode'    => '0644',
         'owner'   => 'redis',
@@ -56,7 +56,7 @@ describe 'redis::sentinel', type: :class do
     }
 
     it {
-      should contain_service('redis-sentinel').with(
+      is_expected.to contain_service('redis-sentinel').with(
         'ensure'     => 'running',
         'enable'     => 'true',
         'hasrestart' => 'true',
@@ -79,10 +79,10 @@ describe 'redis::sentinel', type: :class do
       }
     end
 
-    it { should create_class('redis::sentinel') }
+    it { is_expected.to create_class('redis::sentinel') }
 
     it {
-      should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
+      is_expected.to contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
         'content' => $expected_params_content
       )
     }
@@ -91,16 +91,16 @@ describe 'redis::sentinel', type: :class do
   describe 'on Debian Jessie' do
     let (:facts) { debian_facts.merge(operatingsystemmajrelease: '8') }
 
-    it { should create_class('redis::sentinel') }
+    it { is_expected.to create_class('redis::sentinel') }
 
-    it { should_not contain_package('redis-sentinel').with_ensure('present') }
+    it { is_expected.not_to contain_package('redis-sentinel').with_ensure('present') }
   end
 
   describe 'on Debian Stretch' do
     let (:facts) { debian_facts.merge(operatingsystemmajrelease: '9') }
 
-    it { should create_class('redis::sentinel') }
+    it { is_expected.to create_class('redis::sentinel') }
 
-    it { should contain_package('redis-sentinel').with_ensure('present') }
+    it { is_expected.to contain_package('redis-sentinel').with_ensure('present') }
   end
 end

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -258,13 +258,13 @@ describe 'redis', type: :class do
       end
 
       describe 'without parameter dbfilename' do
-        let(:params) {
-          {
-            dbfilename: false,
-          }
-        }
+         let(:params) {
+           {
+             dbfilename: false,
+           }
+         }
 
-        it { is_expected.to contain_file(config_file_orig).without_content(/^dbfilename/) }
+         it { is_expected.to contain_file(config_file_orig).without_content(/^dbfilename/) }
        end
 
       describe 'with parameter hash_max_ziplist_entries' do

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -221,7 +221,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /daemonize.*yes/
-          )
+        )
         }
       end
 
@@ -234,7 +234,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /databases.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -247,7 +247,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /dbfilename.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -270,7 +270,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /hash-max-ziplist-entries.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -283,7 +283,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /hash-max-ziplist-value.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -296,7 +296,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /list-max-ziplist-entries.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -309,7 +309,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /list-max-ziplist-value.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -322,7 +322,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file('_VALUE_').with(
           'ensure' => 'directory'
-          )
+        )
         }
       end
 
@@ -335,7 +335,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /logfile.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -348,7 +348,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /loglevel.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -396,7 +396,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /unixsocket.*\/tmp\/redis.sock/
-          )
+        )
         }
       end
 
@@ -409,7 +409,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /unixsocketperm.*777/
-          )
+        )
         }
       end
 
@@ -422,7 +422,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /masterauth.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -435,7 +435,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /maxclients.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -448,7 +448,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /maxmemory.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -461,7 +461,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /maxmemory-policy.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -474,7 +474,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /maxmemory-samples.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -487,7 +487,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /min-slaves-max-lag.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -500,7 +500,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /min-slaves-to-write.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -513,7 +513,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /notify-keyspace-events.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -538,7 +538,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /no-appendfsync-on-rewrite.*yes/
-          )
+        )
         }
       end
 
@@ -548,7 +548,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_package(package_name).with(
           'ensure' => '_VALUE_'
-          )
+        )
         }
       end
 
@@ -567,7 +567,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /pidfile.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -580,7 +580,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /port.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -593,7 +593,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /protected-mode.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -606,7 +606,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /hll-sparse-max-bytes.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -619,7 +619,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /hz.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -632,7 +632,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /latency-monitor-threshold.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -645,7 +645,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /rdbcompression.*yes/
-          )
+        )
         }
       end
 
@@ -658,7 +658,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /repl-backlog-size.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -671,7 +671,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /repl-backlog-ttl.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -684,7 +684,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /repl-disable-tcp-nodelay.*yes/
-          )
+        )
         }
       end
 
@@ -697,7 +697,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /repl-ping-slave-period.*1/
-          )
+        )
         }
       end
 
@@ -710,7 +710,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /repl-timeout.*1/
-          )
+        )
         }
       end
 
@@ -723,7 +723,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /requirepass.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -737,7 +737,7 @@ describe 'redis', type: :class do
 
           it { is_expected.to contain_file(config_file_orig).with(
             'content' => /^save/
-            )
+          )
           }
         end
 
@@ -750,7 +750,7 @@ describe 'redis', type: :class do
 
           it { is_expected.to contain_file(config_file_orig).with(
             'content' => /^(?!save)/
-            )
+          )
           }
         end
       end
@@ -864,7 +864,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /set-max-intset-entries.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -877,7 +877,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /slave-priority.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -890,7 +890,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /slave-read-only.*yes/
-          )
+        )
         }
       end
 
@@ -903,7 +903,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /slave-serve-stale-data.*yes/
-          )
+        )
         }
       end
 
@@ -946,7 +946,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /slowlog-log-slower-than.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -959,7 +959,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /slowlog-max-len.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -972,7 +972,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /stop-writes-on-bgsave-error.*yes/
-          )
+        )
         }
       end
 
@@ -985,7 +985,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /syslog-enabled yes/
-          )
+        )
         }
       end
 
@@ -999,7 +999,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /syslog-facility.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -1012,7 +1012,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /tcp-backlog.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -1025,7 +1025,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /tcp-keepalive.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -1038,7 +1038,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /timeout.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -1051,7 +1051,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /dir.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -1064,7 +1064,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /zset-max-ziplist-entries.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -1077,7 +1077,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /zset-max-ziplist-value.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -1090,7 +1090,7 @@ describe 'redis', type: :class do
 
         it { should_not contain_file(config_file_orig).with(
           'content' => /cluster-enabled/
-          )
+        )
         }
       end
 
@@ -1103,7 +1103,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /cluster-enabled.*yes/
-          )
+        )
         }
       end
 
@@ -1117,7 +1117,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /cluster-config-file.*_VALUE_/
-          )
+        )
         }
       end
 
@@ -1131,7 +1131,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with(
           'content' => /cluster-node-timeout.*_VALUE_/
-          )
+        )
         }
       end
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -1147,4 +1147,3 @@ describe 'redis', type: :class do
   end
 
 end
-

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -220,7 +220,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /daemonize.*yes/
+          'content' => /daemonize.*yes/
           )
         }
       end
@@ -233,7 +233,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /databases.*_VALUE_/
+          'content' => /databases.*_VALUE_/
           )
         }
       end
@@ -246,7 +246,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /dbfilename.*_VALUE_/
+          'content' => /dbfilename.*_VALUE_/
           )
         }
       end
@@ -269,7 +269,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /hash-max-ziplist-entries.*_VALUE_/
+          'content' => /hash-max-ziplist-entries.*_VALUE_/
           )
         }
       end
@@ -282,7 +282,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /hash-max-ziplist-value.*_VALUE_/
+          'content' => /hash-max-ziplist-value.*_VALUE_/
           )
         }
       end
@@ -295,7 +295,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /list-max-ziplist-entries.*_VALUE_/
+          'content' => /list-max-ziplist-entries.*_VALUE_/
           )
         }
       end
@@ -308,7 +308,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /list-max-ziplist-value.*_VALUE_/
+          'content' => /list-max-ziplist-value.*_VALUE_/
           )
         }
       end
@@ -321,7 +321,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file('_VALUE_').with(
-            'ensure' => 'directory'
+          'ensure' => 'directory'
           )
         }
       end
@@ -334,7 +334,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /logfile.*_VALUE_/
+          'content' => /logfile.*_VALUE_/
           )
         }
       end
@@ -347,7 +347,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /loglevel.*_VALUE_/
+          'content' => /loglevel.*_VALUE_/
           )
         }
       end
@@ -395,7 +395,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /unixsocket.*\/tmp\/redis.sock/
+          'content' => /unixsocket.*\/tmp\/redis.sock/
           )
         }
       end
@@ -408,7 +408,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /unixsocketperm.*777/
+          'content' => /unixsocketperm.*777/
           )
         }
       end
@@ -421,7 +421,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /masterauth.*_VALUE_/
+          'content' => /masterauth.*_VALUE_/
           )
         }
       end
@@ -434,7 +434,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /maxclients.*_VALUE_/
+          'content' => /maxclients.*_VALUE_/
           )
         }
       end
@@ -447,7 +447,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /maxmemory.*_VALUE_/
+          'content' => /maxmemory.*_VALUE_/
           )
         }
       end
@@ -460,7 +460,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /maxmemory-policy.*_VALUE_/
+          'content' => /maxmemory-policy.*_VALUE_/
           )
         }
       end
@@ -473,7 +473,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /maxmemory-samples.*_VALUE_/
+          'content' => /maxmemory-samples.*_VALUE_/
           )
         }
       end
@@ -486,7 +486,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /min-slaves-max-lag.*_VALUE_/
+          'content' => /min-slaves-max-lag.*_VALUE_/
           )
         }
       end
@@ -499,7 +499,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /min-slaves-to-write.*_VALUE_/
+          'content' => /min-slaves-to-write.*_VALUE_/
           )
         }
       end
@@ -512,7 +512,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /notify-keyspace-events.*_VALUE_/
+          'content' => /notify-keyspace-events.*_VALUE_/
           )
         }
       end
@@ -537,7 +537,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /no-appendfsync-on-rewrite.*yes/
+          'content' => /no-appendfsync-on-rewrite.*yes/
           )
         }
       end
@@ -547,7 +547,7 @@ describe 'redis', type: :class do
         let(:package_name) { manifest_vars[:package_name] }
 
         it { is_expected.to contain_package(package_name).with(
-            'ensure' => '_VALUE_'
+          'ensure' => '_VALUE_'
           )
         }
       end
@@ -566,7 +566,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /pidfile.*_VALUE_/
+          'content' => /pidfile.*_VALUE_/
           )
         }
       end
@@ -579,7 +579,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /port.*_VALUE_/
+          'content' => /port.*_VALUE_/
           )
         }
       end
@@ -592,7 +592,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /protected-mode.*_VALUE_/
+          'content' => /protected-mode.*_VALUE_/
           )
         }
       end
@@ -605,7 +605,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /hll-sparse-max-bytes.*_VALUE_/
+          'content' => /hll-sparse-max-bytes.*_VALUE_/
           )
         }
       end
@@ -618,7 +618,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /hz.*_VALUE_/
+          'content' => /hz.*_VALUE_/
           )
         }
       end
@@ -631,7 +631,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /latency-monitor-threshold.*_VALUE_/
+          'content' => /latency-monitor-threshold.*_VALUE_/
           )
         }
       end
@@ -644,7 +644,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /rdbcompression.*yes/
+          'content' => /rdbcompression.*yes/
           )
         }
       end
@@ -657,7 +657,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /repl-backlog-size.*_VALUE_/
+          'content' => /repl-backlog-size.*_VALUE_/
           )
         }
       end
@@ -670,7 +670,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /repl-backlog-ttl.*_VALUE_/
+          'content' => /repl-backlog-ttl.*_VALUE_/
           )
         }
       end
@@ -683,7 +683,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /repl-disable-tcp-nodelay.*yes/
+          'content' => /repl-disable-tcp-nodelay.*yes/
           )
         }
       end
@@ -696,7 +696,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /repl-ping-slave-period.*1/
+          'content' => /repl-ping-slave-period.*1/
           )
         }
       end
@@ -709,7 +709,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /repl-timeout.*1/
+          'content' => /repl-timeout.*1/
           )
         }
       end
@@ -722,7 +722,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /requirepass.*_VALUE_/
+          'content' => /requirepass.*_VALUE_/
           )
         }
       end
@@ -736,7 +736,7 @@ describe 'redis', type: :class do
           }
 
           it { is_expected.to contain_file(config_file_orig).with(
-              'content' => /^save/
+            'content' => /^save/
             )
           }
         end
@@ -749,7 +749,7 @@ describe 'redis', type: :class do
           }
 
           it { is_expected.to contain_file(config_file_orig).with(
-              'content' => /^(?!save)/
+            'content' => /^(?!save)/
             )
           }
         end
@@ -863,7 +863,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /set-max-intset-entries.*_VALUE_/
+          'content' => /set-max-intset-entries.*_VALUE_/
           )
         }
       end
@@ -876,7 +876,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /slave-priority.*_VALUE_/
+          'content' => /slave-priority.*_VALUE_/
           )
         }
       end
@@ -889,7 +889,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /slave-read-only.*yes/
+          'content' => /slave-read-only.*yes/
           )
         }
       end
@@ -902,7 +902,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /slave-serve-stale-data.*yes/
+          'content' => /slave-serve-stale-data.*yes/
           )
         }
       end
@@ -945,7 +945,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /slowlog-log-slower-than.*_VALUE_/
+          'content' => /slowlog-log-slower-than.*_VALUE_/
           )
         }
       end
@@ -958,7 +958,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /slowlog-max-len.*_VALUE_/
+          'content' => /slowlog-max-len.*_VALUE_/
           )
         }
       end
@@ -971,7 +971,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /stop-writes-on-bgsave-error.*yes/
+          'content' => /stop-writes-on-bgsave-error.*yes/
           )
         }
       end
@@ -984,7 +984,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /syslog-enabled yes/
+          'content' => /syslog-enabled yes/
           )
         }
       end
@@ -998,7 +998,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /syslog-facility.*_VALUE_/
+          'content' => /syslog-facility.*_VALUE_/
           )
         }
       end
@@ -1011,7 +1011,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /tcp-backlog.*_VALUE_/
+          'content' => /tcp-backlog.*_VALUE_/
           )
         }
       end
@@ -1024,7 +1024,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /tcp-keepalive.*_VALUE_/
+          'content' => /tcp-keepalive.*_VALUE_/
           )
         }
       end
@@ -1037,7 +1037,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /timeout.*_VALUE_/
+          'content' => /timeout.*_VALUE_/
           )
         }
       end
@@ -1050,7 +1050,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /dir.*_VALUE_/
+          'content' => /dir.*_VALUE_/
           )
         }
       end
@@ -1063,7 +1063,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /zset-max-ziplist-entries.*_VALUE_/
+          'content' => /zset-max-ziplist-entries.*_VALUE_/
           )
         }
       end
@@ -1076,7 +1076,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /zset-max-ziplist-value.*_VALUE_/
+          'content' => /zset-max-ziplist-value.*_VALUE_/
           )
         }
       end
@@ -1089,7 +1089,7 @@ describe 'redis', type: :class do
         }
 
         it { should_not contain_file(config_file_orig).with(
-            'content' => /cluster-enabled/
+          'content' => /cluster-enabled/
           )
         }
       end
@@ -1102,7 +1102,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /cluster-enabled.*yes/
+          'content' => /cluster-enabled.*yes/
           )
         }
       end
@@ -1116,7 +1116,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /cluster-config-file.*_VALUE_/
+          'content' => /cluster-config-file.*_VALUE_/
           )
         }
       end
@@ -1130,7 +1130,7 @@ describe 'redis', type: :class do
         }
 
         it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /cluster-node-timeout.*_VALUE_/
+          'content' => /cluster-node-timeout.*_VALUE_/
           )
         }
       end

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -216,9 +216,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /daemonize.*yes/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /daemonize.*yes/
+          )
         }
       end
 
@@ -229,9 +230,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /databases.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /databases.*_VALUE_/
+          )
         }
       end
 
@@ -242,9 +244,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /dbfilename.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /dbfilename.*_VALUE_/
+          )
         }
       end
 
@@ -265,9 +268,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /hash-max-ziplist-entries.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /hash-max-ziplist-entries.*_VALUE_/
+          )
         }
       end
 
@@ -278,9 +282,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /hash-max-ziplist-value.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /hash-max-ziplist-value.*_VALUE_/
+          )
         }
       end
 
@@ -291,9 +296,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /list-max-ziplist-entries.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /list-max-ziplist-entries.*_VALUE_/
+          )
         }
       end
 
@@ -304,9 +310,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /list-max-ziplist-value.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /list-max-ziplist-value.*_VALUE_/
+          )
         }
       end
 
@@ -317,9 +324,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file('_VALUE_').with(
-          'ensure' => 'directory'
-        )
+        it {
+          is_expected.to contain_file('_VALUE_').with(
+            'ensure' => 'directory'
+          )
         }
       end
 
@@ -330,9 +338,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /logfile.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /logfile.*_VALUE_/
+          )
         }
       end
 
@@ -343,9 +352,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /loglevel.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /loglevel.*_VALUE_/
+          )
         }
       end
 
@@ -389,9 +399,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /unixsocket.*\/tmp\/redis.sock/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /unixsocket.*\/tmp\/redis.sock/
+          )
         }
       end
 
@@ -402,9 +413,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /unixsocketperm.*777/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /unixsocketperm.*777/
+          )
         }
       end
 
@@ -415,9 +427,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /masterauth.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /masterauth.*_VALUE_/
+          )
         }
       end
 
@@ -428,9 +441,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /maxclients.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /maxclients.*_VALUE_/
+          )
         }
       end
 
@@ -441,9 +455,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /maxmemory.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /maxmemory.*_VALUE_/
+          )
         }
       end
 
@@ -454,9 +469,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /maxmemory-policy.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /maxmemory-policy.*_VALUE_/
+          )
         }
       end
 
@@ -467,9 +483,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /maxmemory-samples.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /maxmemory-samples.*_VALUE_/
+          )
         }
       end
 
@@ -480,9 +497,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /min-slaves-max-lag.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /min-slaves-max-lag.*_VALUE_/
+          )
         }
       end
 
@@ -493,9 +511,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /min-slaves-to-write.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /min-slaves-to-write.*_VALUE_/
+          )
         }
       end
 
@@ -506,9 +525,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /notify-keyspace-events.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /notify-keyspace-events.*_VALUE_/
+          )
         }
       end
 
@@ -531,9 +551,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /no-appendfsync-on-rewrite.*yes/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /no-appendfsync-on-rewrite.*yes/
+          )
         }
       end
 
@@ -541,9 +562,10 @@ describe 'redis', type: :class do
         let (:params) { { package_ensure: '_VALUE_' } }
         let(:package_name) { manifest_vars[:package_name] }
 
-        it { is_expected.to contain_package(package_name).with(
-          'ensure' => '_VALUE_'
-        )
+        it {
+          is_expected.to contain_package(package_name).with(
+            'ensure' => '_VALUE_'
+          )
         }
       end
 
@@ -560,9 +582,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /pidfile.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /pidfile.*_VALUE_/
+          )
         }
       end
 
@@ -573,9 +596,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /port.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /port.*_VALUE_/
+          )
         }
       end
 
@@ -586,9 +610,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /protected-mode.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /protected-mode.*_VALUE_/
+          )
         }
       end
 
@@ -599,9 +624,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /hll-sparse-max-bytes.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /hll-sparse-max-bytes.*_VALUE_/
+          )
         }
       end
 
@@ -612,9 +638,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /hz.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /hz.*_VALUE_/
+          )
         }
       end
 
@@ -625,9 +652,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /latency-monitor-threshold.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /latency-monitor-threshold.*_VALUE_/
+          )
         }
       end
 
@@ -638,9 +666,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /rdbcompression.*yes/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /rdbcompression.*yes/
+          )
         }
       end
 
@@ -651,9 +680,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /repl-backlog-size.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /repl-backlog-size.*_VALUE_/
+          )
         }
       end
 
@@ -664,9 +694,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /repl-backlog-ttl.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /repl-backlog-ttl.*_VALUE_/
+          )
         }
       end
 
@@ -677,9 +708,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /repl-disable-tcp-nodelay.*yes/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /repl-disable-tcp-nodelay.*yes/
+          )
         }
       end
 
@@ -690,9 +722,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /repl-ping-slave-period.*1/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /repl-ping-slave-period.*1/
+          )
         }
       end
 
@@ -703,9 +736,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /repl-timeout.*1/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /repl-timeout.*1/
+          )
         }
       end
 
@@ -716,9 +750,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /requirepass.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /requirepass.*_VALUE_/
+          )
         }
       end
 
@@ -730,9 +765,10 @@ describe 'redis', type: :class do
             }
           }
 
-          it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /^save/
-          )
+          it {
+            is_expected.to contain_file(config_file_orig).with(
+              'content' => /^save/
+            )
           }
         end
 
@@ -743,9 +779,10 @@ describe 'redis', type: :class do
             }
           }
 
-          it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /^(?!save)/
-          )
+          it {
+            is_expected.to contain_file(config_file_orig).with(
+              'content' => /^(?!save)/
+            )
           }
         end
       end
@@ -761,7 +798,8 @@ describe 'redis', type: :class do
 
             it { is_expected.to contain_file(config_file_orig).with('content' => /save 900 1/) }
             it { is_expected.to contain_file(config_file_orig).with('content' => /save 300 10/) }
-            it { is_expected.to contain_file(config_file_orig).with('content' => /save 60 10000/)
+            it {
+              is_expected.to contain_file(config_file_orig).with('content' => /save 60 10000/)
             }
           end
 
@@ -775,7 +813,8 @@ describe 'redis', type: :class do
 
             it { is_expected.to contain_file(config_file_orig).with('content' => /save 900 2/) }
             it { is_expected.to contain_file(config_file_orig).with('content' => /save 300 11/) }
-            it { is_expected.to contain_file(config_file_orig).with('content' => /save 60 10011/)
+            it {
+              is_expected.to contain_file(config_file_orig).with('content' => /save 60 10011/)
             }
           end
         end
@@ -855,9 +894,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /set-max-intset-entries.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /set-max-intset-entries.*_VALUE_/
+          )
         }
       end
 
@@ -868,9 +908,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /slave-priority.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /slave-priority.*_VALUE_/
+          )
         }
       end
 
@@ -881,9 +922,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /slave-read-only.*yes/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /slave-read-only.*yes/
+          )
         }
       end
 
@@ -894,9 +936,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /slave-serve-stale-data.*yes/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /slave-serve-stale-data.*yes/
+          )
         }
       end
 
@@ -909,9 +952,10 @@ describe 'redis', type: :class do
             }
           }
 
-          it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /^slaveof _VALUE_/
-          )
+          it {
+            is_expected.to contain_file(config_file_orig).with(
+              'content' => /^slaveof _VALUE_/
+            )
           }
         end
 
@@ -923,9 +967,10 @@ describe 'redis', type: :class do
             }
           }
 
-          it { is_expected.to contain_file(config_file_orig).with(
-            'content' => /^slaveof _VALUE_/
-          )
+          it {
+            is_expected.to contain_file(config_file_orig).with(
+              'content' => /^slaveof _VALUE_/
+            )
           }
         end
       end
@@ -937,9 +982,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /slowlog-log-slower-than.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /slowlog-log-slower-than.*_VALUE_/
+          )
         }
       end
 
@@ -950,9 +996,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /slowlog-max-len.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /slowlog-max-len.*_VALUE_/
+          )
         }
       end
 
@@ -963,9 +1010,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /stop-writes-on-bgsave-error.*yes/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /stop-writes-on-bgsave-error.*yes/
+          )
         }
       end
 
@@ -976,9 +1024,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /syslog-enabled yes/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /syslog-enabled yes/
+          )
         }
       end
 
@@ -990,9 +1039,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /syslog-facility.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /syslog-facility.*_VALUE_/
+          )
         }
       end
 
@@ -1003,9 +1053,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /tcp-backlog.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /tcp-backlog.*_VALUE_/
+          )
         }
       end
 
@@ -1016,9 +1067,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /tcp-keepalive.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /tcp-keepalive.*_VALUE_/
+          )
         }
       end
 
@@ -1029,9 +1081,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /timeout.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /timeout.*_VALUE_/
+          )
         }
       end
 
@@ -1042,9 +1095,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /dir.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /dir.*_VALUE_/
+          )
         }
       end
 
@@ -1055,9 +1109,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /zset-max-ziplist-entries.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /zset-max-ziplist-entries.*_VALUE_/
+          )
         }
       end
 
@@ -1068,9 +1123,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /zset-max-ziplist-value.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /zset-max-ziplist-value.*_VALUE_/
+          )
         }
       end
 
@@ -1081,9 +1137,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { should_not contain_file(config_file_orig).with(
-          'content' => /cluster-enabled/
-        )
+        it {
+          should_not contain_file(config_file_orig).with(
+            'content' => /cluster-enabled/
+          )
         }
       end
 
@@ -1094,9 +1151,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /cluster-enabled.*yes/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /cluster-enabled.*yes/
+          )
         }
       end
 
@@ -1108,9 +1166,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /cluster-config-file.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /cluster-config-file.*_VALUE_/
+          )
         }
       end
 
@@ -1122,9 +1181,10 @@ describe 'redis', type: :class do
           }
         }
 
-        it { is_expected.to contain_file(config_file_orig).with(
-          'content' => /cluster-node-timeout.*_VALUE_/
-        )
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => /cluster-node-timeout.*_VALUE_/
+          )
         }
       end
     end

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -258,14 +258,14 @@ describe 'redis', type: :class do
       end
 
       describe 'without parameter dbfilename' do
-         let(:params) {
-           {
-             dbfilename: false,
-           }
-         }
+        let(:params) {
+          {
+            dbfilename: false,
+          }
+        }
 
-         it { is_expected.to contain_file(config_file_orig).without_content(/^dbfilename/) }
-       end
+        it { is_expected.to contain_file(config_file_orig).without_content(/^dbfilename/) }
+      end
 
       describe 'with parameter hash_max_ziplist_entries' do
         let (:params) {
@@ -593,17 +593,17 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter protected-mode' do
-              let (:params) {
-                {
-                  protected_mode: '_VALUE_'
-                }
-              }
+        let (:params) {
+          {
+            protected_mode: '_VALUE_'
+          }
+        }
 
-              it { is_expected.to contain_file(config_file_orig).with(
-                  'content' => /protected-mode.*_VALUE_/
-                )
-              }
-            end
+        it { is_expected.to contain_file(config_file_orig).with(
+            'content' => /protected-mode.*_VALUE_/
+          )
+        }
+      end
 
       describe 'with parameter hll_sparse_max_bytes' do
         let (:params) {
@@ -941,7 +941,7 @@ describe 'redis', type: :class do
           it { is_expected.to contain_file(config_file_orig).with(
             'content' => /^slaveof _VALUE_/
           )
-        }
+          }
         end
       end
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe 'redis', :type => :class do
+describe 'redis', type: :class do
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) {
         facts.merge({
-          :redis_server_version => '3.2.3',
+          redis_server_version: '3.2.3',
         })
       }
 
@@ -43,10 +43,10 @@ describe 'redis', :type => :class do
 
             it do
               is_expected.to contain_file('/var/run/redis').with({
-                :ensure => 'directory',
-                :owner  => 'redis',
-                :group  => 'root',
-                :mode   => '2775',
+                ensure: 'directory',
+                owner: 'redis',
+                group: 'root',
+                mode: '2775',
               })
             end
 
@@ -56,10 +56,10 @@ describe 'redis', :type => :class do
 
           it do
             is_expected.to contain_file('/var/run/redis').with({
-              :ensure => 'directory',
-              :owner  => 'redis',
-              :group  => 'redis',
-              :mode   => '0755',
+              ensure: 'directory',
+              owner: 'redis',
+              group: 'redis',
+              mode: '0755',
             })
           end
 
@@ -69,7 +69,7 @@ describe 'redis', :type => :class do
       describe 'with parameter activerehashing' do
         let (:params) {
           {
-            :activerehashing => true
+            activerehashing: true
           }
         }
 
@@ -79,7 +79,7 @@ describe 'redis', :type => :class do
       describe 'with parameter aof_load_truncated' do
         let (:params) {
           {
-            :aof_load_truncated => true
+            aof_load_truncated: true
           }
         }
 
@@ -89,7 +89,7 @@ describe 'redis', :type => :class do
       describe 'with parameter aof_rewrite_incremental_fsync' do
         let (:params) {
           {
-            :aof_rewrite_incremental_fsync => true
+            aof_rewrite_incremental_fsync: true
           }
         }
 
@@ -99,7 +99,7 @@ describe 'redis', :type => :class do
       describe 'with parameter appendfilename' do
         let (:params) {
           {
-            :appendfilename => '_VALUE_'
+            appendfilename: '_VALUE_'
           }
         }
 
@@ -109,7 +109,7 @@ describe 'redis', :type => :class do
       describe 'with parameter appendfsync' do
         let (:params) {
           {
-            :appendfsync => '_VALUE_'
+            appendfsync: '_VALUE_'
           }
         }
 
@@ -119,7 +119,7 @@ describe 'redis', :type => :class do
       describe 'with parameter appendonly' do
         let (:params) {
           {
-            :appendonly => true
+            appendonly: true
           }
         }
 
@@ -129,7 +129,7 @@ describe 'redis', :type => :class do
       describe 'with parameter auto_aof_rewrite_min_size' do
         let (:params) {
           {
-            :auto_aof_rewrite_min_size => '_VALUE_'
+            auto_aof_rewrite_min_size: '_VALUE_'
           }
         }
 
@@ -139,7 +139,7 @@ describe 'redis', :type => :class do
       describe 'with parameter auto_aof_rewrite_percentage' do
         let (:params) {
           {
-            :auto_aof_rewrite_percentage => '_VALUE_'
+            auto_aof_rewrite_percentage: '_VALUE_'
           }
         }
 
@@ -149,7 +149,7 @@ describe 'redis', :type => :class do
       describe 'with parameter bind' do
         let (:params) {
           {
-            :bind => '_VALUE_'
+            bind: '_VALUE_'
           }
         }
 
@@ -159,7 +159,7 @@ describe 'redis', :type => :class do
       describe 'with parameter output_buffer_limit_slave' do
         let (:params) {
           {
-              :output_buffer_limit_slave => '_VALUE_'
+              output_buffer_limit_slave: '_VALUE_'
           }
         }
 
@@ -169,7 +169,7 @@ describe 'redis', :type => :class do
       describe 'with parameter output_buffer_limit_pubsub' do
         let (:params) {
           {
-              :output_buffer_limit_pubsub => '_VALUE_'
+              output_buffer_limit_pubsub: '_VALUE_'
           }
         }
 
@@ -177,43 +177,43 @@ describe 'redis', :type => :class do
       end
 
       describe 'with parameter: config_dir' do
-        let (:params) { { :config_dir => '_VALUE_' } }
+        let (:params) { { config_dir: '_VALUE_' } }
 
         it { is_expected.to contain_file('_VALUE_').with_ensure('directory') }
       end
 
       describe 'with parameter: config_dir_mode' do
-        let (:params) { { :config_dir_mode => '_VALUE_' } }
+        let (:params) { { config_dir_mode: '_VALUE_' } }
 
         it { is_expected.to contain_file('/etc/redis').with_mode('_VALUE_') }
       end
 
       describe 'with parameter: log_dir_mode' do
-        let (:params) { { :log_dir_mode => '_VALUE_' } }
+        let (:params) { { log_dir_mode: '_VALUE_' } }
 
         it { is_expected.to contain_file('/var/log/redis').with_mode('_VALUE_') }
       end
 
       describe 'with parameter: config_file_orig' do
-        let (:params) { { :config_file_orig => '_VALUE_' } }
+        let (:params) { { config_file_orig: '_VALUE_' } }
 
         it { is_expected.to contain_file('_VALUE_') }
       end
 
       describe 'with parameter: config_file_mode' do
-        let (:params) { { :config_file_mode => '_VALUE_' } }
+        let (:params) { { config_file_mode: '_VALUE_' } }
 
         it { is_expected.to contain_file(config_file_orig).with_mode('_VALUE_') }
       end
 
       describe 'with parameter: config_group' do
-        let (:params) { { :config_group => '_VALUE_' } }
+        let (:params) { { config_group: '_VALUE_' } }
 
         it { is_expected.to contain_file('/etc/redis').with_group('_VALUE_') }
       end
 
       describe 'with parameter: config_owner' do
-        let (:params) { { :config_owner => '_VALUE_' } }
+        let (:params) { { config_owner: '_VALUE_' } }
 
         it { is_expected.to contain_file('/etc/redis').with_owner('_VALUE_') }
       end
@@ -221,7 +221,7 @@ describe 'redis', :type => :class do
       describe 'with parameter daemonize' do
         let (:params) {
           {
-            :daemonize => true
+            daemonize: true
           }
         }
 
@@ -234,7 +234,7 @@ describe 'redis', :type => :class do
       describe 'with parameter databases' do
         let (:params) {
           {
-            :databases => '_VALUE_'
+            databases: '_VALUE_'
           }
         }
 
@@ -247,7 +247,7 @@ describe 'redis', :type => :class do
       describe 'with parameter dbfilename' do
         let (:params) {
           {
-            :dbfilename => '_VALUE_'
+            dbfilename: '_VALUE_'
           }
         }
 
@@ -260,7 +260,7 @@ describe 'redis', :type => :class do
       describe 'without parameter dbfilename' do
         let(:params) {
           {
-            :dbfilename => false,
+            dbfilename: false,
           }
         }
 
@@ -270,7 +270,7 @@ describe 'redis', :type => :class do
       describe 'with parameter hash_max_ziplist_entries' do
         let (:params) {
           {
-            :hash_max_ziplist_entries => '_VALUE_'
+            hash_max_ziplist_entries: '_VALUE_'
           }
         }
 
@@ -283,7 +283,7 @@ describe 'redis', :type => :class do
       describe 'with parameter hash_max_ziplist_value' do
         let (:params) {
           {
-            :hash_max_ziplist_value => '_VALUE_'
+            hash_max_ziplist_value: '_VALUE_'
           }
         }
 
@@ -296,7 +296,7 @@ describe 'redis', :type => :class do
       describe 'with parameter list_max_ziplist_entries' do
         let (:params) {
           {
-            :list_max_ziplist_entries => '_VALUE_'
+            list_max_ziplist_entries: '_VALUE_'
           }
         }
 
@@ -309,7 +309,7 @@ describe 'redis', :type => :class do
       describe 'with parameter list_max_ziplist_value' do
         let (:params) {
           {
-            :list_max_ziplist_value => '_VALUE_'
+            list_max_ziplist_value: '_VALUE_'
           }
         }
 
@@ -322,7 +322,7 @@ describe 'redis', :type => :class do
       describe 'with parameter log_dir' do
         let (:params) {
           {
-            :log_dir => '_VALUE_'
+            log_dir: '_VALUE_'
           }
         }
 
@@ -335,7 +335,7 @@ describe 'redis', :type => :class do
       describe 'with parameter log_file' do
         let (:params) {
           {
-            :log_file => '_VALUE_'
+            log_file: '_VALUE_'
           }
         }
 
@@ -348,7 +348,7 @@ describe 'redis', :type => :class do
       describe 'with parameter log_level' do
         let (:params) {
           {
-            :log_level => '_VALUE_'
+            log_level: '_VALUE_'
           }
         }
 
@@ -359,7 +359,7 @@ describe 'redis', :type => :class do
       end
 
       describe 'with parameter: manage_repo' do
-        let (:params) { { :manage_repo => true } }
+        let (:params) { { manage_repo: true } }
 
         case facts[:operatingsystem]
 
@@ -369,14 +369,14 @@ describe 'redis', :type => :class do
 
             it do
               is_expected.to create_apt__source('dotdeb').with({
-                :location => 'http://packages.dotdeb.org/',
-                :release  =>  facts[:lsbdistcodename],
-                :repos    => 'all',
-                :key      => {
+                location: 'http://packages.dotdeb.org/',
+                release: facts[:lsbdistcodename],
+                repos: 'all',
+                key: {
                   "id"=>"6572BBEF1B5FF28B28B706837E3F070089DF5277",
                   "source"=>"http://www.dotdeb.org/dotdeb.gpg"
                 },
-                :include  => { 'src' => true },
+                include: { 'src' => true },
               })
             end
 
@@ -398,7 +398,7 @@ describe 'redis', :type => :class do
       describe 'with parameter unixsocket' do
         let (:params) {
           {
-            :unixsocket => '/tmp/redis.sock'
+            unixsocket: '/tmp/redis.sock'
           }
         }
 
@@ -411,7 +411,7 @@ describe 'redis', :type => :class do
       describe 'with parameter unixsocketperm' do
         let (:params) {
           {
-            :unixsocketperm => '777'
+            unixsocketperm: '777'
           }
         }
 
@@ -424,7 +424,7 @@ describe 'redis', :type => :class do
       describe 'with parameter masterauth' do
         let (:params) {
           {
-            :masterauth => '_VALUE_'
+            masterauth: '_VALUE_'
           }
         }
 
@@ -437,7 +437,7 @@ describe 'redis', :type => :class do
       describe 'with parameter maxclients' do
         let (:params) {
           {
-            :maxclients => '_VALUE_'
+            maxclients: '_VALUE_'
           }
         }
 
@@ -450,7 +450,7 @@ describe 'redis', :type => :class do
       describe 'with parameter maxmemory' do
         let (:params) {
           {
-            :maxmemory => '_VALUE_'
+            maxmemory: '_VALUE_'
           }
         }
 
@@ -463,7 +463,7 @@ describe 'redis', :type => :class do
       describe 'with parameter maxmemory_policy' do
         let (:params) {
           {
-            :maxmemory_policy => '_VALUE_'
+            maxmemory_policy: '_VALUE_'
           }
         }
 
@@ -476,7 +476,7 @@ describe 'redis', :type => :class do
       describe 'with parameter maxmemory_samples' do
         let (:params) {
           {
-            :maxmemory_samples => '_VALUE_'
+            maxmemory_samples: '_VALUE_'
           }
         }
 
@@ -489,7 +489,7 @@ describe 'redis', :type => :class do
       describe 'with parameter min_slaves_max_lag' do
         let (:params) {
           {
-            :min_slaves_max_lag => '_VALUE_'
+            min_slaves_max_lag: '_VALUE_'
           }
         }
 
@@ -502,7 +502,7 @@ describe 'redis', :type => :class do
       describe 'with parameter min_slaves_to_write' do
         let (:params) {
           {
-            :min_slaves_to_write => '_VALUE_'
+            min_slaves_to_write: '_VALUE_'
           }
         }
 
@@ -515,7 +515,7 @@ describe 'redis', :type => :class do
       describe 'with parameter notify_keyspace_events' do
         let (:params) {
           {
-            :notify_keyspace_events => '_VALUE_'
+            notify_keyspace_events: '_VALUE_'
           }
         }
 
@@ -528,7 +528,7 @@ describe 'redis', :type => :class do
       describe 'with parameter notify_service' do
         let (:params) {
           {
-            :notify_service => true
+            notify_service: true
           }
         }
 
@@ -540,7 +540,7 @@ describe 'redis', :type => :class do
       describe 'with parameter no_appendfsync_on_rewrite' do
         let (:params) {
           {
-            :no_appendfsync_on_rewrite => true
+            no_appendfsync_on_rewrite: true
           }
         }
 
@@ -551,7 +551,7 @@ describe 'redis', :type => :class do
       end
 
       describe 'with parameter: package_ensure' do
-        let (:params) { { :package_ensure => '_VALUE_' } }
+        let (:params) { { package_ensure: '_VALUE_' } }
         let(:package_name) { manifest_vars[:package_name] }
 
         it { is_expected.to contain_package(package_name).with(
@@ -561,7 +561,7 @@ describe 'redis', :type => :class do
       end
 
       describe 'with parameter: package_name' do
-        let (:params) { { :package_name => '_VALUE_' } }
+        let (:params) { { package_name: '_VALUE_' } }
 
         it { is_expected.to contain_package('_VALUE_') }
       end
@@ -569,7 +569,7 @@ describe 'redis', :type => :class do
       describe 'with parameter pid_file' do
         let (:params) {
           {
-            :pid_file => '_VALUE_'
+            pid_file: '_VALUE_'
           }
         }
 
@@ -582,7 +582,7 @@ describe 'redis', :type => :class do
       describe 'with parameter port' do
         let (:params) {
           {
-            :port => '_VALUE_'
+            port: '_VALUE_'
           }
         }
 
@@ -595,7 +595,7 @@ describe 'redis', :type => :class do
       describe 'with parameter protected-mode' do
               let (:params) {
                 {
-                  :protected_mode => '_VALUE_'
+                  protected_mode: '_VALUE_'
                 }
               }
 
@@ -608,7 +608,7 @@ describe 'redis', :type => :class do
       describe 'with parameter hll_sparse_max_bytes' do
         let (:params) {
           {
-            :hll_sparse_max_bytes=> '_VALUE_'
+            hll_sparse_max_bytes: '_VALUE_'
           }
         }
 
@@ -621,7 +621,7 @@ describe 'redis', :type => :class do
       describe 'with parameter hz' do
         let (:params) {
           {
-            :hz=> '_VALUE_'
+            hz: '_VALUE_'
           }
         }
 
@@ -634,7 +634,7 @@ describe 'redis', :type => :class do
       describe 'with parameter latency_monitor_threshold' do
         let (:params) {
           {
-            :latency_monitor_threshold=> '_VALUE_'
+            latency_monitor_threshold: '_VALUE_'
           }
         }
 
@@ -647,7 +647,7 @@ describe 'redis', :type => :class do
       describe 'with parameter rdbcompression' do
         let (:params) {
           {
-            :rdbcompression => true
+            rdbcompression: true
           }
         }
 
@@ -660,7 +660,7 @@ describe 'redis', :type => :class do
       describe 'with parameter repl_backlog_size' do
         let (:params) {
           {
-            :repl_backlog_size => '_VALUE_'
+            repl_backlog_size: '_VALUE_'
           }
         }
 
@@ -673,7 +673,7 @@ describe 'redis', :type => :class do
       describe 'with parameter repl_backlog_ttl' do
         let (:params) {
           {
-            :repl_backlog_ttl => '_VALUE_'
+            repl_backlog_ttl: '_VALUE_'
           }
         }
 
@@ -686,7 +686,7 @@ describe 'redis', :type => :class do
       describe 'with parameter repl_disable_tcp_nodelay' do
         let (:params) {
           {
-            :repl_disable_tcp_nodelay => true
+            repl_disable_tcp_nodelay: true
           }
         }
 
@@ -699,7 +699,7 @@ describe 'redis', :type => :class do
       describe 'with parameter repl_ping_slave_period' do
         let (:params) {
           {
-            :repl_ping_slave_period => 1
+            repl_ping_slave_period: 1
           }
         }
 
@@ -712,7 +712,7 @@ describe 'redis', :type => :class do
       describe 'with parameter repl_timeout' do
         let (:params) {
           {
-            :repl_timeout => 1
+            repl_timeout: 1
           }
         }
 
@@ -725,7 +725,7 @@ describe 'redis', :type => :class do
       describe 'with parameter requirepass' do
         let (:params) {
           {
-            :requirepass => '_VALUE_'
+            requirepass: '_VALUE_'
           }
         }
 
@@ -739,7 +739,7 @@ describe 'redis', :type => :class do
         context 'true' do
           let (:params) {
             {
-              :save_db_to_disk => true
+              save_db_to_disk: true
             }
           }
 
@@ -752,7 +752,7 @@ describe 'redis', :type => :class do
         context 'false' do
           let (:params) {
             {
-              :save_db_to_disk => false
+              save_db_to_disk: false
             }
           }
 
@@ -769,7 +769,7 @@ describe 'redis', :type => :class do
           context 'default' do
             let (:params) {
               {
-                :save_db_to_disk => true
+                save_db_to_disk: true
               }
             }
 
@@ -782,8 +782,8 @@ describe 'redis', :type => :class do
           context 'default' do
             let (:params) {
               {
-                :save_db_to_disk => true,
-                :save_db_to_disk_interval => {'900' =>'2', '300' => '11', '60' => '10011'}
+                save_db_to_disk: true,
+                save_db_to_disk_interval: {'900' =>'2', '300' => '11', '60' => '10011'}
               }
             }
 
@@ -799,7 +799,7 @@ describe 'redis', :type => :class do
           context 'default' do
             let (:params) {
               {
-                :save_db_to_disk => false
+                save_db_to_disk: false
               }
             }
 
@@ -811,54 +811,54 @@ describe 'redis', :type => :class do
       end
 
       describe 'with parameter: service_manage (set to false)' do
-        let (:params) { { :service_manage => false } }
+        let (:params) { { service_manage: false } }
         let(:package_name) { manifest_vars[:package_name] }
 
         it { should_not contain_service(package_name) }
       end
 
       describe 'with parameter: service_enable' do
-        let (:params) { { :service_enable => true } }
+        let (:params) { { service_enable: true } }
         let(:package_name) { manifest_vars[:package_name] }
 
         it { is_expected.to contain_service(package_name).with_enable(true) }
       end
 
       describe 'with parameter: service_ensure' do
-        let (:params) { { :service_ensure => '_VALUE_' } }
+        let (:params) { { service_ensure: '_VALUE_' } }
         let(:package_name) { manifest_vars[:package_name] }
 
         it { is_expected.to contain_service(package_name).with_ensure('_VALUE_') }
       end
 
       describe 'with parameter: service_group' do
-        let (:params) { { :service_group => '_VALUE_' } }
+        let (:params) { { service_group: '_VALUE_' } }
 
         it { is_expected.to contain_file('/var/log/redis').with_group('_VALUE_') }
       end
 
       describe 'with parameter: service_hasrestart' do
-        let (:params) { { :service_hasrestart => true } }
+        let (:params) { { service_hasrestart: true } }
         let(:package_name) { manifest_vars[:package_name] }
 
         it { is_expected.to contain_service(package_name).with_hasrestart(true) }
       end
 
       describe 'with parameter: service_hasstatus' do
-        let (:params) { { :service_hasstatus => true } }
+        let (:params) { { service_hasstatus: true } }
         let(:package_name) { manifest_vars[:package_name] }
 
         it { is_expected.to contain_service(package_name).with_hasstatus(true) }
       end
 
       describe 'with parameter: service_name' do
-        let (:params) { { :service_name => '_VALUE_' } }
+        let (:params) { { service_name: '_VALUE_' } }
 
         it { is_expected.to contain_service('_VALUE_').with_name('_VALUE_') }
       end
 
       describe 'with parameter: service_user' do
-        let (:params) { { :service_user => '_VALUE_' } }
+        let (:params) { { service_user: '_VALUE_' } }
 
         it { is_expected.to contain_file('/var/log/redis').with_owner('_VALUE_') }
       end
@@ -866,7 +866,7 @@ describe 'redis', :type => :class do
       describe 'with parameter set_max_intset_entries' do
         let (:params) {
           {
-            :set_max_intset_entries => '_VALUE_'
+            set_max_intset_entries: '_VALUE_'
           }
         }
 
@@ -879,7 +879,7 @@ describe 'redis', :type => :class do
       describe 'with parameter slave_priority' do
         let (:params) {
           {
-            :slave_priority => '_VALUE_'
+            slave_priority: '_VALUE_'
           }
         }
 
@@ -892,7 +892,7 @@ describe 'redis', :type => :class do
       describe 'with parameter slave_read_only' do
         let (:params) {
           {
-            :slave_read_only => true
+            slave_read_only: true
           }
         }
 
@@ -905,7 +905,7 @@ describe 'redis', :type => :class do
       describe 'with parameter slave_serve_stale_data' do
         let (:params) {
           {
-            :slave_serve_stale_data => true
+            slave_serve_stale_data: true
           }
         }
 
@@ -919,8 +919,8 @@ describe 'redis', :type => :class do
         context 'binding to localhost' do
           let (:params) {
             {
-              :bind    => '127.0.0.1',
-              :slaveof => '_VALUE_'
+              bind: '127.0.0.1',
+              slaveof: '_VALUE_'
             }
           }
 
@@ -932,8 +932,8 @@ describe 'redis', :type => :class do
         context 'binding to external ip' do
           let (:params) {
             {
-              :bind    => '10.0.0.1',
-              :slaveof => '_VALUE_'
+              bind: '10.0.0.1',
+              slaveof: '_VALUE_'
             }
           }
 
@@ -947,7 +947,7 @@ describe 'redis', :type => :class do
       describe 'with parameter slowlog_log_slower_than' do
         let (:params) {
           {
-            :slowlog_log_slower_than => '_VALUE_'
+            slowlog_log_slower_than: '_VALUE_'
           }
         }
 
@@ -960,7 +960,7 @@ describe 'redis', :type => :class do
       describe 'with parameter slowlog_max_len' do
         let (:params) {
           {
-            :slowlog_max_len => '_VALUE_'
+            slowlog_max_len: '_VALUE_'
           }
         }
 
@@ -973,7 +973,7 @@ describe 'redis', :type => :class do
       describe 'with parameter stop_writes_on_bgsave_error' do
         let (:params) {
           {
-            :stop_writes_on_bgsave_error => true
+            stop_writes_on_bgsave_error: true
           }
         }
 
@@ -986,7 +986,7 @@ describe 'redis', :type => :class do
       describe 'with parameter syslog_enabled' do
         let (:params) {
           {
-            :syslog_enabled => true
+            syslog_enabled: true
           }
         }
 
@@ -999,8 +999,8 @@ describe 'redis', :type => :class do
       describe 'with parameter syslog_facility' do
         let (:params) {
           {
-            :syslog_enabled => true,
-            :syslog_facility => '_VALUE_'
+            syslog_enabled: true,
+            syslog_facility: '_VALUE_'
           }
         }
 
@@ -1013,7 +1013,7 @@ describe 'redis', :type => :class do
       describe 'with parameter tcp_backlog' do
         let (:params) {
           {
-            :tcp_backlog=> '_VALUE_'
+            tcp_backlog: '_VALUE_'
           }
         }
 
@@ -1026,7 +1026,7 @@ describe 'redis', :type => :class do
       describe 'with parameter tcp_keepalive' do
         let (:params) {
           {
-            :tcp_keepalive => '_VALUE_'
+            tcp_keepalive: '_VALUE_'
           }
         }
 
@@ -1039,7 +1039,7 @@ describe 'redis', :type => :class do
       describe 'with parameter timeout' do
         let (:params) {
           {
-            :timeout => '_VALUE_'
+            timeout: '_VALUE_'
           }
         }
 
@@ -1052,7 +1052,7 @@ describe 'redis', :type => :class do
       describe 'with parameter workdir' do
         let (:params) {
           {
-            :workdir => '_VALUE_'
+            workdir: '_VALUE_'
           }
         }
 
@@ -1065,7 +1065,7 @@ describe 'redis', :type => :class do
       describe 'with parameter zset_max_ziplist_entries' do
         let (:params) {
           {
-            :zset_max_ziplist_entries => '_VALUE_'
+            zset_max_ziplist_entries: '_VALUE_'
           }
         }
 
@@ -1078,7 +1078,7 @@ describe 'redis', :type => :class do
       describe 'with parameter zset_max_ziplist_value' do
         let (:params) {
           {
-            :zset_max_ziplist_value => '_VALUE_'
+            zset_max_ziplist_value: '_VALUE_'
           }
         }
 
@@ -1091,7 +1091,7 @@ describe 'redis', :type => :class do
       describe 'with parameter cluster_enabled-false' do
         let (:params) {
           {
-            :cluster_enabled => false
+            cluster_enabled: false
           }
         }
 
@@ -1104,7 +1104,7 @@ describe 'redis', :type => :class do
       describe 'with parameter cluster_enabled-true' do
         let (:params) {
           {
-            :cluster_enabled => true
+            cluster_enabled: true
           }
         }
 
@@ -1117,8 +1117,8 @@ describe 'redis', :type => :class do
       describe 'with parameter cluster_config_file' do
         let (:params) {
           {
-            :cluster_enabled => true,
-            :cluster_config_file => '_VALUE_'
+            cluster_enabled: true,
+            cluster_config_file: '_VALUE_'
           }
         }
 
@@ -1131,8 +1131,8 @@ describe 'redis', :type => :class do
       describe 'with parameter cluster_config_file' do
         let (:params) {
           {
-            :cluster_enabled => true,
-            :cluster_node_timeout => '_VALUE_'
+            cluster_enabled: true,
+            cluster_node_timeout: '_VALUE_'
           }
         }
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -1143,7 +1143,6 @@ describe 'redis', type: :class do
         }
       end
 
-
     end
   end
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -373,8 +373,8 @@ describe 'redis', type: :class do
                 release: facts[:lsbdistcodename],
                 repos: 'all',
                 key: {
-                  "id"=>"6572BBEF1B5FF28B28B706837E3F070089DF5277",
-                  "source"=>"http://www.dotdeb.org/dotdeb.gpg"
+                  "id" => "6572BBEF1B5FF28B28B706837E3F070089DF5277",
+                  "source" => "http://www.dotdeb.org/dotdeb.gpg"
                 },
                 include: { 'src' => true },
               })
@@ -783,7 +783,7 @@ describe 'redis', type: :class do
             let (:params) {
               {
                 save_db_to_disk: true,
-                save_db_to_disk_interval: { '900' =>'2', '300' => '11', '60' => '10011' }
+                save_db_to_disk_interval: { '900' => '2', '300' => '11', '60' => '10011' }
               }
             }
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -153,7 +153,7 @@ describe 'redis', type: :class do
       describe 'with parameter output_buffer_limit_slave' do
         let (:params) {
           {
-              output_buffer_limit_slave: '_VALUE_'
+            output_buffer_limit_slave: '_VALUE_'
           }
         }
 
@@ -163,7 +163,7 @@ describe 'redis', type: :class do
       describe 'with parameter output_buffer_limit_pubsub' do
         let (:params) {
           {
-              output_buffer_limit_pubsub: '_VALUE_'
+            output_buffer_limit_pubsub: '_VALUE_'
           }
         }
 
@@ -366,9 +366,9 @@ describe 'redis', type: :class do
                                                                release: facts[:lsbdistcodename],
                                                                repos: 'all',
                                                                key: {
-                  "id" => "6572BBEF1B5FF28B28B706837E3F070089DF5277",
-                  "source" => "http://www.dotdeb.org/dotdeb.gpg"
-                },
+                                                                 "id" => "6572BBEF1B5FF28B28B706837E3F070089DF5277",
+                                                                 "source" => "http://www.dotdeb.org/dotdeb.gpg"
+                                                               },
                                                                include: { 'src' => true })
             end
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -264,7 +264,7 @@ describe 'redis', type: :class do
           }
         }
 
-         it { is_expected.to contain_file(config_file_orig).without_content(/^dbfilename/) }
+        it { is_expected.to contain_file(config_file_orig).without_content(/^dbfilename/) }
        end
 
       describe 'with parameter hash_max_ziplist_entries' do

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -773,8 +773,8 @@ describe 'redis', type: :class do
               }
             }
 
-            it { is_expected.to contain_file(config_file_orig).with('content' => /save 900 1/)}
-            it { is_expected.to contain_file(config_file_orig).with('content' => /save 300 10/)}
+            it { is_expected.to contain_file(config_file_orig).with('content' => /save 900 1/) }
+            it { is_expected.to contain_file(config_file_orig).with('content' => /save 300 10/) }
             it { is_expected.to contain_file(config_file_orig).with('content' => /save 60 10000/)
             }
           end
@@ -787,8 +787,8 @@ describe 'redis', type: :class do
               }
             }
 
-            it { is_expected.to contain_file(config_file_orig).with('content' => /save 900 2/)}
-            it { is_expected.to contain_file(config_file_orig).with('content' => /save 300 11/)}
+            it { is_expected.to contain_file(config_file_orig).with('content' => /save 900 2/) }
+            it { is_expected.to contain_file(config_file_orig).with('content' => /save 300 11/) }
             it { is_expected.to contain_file(config_file_orig).with('content' => /save 60 10011/)
             }
           end

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -22,7 +22,7 @@ describe 'redis', type: :class do
 
         it { is_expected.to contain_file(config_file_orig).with_ensure('file') }
 
-        it { is_expected.to contain_file(config_file_orig).without_content(/undef/) }
+        it { is_expected.to contain_file(config_file_orig).without_content(%r{undef}) }
 
         it do
           is_expected.to contain_service(service_name).with(
@@ -64,7 +64,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(/activerehashing.*yes/) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{activerehashing.*yes}) }
       end
 
       describe 'with parameter aof_load_truncated' do
@@ -74,7 +74,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(/aof-load-truncated.*yes/) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{aof-load-truncated.*yes}) }
       end
 
       describe 'with parameter aof_rewrite_incremental_fsync' do
@@ -84,7 +84,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(/aof-rewrite-incremental-fsync.*yes/) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{aof-rewrite-incremental-fsync.*yes}) }
       end
 
       describe 'with parameter appendfilename' do
@@ -94,7 +94,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(/appendfilename.*_VALUE_/) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{appendfilename.*_VALUE_}) }
       end
 
       describe 'with parameter appendfsync' do
@@ -104,7 +104,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(/appendfsync.*_VALUE_/) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{appendfsync.*_VALUE_}) }
       end
 
       describe 'with parameter appendonly' do
@@ -114,7 +114,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(/appendonly.*yes/) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{appendonly.*yes}) }
       end
 
       describe 'with parameter auto_aof_rewrite_min_size' do
@@ -124,7 +124,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(/auto-aof-rewrite-min-size.*_VALUE_/) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{auto-aof-rewrite-min-size.*_VALUE_}) }
       end
 
       describe 'with parameter auto_aof_rewrite_percentage' do
@@ -134,7 +134,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(/auto-aof-rewrite-percentage.*_VALUE_/) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{auto-aof-rewrite-percentage.*_VALUE_}) }
       end
 
       describe 'with parameter bind' do
@@ -144,7 +144,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(/bind.*_VALUE_/) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{bind.*_VALUE_}) }
       end
 
       describe 'with parameter output_buffer_limit_slave' do
@@ -154,7 +154,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(/client-output-buffer-limit slave.*_VALUE_/) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{client-output-buffer-limit slave.*_VALUE_}) }
       end
 
       describe 'with parameter output_buffer_limit_pubsub' do
@@ -164,7 +164,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(/client-output-buffer-limit pubsub.*_VALUE_/) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{client-output-buffer-limit pubsub.*_VALUE_}) }
       end
 
       describe 'with parameter: config_dir' do
@@ -218,7 +218,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /daemonize.*yes/
+            'content' => %r{daemonize.*yes}
           )
         }
       end
@@ -232,7 +232,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /databases.*_VALUE_/
+            'content' => %r{databases.*_VALUE_}
           )
         }
       end
@@ -246,7 +246,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /dbfilename.*_VALUE_/
+            'content' => %r{dbfilename.*_VALUE_}
           )
         }
       end
@@ -258,7 +258,7 @@ describe 'redis', type: :class do
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).without_content(/^dbfilename/) }
+        it { is_expected.to contain_file(config_file_orig).without_content(%r{^dbfilename}) }
       end
 
       describe 'with parameter hash_max_ziplist_entries' do
@@ -270,7 +270,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /hash-max-ziplist-entries.*_VALUE_/
+            'content' => %r{hash-max-ziplist-entries.*_VALUE_}
           )
         }
       end
@@ -284,7 +284,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /hash-max-ziplist-value.*_VALUE_/
+            'content' => %r{hash-max-ziplist-value.*_VALUE_}
           )
         }
       end
@@ -298,7 +298,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /list-max-ziplist-entries.*_VALUE_/
+            'content' => %r{list-max-ziplist-entries.*_VALUE_}
           )
         }
       end
@@ -312,7 +312,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /list-max-ziplist-value.*_VALUE_/
+            'content' => %r{list-max-ziplist-value.*_VALUE_}
           )
         }
       end
@@ -340,7 +340,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /logfile.*_VALUE_/
+            'content' => %r{logfile.*_VALUE_}
           )
         }
       end
@@ -354,7 +354,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /loglevel.*_VALUE_/
+            'content' => %r{loglevel.*_VALUE_}
           )
         }
       end
@@ -415,7 +415,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /unixsocketperm.*777/
+            'content' => %r{unixsocketperm.*777}
           )
         }
       end
@@ -429,7 +429,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /masterauth.*_VALUE_/
+            'content' => %r{masterauth.*_VALUE_}
           )
         }
       end
@@ -443,7 +443,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /maxclients.*_VALUE_/
+            'content' => %r{maxclients.*_VALUE_}
           )
         }
       end
@@ -457,7 +457,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /maxmemory.*_VALUE_/
+            'content' => %r{maxmemory.*_VALUE_}
           )
         }
       end
@@ -471,7 +471,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /maxmemory-policy.*_VALUE_/
+            'content' => %r{maxmemory-policy.*_VALUE_}
           )
         }
       end
@@ -485,7 +485,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /maxmemory-samples.*_VALUE_/
+            'content' => %r{maxmemory-samples.*_VALUE_}
           )
         }
       end
@@ -499,7 +499,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /min-slaves-max-lag.*_VALUE_/
+            'content' => %r{min-slaves-max-lag.*_VALUE_}
           )
         }
       end
@@ -513,7 +513,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /min-slaves-to-write.*_VALUE_/
+            'content' => %r{min-slaves-to-write.*_VALUE_}
           )
         }
       end
@@ -527,7 +527,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /notify-keyspace-events.*_VALUE_/
+            'content' => %r{notify-keyspace-events.*_VALUE_}
           )
         }
       end
@@ -553,7 +553,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /no-appendfsync-on-rewrite.*yes/
+            'content' => %r{no-appendfsync-on-rewrite.*yes}
           )
         }
       end
@@ -584,7 +584,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /pidfile.*_VALUE_/
+            'content' => %r{pidfile.*_VALUE_}
           )
         }
       end
@@ -598,7 +598,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /port.*_VALUE_/
+            'content' => %r{port.*_VALUE_}
           )
         }
       end
@@ -612,7 +612,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /protected-mode.*_VALUE_/
+            'content' => %r{protected-mode.*_VALUE_}
           )
         }
       end
@@ -626,7 +626,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /hll-sparse-max-bytes.*_VALUE_/
+            'content' => %r{hll-sparse-max-bytes.*_VALUE_}
           )
         }
       end
@@ -640,7 +640,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /hz.*_VALUE_/
+            'content' => %r{hz.*_VALUE_}
           )
         }
       end
@@ -654,7 +654,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /latency-monitor-threshold.*_VALUE_/
+            'content' => %r{latency-monitor-threshold.*_VALUE_}
           )
         }
       end
@@ -668,7 +668,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /rdbcompression.*yes/
+            'content' => %r{rdbcompression.*yes}
           )
         }
       end
@@ -682,7 +682,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /repl-backlog-size.*_VALUE_/
+            'content' => %r{repl-backlog-size.*_VALUE_}
           )
         }
       end
@@ -696,7 +696,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /repl-backlog-ttl.*_VALUE_/
+            'content' => %r{repl-backlog-ttl.*_VALUE_}
           )
         }
       end
@@ -710,7 +710,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /repl-disable-tcp-nodelay.*yes/
+            'content' => %r{repl-disable-tcp-nodelay.*yes}
           )
         }
       end
@@ -724,7 +724,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /repl-ping-slave-period.*1/
+            'content' => %r{repl-ping-slave-period.*1}
           )
         }
       end
@@ -738,7 +738,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /repl-timeout.*1/
+            'content' => %r{repl-timeout.*1}
           )
         }
       end
@@ -752,7 +752,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /requirepass.*_VALUE_/
+            'content' => %r{requirepass.*_VALUE_}
           )
         }
       end
@@ -767,7 +767,7 @@ describe 'redis', type: :class do
 
           it {
             is_expected.to contain_file(config_file_orig).with(
-              'content' => /^save/
+              'content' => %r{^save}
             )
           }
         end
@@ -781,7 +781,7 @@ describe 'redis', type: :class do
 
           it {
             is_expected.to contain_file(config_file_orig).with(
-              'content' => /^(?!save)/
+              'content' => %r{^(?!save)}
             )
           }
         end
@@ -796,10 +796,10 @@ describe 'redis', type: :class do
               }
             end
 
-            it { is_expected.to contain_file(config_file_orig).with('content' => /save 900 1/) }
-            it { is_expected.to contain_file(config_file_orig).with('content' => /save 300 10/) }
+            it { is_expected.to contain_file(config_file_orig).with('content' => %r{save 900 1}) }
+            it { is_expected.to contain_file(config_file_orig).with('content' => %r{save 300 10}) }
             it {
-              is_expected.to contain_file(config_file_orig).with('content' => /save 60 10000/)
+              is_expected.to contain_file(config_file_orig).with('content' => %r{save 60 10000})
             }
           end
 
@@ -811,10 +811,10 @@ describe 'redis', type: :class do
               }
             end
 
-            it { is_expected.to contain_file(config_file_orig).with('content' => /save 900 2/) }
-            it { is_expected.to contain_file(config_file_orig).with('content' => /save 300 11/) }
+            it { is_expected.to contain_file(config_file_orig).with('content' => %r{save 900 2}) }
+            it { is_expected.to contain_file(config_file_orig).with('content' => %r{save 300 11}) }
             it {
-              is_expected.to contain_file(config_file_orig).with('content' => /save 60 10011/)
+              is_expected.to contain_file(config_file_orig).with('content' => %r{save 60 10011})
             }
           end
         end
@@ -827,9 +827,9 @@ describe 'redis', type: :class do
               }
             end
 
-            it { is_expected.to contain_file(config_file_orig).without('content' => /save 900 1/) }
-            it { is_expected.to contain_file(config_file_orig).without('content' => /save 300 10/) }
-            it { is_expected.to contain_file(config_file_orig).without('content' => /save 60 10000/) }
+            it { is_expected.to contain_file(config_file_orig).without('content' => %r{save 900 1}) }
+            it { is_expected.to contain_file(config_file_orig).without('content' => %r{save 300 10}) }
+            it { is_expected.to contain_file(config_file_orig).without('content' => %r{save 60 10000}) }
           end
         end
       end
@@ -896,7 +896,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /set-max-intset-entries.*_VALUE_/
+            'content' => %r{set-max-intset-entries.*_VALUE_}
           )
         }
       end
@@ -910,7 +910,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /slave-priority.*_VALUE_/
+            'content' => %r{slave-priority.*_VALUE_}
           )
         }
       end
@@ -924,7 +924,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /slave-read-only.*yes/
+            'content' => %r{slave-read-only.*yes}
           )
         }
       end
@@ -938,7 +938,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /slave-serve-stale-data.*yes/
+            'content' => %r{slave-serve-stale-data.*yes}
           )
         }
       end
@@ -954,7 +954,7 @@ describe 'redis', type: :class do
 
           it {
             is_expected.to contain_file(config_file_orig).with(
-              'content' => /^slaveof _VALUE_/
+              'content' => %r{^slaveof _VALUE_}
             )
           }
         end
@@ -969,7 +969,7 @@ describe 'redis', type: :class do
 
           it {
             is_expected.to contain_file(config_file_orig).with(
-              'content' => /^slaveof _VALUE_/
+              'content' => %r{^slaveof _VALUE_}
             )
           }
         end
@@ -984,7 +984,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /slowlog-log-slower-than.*_VALUE_/
+            'content' => %r{slowlog-log-slower-than.*_VALUE_}
           )
         }
       end
@@ -998,7 +998,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /slowlog-max-len.*_VALUE_/
+            'content' => %r{slowlog-max-len.*_VALUE_}
           )
         }
       end
@@ -1012,7 +1012,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /stop-writes-on-bgsave-error.*yes/
+            'content' => %r{stop-writes-on-bgsave-error.*yes}
           )
         }
       end
@@ -1026,7 +1026,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /syslog-enabled yes/
+            'content' => %r{syslog-enabled yes}
           )
         }
       end
@@ -1041,7 +1041,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /syslog-facility.*_VALUE_/
+            'content' => %r{syslog-facility.*_VALUE_}
           )
         }
       end
@@ -1055,7 +1055,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /tcp-backlog.*_VALUE_/
+            'content' => %r{tcp-backlog.*_VALUE_}
           )
         }
       end
@@ -1069,7 +1069,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /tcp-keepalive.*_VALUE_/
+            'content' => %r{tcp-keepalive.*_VALUE_}
           )
         }
       end
@@ -1083,7 +1083,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /timeout.*_VALUE_/
+            'content' => %r{timeout.*_VALUE_}
           )
         }
       end
@@ -1097,7 +1097,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /dir.*_VALUE_/
+            'content' => %r{dir.*_VALUE_}
           )
         }
       end
@@ -1111,7 +1111,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /zset-max-ziplist-entries.*_VALUE_/
+            'content' => %r{zset-max-ziplist-entries.*_VALUE_}
           )
         }
       end
@@ -1125,7 +1125,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /zset-max-ziplist-value.*_VALUE_/
+            'content' => %r{zset-max-ziplist-value.*_VALUE_}
           )
         }
       end
@@ -1139,7 +1139,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.not_to contain_file(config_file_orig).with(
-            'content' => /cluster-enabled/
+            'content' => %r{cluster-enabled}
           )
         }
       end
@@ -1153,7 +1153,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /cluster-enabled.*yes/
+            'content' => %r{cluster-enabled.*yes}
           )
         }
       end
@@ -1168,7 +1168,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /cluster-config-file.*_VALUE_/
+            'content' => %r{cluster-config-file.*_VALUE_}
           )
         }
       end
@@ -1183,7 +1183,7 @@ describe 'redis', type: :class do
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => /cluster-node-timeout.*_VALUE_/
+            'content' => %r{cluster-node-timeout.*_VALUE_}
           )
         }
       end

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -254,7 +254,7 @@ describe 'redis', type: :class do
       describe 'without parameter dbfilename' do
         let(:params) {
           {
-            dbfilename: false,
+            dbfilename: false
           }
         }
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -838,7 +838,7 @@ describe 'redis', type: :class do
         let (:params) { { service_manage: false } }
         let(:package_name) { manifest_vars[:package_name] }
 
-        it { should_not contain_service(package_name) }
+        it { is_expected.not_to contain_service(package_name) }
       end
 
       describe 'with parameter: service_enable' do
@@ -1138,7 +1138,7 @@ describe 'redis', type: :class do
         end
 
         it {
-          should_not contain_file(config_file_orig).with(
+          is_expected.not_to contain_file(config_file_orig).with(
             'content' => /cluster-enabled/
           )
         }

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -5,9 +5,7 @@ describe 'redis', type: :class do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) {
-        facts.merge({
-          redis_server_version: '3.2.3',
-        })
+        facts.merge(redis_server_version: '3.2.3')
       }
 
       let(:package_name) { manifest_vars[:package_name] }
@@ -42,12 +40,10 @@ describe 'redis', type: :class do
           context 'on Debian' do
 
             it do
-              is_expected.to contain_file('/var/run/redis').with({
-                ensure: 'directory',
-                owner: 'redis',
-                group: 'root',
-                mode: '2775',
-              })
+              is_expected.to contain_file('/var/run/redis').with(ensure: 'directory',
+                                                                 owner: 'redis',
+                                                                 group: 'root',
+                                                                 mode: '2775')
             end
 
           end
@@ -55,12 +51,10 @@ describe 'redis', type: :class do
         when 'Ubuntu'
 
           it do
-            is_expected.to contain_file('/var/run/redis').with({
-              ensure: 'directory',
-              owner: 'redis',
-              group: 'redis',
-              mode: '0755',
-            })
+            is_expected.to contain_file('/var/run/redis').with(ensure: 'directory',
+                                                               owner: 'redis',
+                                                               group: 'redis',
+                                                               mode: '0755')
           end
 
         end
@@ -368,16 +362,14 @@ describe 'redis', type: :class do
           context 'on Debian' do
 
             it do
-              is_expected.to create_apt__source('dotdeb').with({
-                location: 'http://packages.dotdeb.org/',
-                release: facts[:lsbdistcodename],
-                repos: 'all',
-                key: {
+              is_expected.to create_apt__source('dotdeb').with(location: 'http://packages.dotdeb.org/',
+                                                               release: facts[:lsbdistcodename],
+                                                               repos: 'all',
+                                                               key: {
                   "id" => "6572BBEF1B5FF28B28B706837E3F070089DF5277",
                   "source" => "http://www.dotdeb.org/dotdeb.gpg"
                 },
-                include: { 'src' => true },
-              })
+                                                               include: { 'src' => true })
             end
 
           end

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -783,7 +783,7 @@ describe 'redis', type: :class do
             let (:params) {
               {
                 save_db_to_disk: true,
-                save_db_to_disk_interval: {'900' =>'2', '300' => '11', '60' => '10011'}
+                save_db_to_disk_interval: { '900' =>'2', '300' => '11', '60' => '10011' }
               }
             }
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'redis', type: :class do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) {
+      let(:facts) do
         facts.merge(redis_server_version: '3.2.3')
-      }
+      end
 
       let(:package_name) { manifest_vars[:package_name] }
       let(:service_name) { manifest_vars[:service_name] }
@@ -58,111 +58,111 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter activerehashing' do
-        let (:params) {
+        let (:params) do
           {
             activerehashing: true
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).with_content(/activerehashing.*yes/) }
       end
 
       describe 'with parameter aof_load_truncated' do
-        let (:params) {
+        let (:params) do
           {
             aof_load_truncated: true
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).with_content(/aof-load-truncated.*yes/) }
       end
 
       describe 'with parameter aof_rewrite_incremental_fsync' do
-        let (:params) {
+        let (:params) do
           {
             aof_rewrite_incremental_fsync: true
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).with_content(/aof-rewrite-incremental-fsync.*yes/) }
       end
 
       describe 'with parameter appendfilename' do
-        let (:params) {
+        let (:params) do
           {
             appendfilename: '_VALUE_'
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).with_content(/appendfilename.*_VALUE_/) }
       end
 
       describe 'with parameter appendfsync' do
-        let (:params) {
+        let (:params) do
           {
             appendfsync: '_VALUE_'
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).with_content(/appendfsync.*_VALUE_/) }
       end
 
       describe 'with parameter appendonly' do
-        let (:params) {
+        let (:params) do
           {
             appendonly: true
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).with_content(/appendonly.*yes/) }
       end
 
       describe 'with parameter auto_aof_rewrite_min_size' do
-        let (:params) {
+        let (:params) do
           {
             auto_aof_rewrite_min_size: '_VALUE_'
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).with_content(/auto-aof-rewrite-min-size.*_VALUE_/) }
       end
 
       describe 'with parameter auto_aof_rewrite_percentage' do
-        let (:params) {
+        let (:params) do
           {
             auto_aof_rewrite_percentage: '_VALUE_'
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).with_content(/auto-aof-rewrite-percentage.*_VALUE_/) }
       end
 
       describe 'with parameter bind' do
-        let (:params) {
+        let (:params) do
           {
             bind: '_VALUE_'
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).with_content(/bind.*_VALUE_/) }
       end
 
       describe 'with parameter output_buffer_limit_slave' do
-        let (:params) {
+        let (:params) do
           {
             output_buffer_limit_slave: '_VALUE_'
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).with_content(/client-output-buffer-limit slave.*_VALUE_/) }
       end
 
       describe 'with parameter output_buffer_limit_pubsub' do
-        let (:params) {
+        let (:params) do
           {
             output_buffer_limit_pubsub: '_VALUE_'
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).with_content(/client-output-buffer-limit pubsub.*_VALUE_/) }
       end
@@ -210,11 +210,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter daemonize' do
-        let (:params) {
+        let (:params) do
           {
             daemonize: true
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -224,11 +224,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter databases' do
-        let (:params) {
+        let (:params) do
           {
             databases: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -238,11 +238,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter dbfilename' do
-        let (:params) {
+        let (:params) do
           {
             dbfilename: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -252,21 +252,21 @@ describe 'redis', type: :class do
       end
 
       describe 'without parameter dbfilename' do
-        let(:params) {
+        let(:params) do
           {
             dbfilename: false
           }
-        }
+        end
 
         it { is_expected.to contain_file(config_file_orig).without_content(/^dbfilename/) }
       end
 
       describe 'with parameter hash_max_ziplist_entries' do
-        let (:params) {
+        let (:params) do
           {
             hash_max_ziplist_entries: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -276,11 +276,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter hash_max_ziplist_value' do
-        let (:params) {
+        let (:params) do
           {
             hash_max_ziplist_value: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -290,11 +290,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter list_max_ziplist_entries' do
-        let (:params) {
+        let (:params) do
           {
             list_max_ziplist_entries: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -304,11 +304,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter list_max_ziplist_value' do
-        let (:params) {
+        let (:params) do
           {
             list_max_ziplist_value: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -318,11 +318,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter log_dir' do
-        let (:params) {
+        let (:params) do
           {
             log_dir: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file('_VALUE_').with(
@@ -332,11 +332,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter log_file' do
-        let (:params) {
+        let (:params) do
           {
             log_file: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -346,11 +346,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter log_level' do
-        let (:params) {
+        let (:params) do
           {
             log_level: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -393,11 +393,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter unixsocket' do
-        let (:params) {
+        let (:params) do
           {
             unixsocket: '/tmp/redis.sock'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -407,11 +407,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter unixsocketperm' do
-        let (:params) {
+        let (:params) do
           {
             unixsocketperm: '777'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -421,11 +421,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter masterauth' do
-        let (:params) {
+        let (:params) do
           {
             masterauth: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -435,11 +435,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter maxclients' do
-        let (:params) {
+        let (:params) do
           {
             maxclients: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -449,11 +449,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter maxmemory' do
-        let (:params) {
+        let (:params) do
           {
             maxmemory: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -463,11 +463,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter maxmemory_policy' do
-        let (:params) {
+        let (:params) do
           {
             maxmemory_policy: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -477,11 +477,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter maxmemory_samples' do
-        let (:params) {
+        let (:params) do
           {
             maxmemory_samples: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -491,11 +491,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter min_slaves_max_lag' do
-        let (:params) {
+        let (:params) do
           {
             min_slaves_max_lag: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -505,11 +505,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter min_slaves_to_write' do
-        let (:params) {
+        let (:params) do
           {
             min_slaves_to_write: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -519,11 +519,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter notify_keyspace_events' do
-        let (:params) {
+        let (:params) do
           {
             notify_keyspace_events: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -533,11 +533,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter notify_service' do
-        let (:params) {
+        let (:params) do
           {
             notify_service: true
           }
-        }
+        end
 
         let(:service_name) { manifest_vars[:service_name] }
 
@@ -545,11 +545,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter no_appendfsync_on_rewrite' do
-        let (:params) {
+        let (:params) do
           {
             no_appendfsync_on_rewrite: true
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -576,11 +576,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter pid_file' do
-        let (:params) {
+        let (:params) do
           {
             pid_file: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -590,11 +590,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter port' do
-        let (:params) {
+        let (:params) do
           {
             port: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -604,11 +604,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter protected-mode' do
-        let (:params) {
+        let (:params) do
           {
             protected_mode: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -618,11 +618,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter hll_sparse_max_bytes' do
-        let (:params) {
+        let (:params) do
           {
             hll_sparse_max_bytes: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -632,11 +632,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter hz' do
-        let (:params) {
+        let (:params) do
           {
             hz: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -646,11 +646,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter latency_monitor_threshold' do
-        let (:params) {
+        let (:params) do
           {
             latency_monitor_threshold: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -660,11 +660,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter rdbcompression' do
-        let (:params) {
+        let (:params) do
           {
             rdbcompression: true
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -674,11 +674,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter repl_backlog_size' do
-        let (:params) {
+        let (:params) do
           {
             repl_backlog_size: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -688,11 +688,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter repl_backlog_ttl' do
-        let (:params) {
+        let (:params) do
           {
             repl_backlog_ttl: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -702,11 +702,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter repl_disable_tcp_nodelay' do
-        let (:params) {
+        let (:params) do
           {
             repl_disable_tcp_nodelay: true
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -716,11 +716,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter repl_ping_slave_period' do
-        let (:params) {
+        let (:params) do
           {
             repl_ping_slave_period: 1
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -730,11 +730,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter repl_timeout' do
-        let (:params) {
+        let (:params) do
           {
             repl_timeout: 1
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -744,11 +744,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter requirepass' do
-        let (:params) {
+        let (:params) do
           {
             requirepass: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -759,11 +759,11 @@ describe 'redis', type: :class do
 
       describe 'with parameter save_db_to_disk' do
         context 'true' do
-          let (:params) {
+          let (:params) do
             {
               save_db_to_disk: true
             }
-          }
+          end
 
           it {
             is_expected.to contain_file(config_file_orig).with(
@@ -773,11 +773,11 @@ describe 'redis', type: :class do
         end
 
         context 'false' do
-          let (:params) {
+          let (:params) do
             {
               save_db_to_disk: false
             }
-          }
+          end
 
           it {
             is_expected.to contain_file(config_file_orig).with(
@@ -790,11 +790,11 @@ describe 'redis', type: :class do
       describe 'with parameter save_db_to_disk_interval' do
         context 'with save_db_to_disk true' do
           context 'default' do
-            let (:params) {
+            let (:params) do
               {
                 save_db_to_disk: true
               }
-            }
+            end
 
             it { is_expected.to contain_file(config_file_orig).with('content' => /save 900 1/) }
             it { is_expected.to contain_file(config_file_orig).with('content' => /save 300 10/) }
@@ -804,12 +804,12 @@ describe 'redis', type: :class do
           end
 
           context 'default' do
-            let (:params) {
+            let (:params) do
               {
                 save_db_to_disk: true,
                 save_db_to_disk_interval: { '900' => '2', '300' => '11', '60' => '10011' }
               }
-            }
+            end
 
             it { is_expected.to contain_file(config_file_orig).with('content' => /save 900 2/) }
             it { is_expected.to contain_file(config_file_orig).with('content' => /save 300 11/) }
@@ -821,11 +821,11 @@ describe 'redis', type: :class do
 
         context 'with save_db_to_disk false' do
           context 'default' do
-            let (:params) {
+            let (:params) do
               {
                 save_db_to_disk: false
               }
-            }
+            end
 
             it { is_expected.to contain_file(config_file_orig).without('content' => /save 900 1/) }
             it { is_expected.to contain_file(config_file_orig).without('content' => /save 300 10/) }
@@ -888,11 +888,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter set_max_intset_entries' do
-        let (:params) {
+        let (:params) do
           {
             set_max_intset_entries: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -902,11 +902,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter slave_priority' do
-        let (:params) {
+        let (:params) do
           {
             slave_priority: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -916,11 +916,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter slave_read_only' do
-        let (:params) {
+        let (:params) do
           {
             slave_read_only: true
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -930,11 +930,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter slave_serve_stale_data' do
-        let (:params) {
+        let (:params) do
           {
             slave_serve_stale_data: true
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -945,12 +945,12 @@ describe 'redis', type: :class do
 
       describe 'with parameter: slaveof' do
         context 'binding to localhost' do
-          let (:params) {
+          let (:params) do
             {
               bind: '127.0.0.1',
               slaveof: '_VALUE_'
             }
-          }
+          end
 
           it {
             is_expected.to contain_file(config_file_orig).with(
@@ -960,12 +960,12 @@ describe 'redis', type: :class do
         end
 
         context 'binding to external ip' do
-          let (:params) {
+          let (:params) do
             {
               bind: '10.0.0.1',
               slaveof: '_VALUE_'
             }
-          }
+          end
 
           it {
             is_expected.to contain_file(config_file_orig).with(
@@ -976,11 +976,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter slowlog_log_slower_than' do
-        let (:params) {
+        let (:params) do
           {
             slowlog_log_slower_than: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -990,11 +990,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter slowlog_max_len' do
-        let (:params) {
+        let (:params) do
           {
             slowlog_max_len: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1004,11 +1004,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter stop_writes_on_bgsave_error' do
-        let (:params) {
+        let (:params) do
           {
             stop_writes_on_bgsave_error: true
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1018,11 +1018,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter syslog_enabled' do
-        let (:params) {
+        let (:params) do
           {
             syslog_enabled: true
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1032,12 +1032,12 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter syslog_facility' do
-        let (:params) {
+        let (:params) do
           {
             syslog_enabled: true,
             syslog_facility: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1047,11 +1047,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter tcp_backlog' do
-        let (:params) {
+        let (:params) do
           {
             tcp_backlog: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1061,11 +1061,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter tcp_keepalive' do
-        let (:params) {
+        let (:params) do
           {
             tcp_keepalive: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1075,11 +1075,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter timeout' do
-        let (:params) {
+        let (:params) do
           {
             timeout: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1089,11 +1089,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter workdir' do
-        let (:params) {
+        let (:params) do
           {
             workdir: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1103,11 +1103,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter zset_max_ziplist_entries' do
-        let (:params) {
+        let (:params) do
           {
             zset_max_ziplist_entries: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1117,11 +1117,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter zset_max_ziplist_value' do
-        let (:params) {
+        let (:params) do
           {
             zset_max_ziplist_value: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1131,11 +1131,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter cluster_enabled-false' do
-        let (:params) {
+        let (:params) do
           {
             cluster_enabled: false
           }
-        }
+        end
 
         it {
           should_not contain_file(config_file_orig).with(
@@ -1145,11 +1145,11 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter cluster_enabled-true' do
-        let (:params) {
+        let (:params) do
           {
             cluster_enabled: true
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1159,12 +1159,12 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter cluster_config_file' do
-        let (:params) {
+        let (:params) do
           {
             cluster_enabled: true,
             cluster_config_file: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
@@ -1174,12 +1174,12 @@ describe 'redis', type: :class do
       end
 
       describe 'with parameter cluster_config_file' do
-        let (:params) {
+        let (:params) do
           {
             cluster_enabled: true,
             cluster_node_timeout: '_VALUE_'
           }
-        }
+        end
 
         it {
           is_expected.to contain_file(config_file_orig).with(

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -926,7 +926,8 @@ describe 'redis', type: :class do
 
           it { is_expected.to contain_file(config_file_orig).with(
             'content' => /^slaveof _VALUE_/
-          )}
+          )
+          }
         end
 
         context 'binding to external ip' do

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'redis', type: :class do
-
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) {
@@ -38,14 +37,12 @@ describe 'redis', type: :class do
         when 'Debian'
 
           context 'on Debian' do
-
             it do
               is_expected.to contain_file('/var/run/redis').with(ensure: 'directory',
                                                                  owner: 'redis',
                                                                  group: 'root',
                                                                  mode: '2775')
             end
-
           end
 
         when 'Ubuntu'
@@ -360,7 +357,6 @@ describe 'redis', type: :class do
         when 'Debian'
 
           context 'on Debian' do
-
             it do
               is_expected.to create_apt__source('dotdeb').with(location: 'http://packages.dotdeb.org/',
                                                                release: facts[:lsbdistcodename],
@@ -371,7 +367,6 @@ describe 'redis', type: :class do
                                                                },
                                                                include: { 'src' => true })
             end
-
           end
 
         when 'Ubuntu'
@@ -757,7 +752,6 @@ describe 'redis', type: :class do
 
       describe 'with parameter save_db_to_disk_interval' do
         context 'with save_db_to_disk true' do
-
           context 'default' do
             let (:params) {
               {
@@ -784,7 +778,6 @@ describe 'redis', type: :class do
             it { is_expected.to contain_file(config_file_orig).with('content' => /save 60 10011/)
             }
           end
-
         end
 
         context 'with save_db_to_disk false' do
@@ -1134,8 +1127,6 @@ describe 'redis', type: :class do
         )
         }
       end
-
     end
   end
-
 end

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -37,7 +37,7 @@ describe 'redis', type: :class do
         end
 
         case facts[:operatingsystem]
-          when 'Debian'
+        when 'Debian'
 
           context 'on Debian' do
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -366,8 +366,8 @@ describe 'redis', type: :class do
                                                                release: facts[:lsbdistcodename],
                                                                repos: 'all',
                                                                key: {
-                                                                 "id" => "6572BBEF1B5FF28B28B706837E3F070089DF5277",
-                                                                 "source" => "http://www.dotdeb.org/dotdeb.gpg"
+                                                                 'id' => '6572BBEF1B5FF28B28B706837E3F070089DF5277',
+                                                                 'source' => 'http://www.dotdeb.org/dotdeb.gpg'
                                                                },
                                                                include: { 'src' => true })
             end

--- a/spec/classes/redis_ubuntu_1404_spec.rb
+++ b/spec/classes/redis_ubuntu_1404_spec.rb
@@ -2,15 +2,12 @@ require 'spec_helper'
 
 describe 'redis' do
   context 'on Ubuntu 1404' do
-
     let(:facts) {
       ubuntu_1404_facts
     }
 
     context 'should set Ubuntu specific values' do
-
       context 'when $::redis_server_version fact is not present (older features not enabled)' do
-
         let(:facts) {
           ubuntu_1404_facts.merge(redis_server_version: nil)
         }
@@ -18,11 +15,9 @@ describe 'redis' do
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
-
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3.2.1) (older features enabled)' do
-
         let(:facts) {
           ubuntu_1404_facts.merge(redis_server_version: nil)
         }
@@ -31,11 +26,9 @@ describe 'redis' do
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
-
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3:3.2.1) (older features enabled)' do
-
         let(:facts) {
           ubuntu_1404_facts.merge(redis_server_version: nil)
         }
@@ -44,11 +37,9 @@ describe 'redis' do
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
-
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4:4.0-rc3) (older features enabled)' do
-
         let(:facts) {
           ubuntu_1404_facts.merge(redis_server_version: nil)
         }
@@ -57,10 +48,8 @@ describe 'redis' do
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
-
       end
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
-
         let(:facts) {
           ubuntu_1404_facts.merge(redis_server_version: nil)
         }
@@ -69,11 +58,9 @@ describe 'redis' do
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
-
       end
 
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
-
         let(:facts) {
           ubuntu_1404_facts.merge(redis_server_version: '2.8.4')
         }
@@ -81,11 +68,9 @@ describe 'redis' do
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
-
       end
 
       context 'when $::redis_server_version fact is present but a newer version (older features enabled)' do
-
         let(:facts) {
           ubuntu_1404_facts.merge(redis_server_version: '3.2.1')
         }
@@ -93,10 +78,7 @@ describe 'redis' do
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
-
       end
     end
-
   end
-
 end

--- a/spec/classes/redis_ubuntu_1404_spec.rb
+++ b/spec/classes/redis_ubuntu_1404_spec.rb
@@ -2,15 +2,15 @@ require 'spec_helper'
 
 describe 'redis' do
   context 'on Ubuntu 1404' do
-    let(:facts) {
+    let(:facts) do
       ubuntu_1404_facts
-    }
+    end
 
     context 'should set Ubuntu specific values' do
       context 'when $::redis_server_version fact is not present (older features not enabled)' do
-        let(:facts) {
+        let(:facts) do
           ubuntu_1404_facts.merge(redis_server_version: nil)
-        }
+        end
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
@@ -18,9 +18,9 @@ describe 'redis' do
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3.2.1) (older features enabled)' do
-        let(:facts) {
+        let(:facts) do
           ubuntu_1404_facts.merge(redis_server_version: nil)
-        }
+        end
         let (:params) { { package_ensure: '3.2.1' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
@@ -29,9 +29,9 @@ describe 'redis' do
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3:3.2.1) (older features enabled)' do
-        let(:facts) {
+        let(:facts) do
           ubuntu_1404_facts.merge(redis_server_version: nil)
-        }
+        end
         let (:params) { { package_ensure: '3:3.2.1' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
@@ -40,9 +40,9 @@ describe 'redis' do
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4:4.0-rc3) (older features enabled)' do
-        let(:facts) {
+        let(:facts) do
           ubuntu_1404_facts.merge(redis_server_version: nil)
-        }
+        end
         let (:params) { { package_ensure: '4:4.0-rc3' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
@@ -50,9 +50,9 @@ describe 'redis' do
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
       end
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
-        let(:facts) {
+        let(:facts) do
           ubuntu_1404_facts.merge(redis_server_version: nil)
-        }
+        end
         let (:params) { { package_ensure: '4.0-rc3' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
@@ -61,9 +61,9 @@ describe 'redis' do
       end
 
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
-        let(:facts) {
+        let(:facts) do
           ubuntu_1404_facts.merge(redis_server_version: '2.8.4')
-        }
+        end
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
@@ -71,9 +71,9 @@ describe 'redis' do
       end
 
       context 'when $::redis_server_version fact is present but a newer version (older features enabled)' do
-        let(:facts) {
+        let(:facts) do
           ubuntu_1404_facts.merge(redis_server_version: '3.2.1')
-        }
+        end
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }

--- a/spec/classes/redis_ubuntu_1404_spec.rb
+++ b/spec/classes/redis_ubuntu_1404_spec.rb
@@ -12,9 +12,7 @@ describe 'redis' do
       context 'when $::redis_server_version fact is not present (older features not enabled)' do
 
         let(:facts) {
-          ubuntu_1404_facts.merge({
-            redis_server_version: nil,
-          })
+          ubuntu_1404_facts.merge(redis_server_version: nil)
         }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
@@ -26,9 +24,7 @@ describe 'redis' do
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3.2.1) (older features enabled)' do
 
         let(:facts) {
-          ubuntu_1404_facts.merge({
-            redis_server_version: nil,
-          })
+          ubuntu_1404_facts.merge(redis_server_version: nil)
         }
         let (:params) { { package_ensure: '3.2.1' } }
 
@@ -41,9 +37,7 @@ describe 'redis' do
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3:3.2.1) (older features enabled)' do
 
         let(:facts) {
-          ubuntu_1404_facts.merge({
-            redis_server_version: nil,
-          })
+          ubuntu_1404_facts.merge(redis_server_version: nil)
         }
         let (:params) { { package_ensure: '3:3.2.1' } }
 
@@ -56,9 +50,7 @@ describe 'redis' do
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4:4.0-rc3) (older features enabled)' do
 
         let(:facts) {
-          ubuntu_1404_facts.merge({
-            redis_server_version: nil,
-          })
+          ubuntu_1404_facts.merge(redis_server_version: nil)
         }
         let (:params) { { package_ensure: '4:4.0-rc3' } }
 
@@ -70,9 +62,7 @@ describe 'redis' do
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
 
         let(:facts) {
-          ubuntu_1404_facts.merge({
-            redis_server_version: nil,
-          })
+          ubuntu_1404_facts.merge(redis_server_version: nil)
         }
         let (:params) { { package_ensure: '4.0-rc3' } }
 
@@ -85,9 +75,7 @@ describe 'redis' do
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
 
         let(:facts) {
-          ubuntu_1404_facts.merge({
-            redis_server_version: '2.8.4',
-          })
+          ubuntu_1404_facts.merge(redis_server_version: '2.8.4')
         }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
@@ -99,9 +87,7 @@ describe 'redis' do
       context 'when $::redis_server_version fact is present but a newer version (older features enabled)' do
 
         let(:facts) {
-          ubuntu_1404_facts.merge({
-            redis_server_version: '3.2.1',
-          })
+          ubuntu_1404_facts.merge(redis_server_version: '3.2.1')
         }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }

--- a/spec/classes/redis_ubuntu_1404_spec.rb
+++ b/spec/classes/redis_ubuntu_1404_spec.rb
@@ -12,9 +12,9 @@ describe 'redis' do
           ubuntu_1404_facts.merge(redis_server_version: nil)
         end
 
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^hash-max-ziplist-entries}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => %r{^tcp-backlog}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => %r{^protected-mode}) }
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3.2.1) (older features enabled)' do
@@ -23,9 +23,9 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '3.2.1' } }
 
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^hash-max-ziplist-entries}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^protected-mode}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^tcp-backlog}) }
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3:3.2.1) (older features enabled)' do
@@ -34,9 +34,9 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '3:3.2.1' } }
 
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^hash-max-ziplist-entries}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^protected-mode}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^tcp-backlog}) }
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4:4.0-rc3) (older features enabled)' do
@@ -45,9 +45,9 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '4:4.0-rc3' } }
 
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^hash-max-ziplist-entries}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => %r{^protected-mode}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^tcp-backlog}) }
       end
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
         let(:facts) do
@@ -55,9 +55,9 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '4.0-rc3' } }
 
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^hash-max-ziplist-entries}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => %r{^protected-mode}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^tcp-backlog}) }
       end
 
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
@@ -65,9 +65,9 @@ describe 'redis' do
           ubuntu_1404_facts.merge(redis_server_version: '2.8.4')
         end
 
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^hash-max-ziplist-entries}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => %r{^tcp-backlog}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => %r{^protected-mode}) }
       end
 
       context 'when $::redis_server_version fact is present but a newer version (older features enabled)' do
@@ -75,9 +75,9 @@ describe 'redis' do
           ubuntu_1404_facts.merge(redis_server_version: '3.2.1')
         end
 
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
-        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^hash-max-ziplist-entries}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^tcp-backlog}) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => %r{^protected-mode}) }
       end
     end
   end

--- a/spec/classes/redis_ubuntu_1404_spec.rb
+++ b/spec/classes/redis_ubuntu_1404_spec.rb
@@ -13,7 +13,7 @@ describe 'redis' do
 
         let(:facts) {
           ubuntu_1404_facts.merge({
-            :redis_server_version => nil,
+            redis_server_version: nil,
           })
         }
 
@@ -27,10 +27,10 @@ describe 'redis' do
 
         let(:facts) {
           ubuntu_1404_facts.merge({
-            :redis_server_version => nil,
+            redis_server_version: nil,
           })
         }
-        let (:params) { { :package_ensure => '3.2.1' } }
+        let (:params) { { package_ensure: '3.2.1' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
@@ -42,10 +42,10 @@ describe 'redis' do
 
         let(:facts) {
           ubuntu_1404_facts.merge({
-            :redis_server_version => nil,
+            redis_server_version: nil,
           })
         }
-        let (:params) { { :package_ensure => '3:3.2.1' } }
+        let (:params) { { package_ensure: '3:3.2.1' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
@@ -57,10 +57,10 @@ describe 'redis' do
 
         let(:facts) {
           ubuntu_1404_facts.merge({
-            :redis_server_version => nil,
+            redis_server_version: nil,
           })
         }
-        let (:params) { { :package_ensure => '4:4.0-rc3' } }
+        let (:params) { { package_ensure: '4:4.0-rc3' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
@@ -71,10 +71,10 @@ describe 'redis' do
 
         let(:facts) {
           ubuntu_1404_facts.merge({
-            :redis_server_version => nil,
+            redis_server_version: nil,
           })
         }
-        let (:params) { { :package_ensure => '4.0-rc3' } }
+        let (:params) { { package_ensure: '4.0-rc3' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
@@ -86,7 +86,7 @@ describe 'redis' do
 
         let(:facts) {
           ubuntu_1404_facts.merge({
-            :redis_server_version => '2.8.4',
+            redis_server_version: '2.8.4',
           })
         }
 
@@ -100,7 +100,7 @@ describe 'redis' do
 
         let(:facts) {
           ubuntu_1404_facts.merge({
-            :redis_server_version => '3.2.1',
+            redis_server_version: '3.2.1',
           })
         }
 

--- a/spec/classes/redis_ubuntu_1404_spec.rb
+++ b/spec/classes/redis_ubuntu_1404_spec.rb
@@ -12,9 +12,9 @@ describe 'redis' do
           ubuntu_1404_facts.merge(redis_server_version: nil)
         end
 
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3.2.1) (older features enabled)' do
@@ -23,9 +23,9 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '3.2.1' } }
 
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3:3.2.1) (older features enabled)' do
@@ -34,9 +34,9 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '3:3.2.1' } }
 
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
       end
 
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4:4.0-rc3) (older features enabled)' do
@@ -45,9 +45,9 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '4:4.0-rc3' } }
 
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
       end
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
         let(:facts) do
@@ -55,9 +55,9 @@ describe 'redis' do
         end
         let (:params) { { package_ensure: '4.0-rc3' } }
 
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
       end
 
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
@@ -65,9 +65,9 @@ describe 'redis' do
           ubuntu_1404_facts.merge(redis_server_version: '2.8.4')
         end
 
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
       end
 
       context 'when $::redis_server_version fact is present but a newer version (older features enabled)' do
@@ -75,9 +75,9 @@ describe 'redis' do
           ubuntu_1404_facts.merge(redis_server_version: '3.2.1')
         end
 
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { is_expected.to contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
       end
     end
   end

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -89,7 +89,7 @@ describe 'redis::ulimit' do
         'notify' => [
           'Exec[systemd-reload-redis]'
         ]
-        )
+      )
     end
   end
 

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -87,7 +87,7 @@ describe 'redis::ulimit' do
                 "set $nofile/value \"7777\""
               ],
               'notify' => [
-                'Exec[systemd-reload-redis]',
+                'Exec[systemd-reload-redis]'
               ]
         )
     end

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -16,6 +16,7 @@ describe 'redis::ulimit' do
         }'
       ]
     end
+
     it { should compile.with_all_deps }
     it do
       is_expected.to contain_file("/etc/security/limits.d/redis.conf").with(
@@ -45,6 +46,7 @@ describe 'redis::ulimit' do
         }'
       ]
     end
+
     it { should compile.with_all_deps }
     it do
       is_expected.to contain_file("/etc/security/limits.d/redis.conf").with(
@@ -72,6 +74,7 @@ describe 'redis::ulimit' do
         }'
       ]
     end
+
     it { should compile.with_all_deps }
     it do
       is_expected.to contain_file("/etc/systemd/system/redis-server.service.d/limit.conf").with(
@@ -116,6 +119,7 @@ describe 'redis::ulimit' do
           }'
         ]
       end
+
       it { should compile.with_all_deps }
       it do
         is_expected.not_to contain_file('/etc/systemd/system/redis-server.service.d/limit.conf')
@@ -144,6 +148,7 @@ describe 'redis::ulimit' do
           }'
         ]
       end
+
       it { should compile.with_all_deps }
       it do
         is_expected.not_to contain_file('/etc/systemd/system/redis-server.service.d/limit.conf')

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -148,5 +148,4 @@ describe 'redis::ulimit' do
       end
     end
   end
-
 end

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -6,9 +6,9 @@ describe 'redis::ulimit' do
   # Puppet::Util::Log.newdestination(:console)
 
   context 'with managed_by_cluster_manager true' do
-    let(:facts) {
+    let(:facts) do
       debian_facts
-    }
+    end
     let :pre_condition do
       [
         'class { redis:
@@ -30,9 +30,9 @@ describe 'redis::ulimit' do
   end
 
   context 'with managed_by_cluster_manager true but not managing service' do
-    let(:facts) {
+    let(:facts) do
       debian_facts.merge(service_provider: 'systemd')
-    }
+    end
     let :pre_condition do
       [
         'class { "redis":
@@ -56,9 +56,9 @@ describe 'redis::ulimit' do
   end
 
   context 'on a systemd system' do
-    let(:facts) {
+    let(:facts) do
       debian_facts.merge(service_provider: 'systemd')
-    }
+    end
     let :pre_condition do
       [
         'class { redis:
@@ -95,9 +95,9 @@ describe 'redis::ulimit' do
 
   context 'on a non-systemd system' do
     context 'Ubuntu 1404 system' do
-      let(:facts) {
+      let(:facts) do
         ubuntu_1404_facts.merge(service_provider: 'debian')
-      }
+      end
       let :pre_condition do
         [
           'class { redis:
@@ -122,9 +122,9 @@ describe 'redis::ulimit' do
     end
 
     context 'CentOS 6 system' do
-      let(:facts) {
+      let(:facts) do
         centos_6_facts.merge(service_provider: 'redhat')
-      }
+      end
       let :pre_condition do
         [
           'class { redis:

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -33,7 +33,7 @@ describe 'redis::ulimit' do
   context 'with managed_by_cluster_manager true but not managing service' do
     let(:facts) {
       debian_facts.merge({
-        :service_provider => 'systemd',
+        service_provider: 'systemd',
       })
     }
     let :pre_condition do
@@ -62,7 +62,7 @@ describe 'redis::ulimit' do
   context 'on a systemd system' do
     let(:facts) {
       debian_facts.merge({
-        :service_provider => 'systemd',
+        service_provider: 'systemd',
       })
     }
     let :pre_condition do
@@ -106,7 +106,7 @@ describe 'redis::ulimit' do
     context 'Ubuntu 1404 system' do
       let(:facts) {
         ubuntu_1404_facts.merge({
-          :service_provider => 'debian',
+          service_provider: 'debian',
         })
       }
       let :pre_condition do
@@ -134,7 +134,7 @@ describe 'redis::ulimit' do
     context 'CentOS 6 system' do
       let(:facts) {
         centos_6_facts.merge({
-          :service_provider => 'redhat',
+          service_provider: 'redhat',
         })
       }
       let :pre_condition do

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -97,7 +97,7 @@ describe 'redis::ulimit' do
           "defnode nofile Service/LimitNOFILE \"\"",
           "set $nofile/value \"7777\""
         ],
-        'notify'   => [
+        'notify' => [
           'Exec[systemd-reload-redis]',
         ],
         }

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -17,7 +17,7 @@ describe 'redis::ulimit' do
       ]
     end
 
-    it { should compile.with_all_deps }
+    it { is_expected.to compile.with_all_deps }
     it do
       is_expected.to contain_file('/etc/security/limits.d/redis.conf').with(
         'ensure'  => 'file',
@@ -43,7 +43,7 @@ describe 'redis::ulimit' do
       ]
     end
 
-    it { should compile.with_all_deps }
+    it { is_expected.to compile.with_all_deps }
     it do
       is_expected.to contain_file('/etc/security/limits.d/redis.conf').with(
         'ensure'  => 'file',
@@ -67,7 +67,7 @@ describe 'redis::ulimit' do
       ]
     end
 
-    it { should compile.with_all_deps }
+    it { is_expected.to compile.with_all_deps }
     it do
       is_expected.to contain_file('/etc/systemd/system/redis-server.service.d/limit.conf').with(
         'ensure' => 'file',
@@ -106,7 +106,7 @@ describe 'redis::ulimit' do
         ]
       end
 
-      it { should compile.with_all_deps }
+      it { is_expected.to compile.with_all_deps }
       it do
         is_expected.not_to contain_file('/etc/systemd/system/redis-server.service.d/limit.conf')
       end
@@ -133,7 +133,7 @@ describe 'redis::ulimit' do
         ]
       end
 
-      it { should compile.with_all_deps }
+      it { is_expected.to compile.with_all_deps }
       it do
         is_expected.not_to contain_file('/etc/systemd/system/redis-server.service.d/limit.conf')
       end

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -96,7 +96,7 @@ describe 'redis::ulimit' do
         ],
         'notify'   => [
           'Exec[systemd-reload-redis]',
-          ],
+        ],
         }
         )
     end

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -160,5 +160,4 @@ describe 'redis::ulimit' do
     end
   end
 
-
 end

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -20,11 +20,11 @@ describe 'redis::ulimit' do
     it { should compile.with_all_deps }
     it do
       is_expected.to contain_file('/etc/security/limits.d/redis.conf').with(
-                  'ensure'  => 'file',
-                  'owner'   => 'root',
-                  'group'   => 'root',
-                  'mode'    => '0644',
-                  'content' => "redis soft nofile 65536\nredis hard nofile 65536\n"
+        'ensure'  => 'file',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'content' => "redis soft nofile 65536\nredis hard nofile 65536\n"
       )
     end
   end
@@ -46,11 +46,11 @@ describe 'redis::ulimit' do
     it { should compile.with_all_deps }
     it do
       is_expected.to contain_file('/etc/security/limits.d/redis.conf').with(
-                  'ensure'  => 'file',
-                  'owner'   => 'root',
-                  'group'   => 'root',
-                  'mode'    => '0644',
-                  'content' => "redis soft nofile 65536\nredis hard nofile 65536\n"
+        'ensure'  => 'file',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'content' => "redis soft nofile 65536\nredis hard nofile 65536\n"
       )
     end
   end
@@ -70,25 +70,25 @@ describe 'redis::ulimit' do
     it { should compile.with_all_deps }
     it do
       is_expected.to contain_file('/etc/systemd/system/redis-server.service.d/limit.conf').with(
-              'ensure' => 'file',
-              'owner'  => 'root',
-              'group'  => 'root',
-              'mode'   => '0444'
+        'ensure' => 'file',
+        'owner'  => 'root',
+        'group'  => 'root',
+        'mode'   => '0444'
       )
     end
 
     it do
       is_expected.to contain_augeas('Systemd redis ulimit').with(
-              'incl' => '/etc/systemd/system/redis-server.service.d/limits.conf',
-              'lens'     => 'Systemd.lns',
-              'context'  => '/etc/systemd/system/redis-server.service.d/limits.conf',
-              'changes'  => [
-                'defnode nofile Service/LimitNOFILE ""',
-                'set $nofile/value "7777"'
-              ],
-              'notify' => [
-                'Exec[systemd-reload-redis]'
-              ]
+        'incl' => '/etc/systemd/system/redis-server.service.d/limits.conf',
+        'lens'     => 'Systemd.lns',
+        'context'  => '/etc/systemd/system/redis-server.service.d/limits.conf',
+        'changes'  => [
+          'defnode nofile Service/LimitNOFILE ""',
+          'set $nofile/value "7777"'
+        ],
+        'notify' => [
+          'Exec[systemd-reload-redis]'
+        ]
         )
     end
   end

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -19,12 +19,12 @@ describe 'redis::ulimit' do
 
     it { should compile.with_all_deps }
     it do
-      is_expected.to contain_file("/etc/security/limits.d/redis.conf").with(
-                  "ensure"  => "file",
-                  "owner"   => "root",
-                  "group"   => "root",
-                  "mode"    => "0644",
-                  "content" => "redis soft nofile 65536\nredis hard nofile 65536\n"
+      is_expected.to contain_file('/etc/security/limits.d/redis.conf').with(
+                  'ensure'  => 'file',
+                  'owner'   => 'root',
+                  'group'   => 'root',
+                  'mode'    => '0644',
+                  'content' => "redis soft nofile 65536\nredis hard nofile 65536\n"
       )
     end
   end
@@ -45,12 +45,12 @@ describe 'redis::ulimit' do
 
     it { should compile.with_all_deps }
     it do
-      is_expected.to contain_file("/etc/security/limits.d/redis.conf").with(
-                  "ensure"  => "file",
-                  "owner"   => "root",
-                  "group"   => "root",
-                  "mode"    => "0644",
-                  "content" => "redis soft nofile 65536\nredis hard nofile 65536\n"
+      is_expected.to contain_file('/etc/security/limits.d/redis.conf').with(
+                  'ensure'  => 'file',
+                  'owner'   => 'root',
+                  'group'   => 'root',
+                  'mode'    => '0644',
+                  'content' => "redis soft nofile 65536\nredis hard nofile 65536\n"
       )
     end
   end
@@ -69,22 +69,22 @@ describe 'redis::ulimit' do
 
     it { should compile.with_all_deps }
     it do
-      is_expected.to contain_file("/etc/systemd/system/redis-server.service.d/limit.conf").with(
-              "ensure" => "file",
-              "owner"  => "root",
-              "group"  => "root",
-              "mode"   => "0444"
+      is_expected.to contain_file('/etc/systemd/system/redis-server.service.d/limit.conf').with(
+              'ensure' => 'file',
+              'owner'  => 'root',
+              'group'  => 'root',
+              'mode'   => '0444'
       )
     end
 
     it do
-      is_expected.to contain_augeas("Systemd redis ulimit").with(
+      is_expected.to contain_augeas('Systemd redis ulimit').with(
               'incl' => '/etc/systemd/system/redis-server.service.d/limits.conf',
               'lens'     => 'Systemd.lns',
               'context'  => '/etc/systemd/system/redis-server.service.d/limits.conf',
               'changes'  => [
-                "defnode nofile Service/LimitNOFILE \"\"",
-                "set $nofile/value \"7777\""
+                'defnode nofile Service/LimitNOFILE ""',
+                'set $nofile/value "7777"'
               ],
               'notify' => [
                 'Exec[systemd-reload-redis]'

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -20,22 +20,18 @@ describe 'redis::ulimit' do
     it { should compile.with_all_deps }
     it do
       is_expected.to contain_file("/etc/security/limits.d/redis.conf").with(
-        {
-          "ensure"  => "file",
-          "owner"   => "root",
-          "group"   => "root",
-          "mode"    => "0644",
-          "content" => "redis soft nofile 65536\nredis hard nofile 65536\n",
-        }
+                  "ensure"  => "file",
+                  "owner"   => "root",
+                  "group"   => "root",
+                  "mode"    => "0644",
+                  "content" => "redis soft nofile 65536\nredis hard nofile 65536\n"
       )
     end
   end
 
   context 'with managed_by_cluster_manager true but not managing service' do
     let(:facts) {
-      debian_facts.merge({
-        service_provider: 'systemd',
-      })
+      debian_facts.merge(service_provider: 'systemd')
     }
     let :pre_condition do
       [
@@ -50,22 +46,18 @@ describe 'redis::ulimit' do
     it { should compile.with_all_deps }
     it do
       is_expected.to contain_file("/etc/security/limits.d/redis.conf").with(
-        {
-          "ensure"  => "file",
-          "owner"   => "root",
-          "group"   => "root",
-          "mode"    => "0644",
-          "content" => "redis soft nofile 65536\nredis hard nofile 65536\n",
-        }
+                  "ensure"  => "file",
+                  "owner"   => "root",
+                  "group"   => "root",
+                  "mode"    => "0644",
+                  "content" => "redis soft nofile 65536\nredis hard nofile 65536\n"
       )
     end
   end
 
   context 'on a systemd system' do
     let(:facts) {
-      debian_facts.merge({
-        service_provider: 'systemd',
-      })
+      debian_facts.merge(service_provider: 'systemd')
     }
     let :pre_condition do
       [
@@ -78,29 +70,25 @@ describe 'redis::ulimit' do
     it { should compile.with_all_deps }
     it do
       is_expected.to contain_file("/etc/systemd/system/redis-server.service.d/limit.conf").with(
-      {
-        "ensure" => "file",
-        "owner"  => "root",
-        "group"  => "root",
-        "mode"   => "0444",
-      }
+              "ensure" => "file",
+              "owner"  => "root",
+              "group"  => "root",
+              "mode"   => "0444"
       )
     end
 
     it do
       is_expected.to contain_augeas("Systemd redis ulimit").with(
-      {
-        'incl'     => '/etc/systemd/system/redis-server.service.d/limits.conf',
-        'lens'     => 'Systemd.lns',
-        'context'  => '/etc/systemd/system/redis-server.service.d/limits.conf',
-        'changes'  => [
-          "defnode nofile Service/LimitNOFILE \"\"",
-          "set $nofile/value \"7777\""
-        ],
-        'notify' => [
-          'Exec[systemd-reload-redis]',
-        ],
-        }
+              'incl' => '/etc/systemd/system/redis-server.service.d/limits.conf',
+              'lens'     => 'Systemd.lns',
+              'context'  => '/etc/systemd/system/redis-server.service.d/limits.conf',
+              'changes'  => [
+                "defnode nofile Service/LimitNOFILE \"\"",
+                "set $nofile/value \"7777\""
+              ],
+              'notify' => [
+                'Exec[systemd-reload-redis]',
+              ]
         )
     end
   end
@@ -108,9 +96,7 @@ describe 'redis::ulimit' do
   context 'on a non-systemd system' do
     context 'Ubuntu 1404 system' do
       let(:facts) {
-        ubuntu_1404_facts.merge({
-          service_provider: 'debian',
-        })
+        ubuntu_1404_facts.merge(service_provider: 'debian')
       }
       let :pre_condition do
         [
@@ -137,9 +123,7 @@ describe 'redis::ulimit' do
 
     context 'CentOS 6 system' do
       let(:facts) {
-        centos_6_facts.merge({
-          service_provider: 'redhat',
-        })
+        centos_6_facts.merge(service_provider: 'redhat')
       }
       let :pre_condition do
         [

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -9,12 +9,14 @@ describe 'redis::instance', type: :define do
   let :title do
     'app2'
   end
+
   describe 'os-dependent items' do
     context "on Ubuntu systems" do
       context '14.04' do
         let(:facts) {
           ubuntu_1404_facts
         }
+
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
@@ -31,6 +33,7 @@ describe 'redis::instance', type: :define do
             service_provider: 'systemd',
           })
         }
+
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
@@ -46,6 +49,7 @@ describe 'redis::instance', type: :define do
         let(:facts) {
           centos_6_facts
         }
+
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
@@ -62,6 +66,7 @@ describe 'redis::instance', type: :define do
             service_provider: 'systemd',
           })
         }
+
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -11,7 +11,7 @@ describe 'redis::instance', type: :define do
   end
 
   describe 'os-dependent items' do
-    context "on Ubuntu systems" do
+    context 'on Ubuntu systems' do
       context '14.04' do
         let(:facts) {
           ubuntu_1404_facts
@@ -42,7 +42,7 @@ describe 'redis::instance', type: :define do
         it { should contain_file('/etc/systemd/system/redis-server-app2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis\/redis-server-app2.conf/) }
       end
     end
-    context "on CentOS systems" do
+    context 'on CentOS systems' do
       context '6' do
         let(:facts) {
           centos_6_facts

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -17,29 +17,29 @@ describe 'redis::instance', type: :define do
           ubuntu_1404_facts
         end
 
-        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
-        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
-        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
-        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
-        it { should contain_file('/var/lib/redis/redis-server-app2') }
-        it { should contain_service('redis-server-app2').with_ensure('running') }
-        it { should contain_service('redis-server-app2').with_enable('true') }
-        it { should contain_file('/etc/init.d/redis-server-app2').with_content(/DAEMON_ARGS=\/etc\/redis\/redis-server-app2.conf/) }
-        it { should contain_file('/etc/init.d/redis-server-app2').with_content(/PIDFILE=\/var\/run\/redis\/redis-server-app2.pid/) }
+        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
+        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
+        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
+        it { is_expected.to contain_file('/var/lib/redis/redis-server-app2') }
+        it { is_expected.to contain_service('redis-server-app2').with_ensure('running') }
+        it { is_expected.to contain_service('redis-server-app2').with_enable('true') }
+        it { is_expected.to contain_file('/etc/init.d/redis-server-app2').with_content(/DAEMON_ARGS=\/etc\/redis\/redis-server-app2.conf/) }
+        it { is_expected.to contain_file('/etc/init.d/redis-server-app2').with_content(/PIDFILE=\/var\/run\/redis\/redis-server-app2.pid/) }
       end
       context '16.04' do
         let(:facts) do
           ubuntu_1604_facts.merge(service_provider: 'systemd')
         end
 
-        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
-        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
-        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
-        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
-        it { should contain_file('/var/lib/redis/redis-server-app2') }
-        it { should contain_service('redis-server-app2').with_ensure('running') }
-        it { should contain_service('redis-server-app2').with_enable('true') }
-        it { should contain_file('/etc/systemd/system/redis-server-app2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis\/redis-server-app2.conf/) }
+        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
+        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
+        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
+        it { is_expected.to contain_file('/var/lib/redis/redis-server-app2') }
+        it { is_expected.to contain_service('redis-server-app2').with_ensure('running') }
+        it { is_expected.to contain_service('redis-server-app2').with_enable('true') }
+        it { is_expected.to contain_file('/etc/systemd/system/redis-server-app2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis\/redis-server-app2.conf/) }
       end
     end
     context 'on CentOS systems' do
@@ -48,29 +48,29 @@ describe 'redis::instance', type: :define do
           centos_6_facts
         end
 
-        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
-        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
-        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
-        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
-        it { should contain_file('/var/lib/redis/redis-server-app2') }
-        it { should contain_service('redis-server-app2').with_ensure('running') }
-        it { should contain_service('redis-server-app2').with_enable('true') }
-        it { should contain_file('/etc/init.d/redis-server-app2').with_content(/REDIS_CONFIG="\/etc\/redis-server-app2.conf"/) }
-        it { should contain_file('/etc/init.d/redis-server-app2').with_content(/pidfile="\/var\/run\/redis\/redis-server-app2.pid"/) }
+        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
+        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
+        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
+        it { is_expected.to contain_file('/var/lib/redis/redis-server-app2') }
+        it { is_expected.to contain_service('redis-server-app2').with_ensure('running') }
+        it { is_expected.to contain_service('redis-server-app2').with_enable('true') }
+        it { is_expected.to contain_file('/etc/init.d/redis-server-app2').with_content(/REDIS_CONFIG="\/etc\/redis-server-app2.conf"/) }
+        it { is_expected.to contain_file('/etc/init.d/redis-server-app2').with_content(/pidfile="\/var\/run\/redis\/redis-server-app2.pid"/) }
       end
       context '7' do
         let(:facts) do
           centos_7_facts.merge(service_provider: 'systemd')
         end
 
-        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
-        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
-        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
-        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
-        it { should contain_file('/var/lib/redis/redis-server-app2') }
-        it { should contain_service('redis-server-app2').with_ensure('running') }
-        it { should contain_service('redis-server-app2').with_enable('true') }
-        it { should contain_file('/etc/systemd/system/redis-server-app2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis-server-app2.conf/) }
+        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
+        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
+        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
+        it { is_expected.to contain_file('/var/lib/redis/redis-server-app2') }
+        it { is_expected.to contain_service('redis-server-app2').with_ensure('running') }
+        it { is_expected.to contain_service('redis-server-app2').with_enable('true') }
+        it { is_expected.to contain_file('/etc/systemd/system/redis-server-app2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis-server-app2.conf/) }
       end
     end
   end

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -29,9 +29,7 @@ describe 'redis::instance', type: :define do
       end
       context '16.04' do
         let(:facts) {
-          ubuntu_1604_facts.merge({
-            service_provider: 'systemd',
-          })
+          ubuntu_1604_facts.merge(service_provider: 'systemd')
         }
 
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
@@ -62,9 +60,7 @@ describe 'redis::instance', type: :define do
       end
       context '7' do
         let(:facts) {
-          centos_7_facts.merge({
-            service_provider: 'systemd',
-          })
+          centos_7_facts.merge(service_provider: 'systemd')
         }
 
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'redis::instance', :type => :define do
+describe 'redis::instance', type: :define do
   let :pre_condition do
     'class { "redis":
       default_install => false,
@@ -28,7 +28,7 @@ describe 'redis::instance', :type => :define do
       context '16.04' do
         let(:facts) {
           ubuntu_1604_facts.merge({
-            :service_provider => 'systemd',
+            service_provider: 'systemd',
           })
         }
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
@@ -59,7 +59,7 @@ describe 'redis::instance', :type => :define do
       context '7' do
         let(:facts) {
           centos_7_facts.merge({
-            :service_provider => 'systemd',
+            service_provider: 'systemd',
           })
         }
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -13,9 +13,9 @@ describe 'redis::instance', type: :define do
   describe 'os-dependent items' do
     context 'on Ubuntu systems' do
       context '14.04' do
-        let(:facts) {
+        let(:facts) do
           ubuntu_1404_facts
-        }
+        end
 
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
@@ -28,9 +28,9 @@ describe 'redis::instance', type: :define do
         it { should contain_file('/etc/init.d/redis-server-app2').with_content(/PIDFILE=\/var\/run\/redis\/redis-server-app2.pid/) }
       end
       context '16.04' do
-        let(:facts) {
+        let(:facts) do
           ubuntu_1604_facts.merge(service_provider: 'systemd')
-        }
+        end
 
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
@@ -44,9 +44,9 @@ describe 'redis::instance', type: :define do
     end
     context 'on CentOS systems' do
       context '6' do
-        let(:facts) {
+        let(:facts) do
           centos_6_facts
-        }
+        end
 
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
@@ -59,9 +59,9 @@ describe 'redis::instance', type: :define do
         it { should contain_file('/etc/init.d/redis-server-app2').with_content(/pidfile="\/var\/run\/redis\/redis-server-app2.pid"/) }
       end
       context '7' do
-        let(:facts) {
+        let(:facts) do
           centos_7_facts.merge(service_provider: 'systemd')
-        }
+        end
 
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -17,7 +17,7 @@ describe 'redis::instance', type: :define do
           ubuntu_1404_facts
         end
 
-        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => %r{^bind 127.0.0.1}) }
         it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
         it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
         it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
@@ -32,7 +32,7 @@ describe 'redis::instance', type: :define do
           ubuntu_1604_facts.merge(service_provider: 'systemd')
         end
 
-        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => %r{^bind 127.0.0.1}) }
         it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
         it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
         it { is_expected.to contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
@@ -48,7 +48,7 @@ describe 'redis::instance', type: :define do
           centos_6_facts
         end
 
-        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => %r{^bind 127.0.0.1}) }
         it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
         it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
         it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
@@ -63,7 +63,7 @@ describe 'redis::instance', type: :define do
           centos_7_facts.merge(service_provider: 'systemd')
         end
 
-        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => %r{^bind 127.0.0.1}) }
         it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
         it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
         it { is_expected.to contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }

--- a/spec/functions/redisget_spec.rb
+++ b/spec/functions/redisget_spec.rb
@@ -59,7 +59,7 @@ describe 'redisget' do
 
   describe 'with incorrect arguments' do
     context 'with no argument specified' do
-      it { is_expected.to run.with_params().and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
+      it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
     end
 
     context 'with only one argument specified' do

--- a/spec/functions/redisget_spec.rb
+++ b/spec/functions/redisget_spec.rb
@@ -72,7 +72,7 @@ describe 'redisget' do
   end
 
   describe 'when an invalid type (non-string) is specified' do
-    before(:each) {
+    before {
       mr = MockRedis.new
       Redis.stubs(:new).returns(mr)
     }

--- a/spec/functions/redisget_spec.rb
+++ b/spec/functions/redisget_spec.rb
@@ -24,36 +24,36 @@ describe 'redisget' do
   end
 
   context 'should return nil if key does not exist and no default is specified' do
-    before {
+    before do
       mr = MockRedis.new
       Redis.stubs(:new).returns(mr)
-    }
+    end
     it { is_expected.to run.with_params('nonexistent_key', REDIS_URL).and_return(nil) }
   end
 
   context 'should return the default value if specified and key does not exist' do
-    before {
+    before do
       mr = MockRedis.new
       Redis.stubs(:new).returns(mr)
-    }
+    end
     it { is_expected.to run.with_params('nonexistent_key', REDIS_URL, 'default_value').and_return('default_value') }
   end
 
   context 'should return the value of the specified key' do
-    before {
+    before do
       mr = MockRedis.new
       Redis.stubs(:new).returns(mr)
       mr.set('key', 'value')
-    }
+    end
     it { is_expected.to run.with_params('key', REDIS_URL).and_return('value') }
   end
 
   context 'should return the value of the specified key and not the default' do
-    before {
+    before do
       mr = MockRedis.new
       Redis.stubs(:new).returns(mr)
       mr.set('key', 'value')
-    }
+    end
     it { is_expected.to run.with_params('key', REDIS_URL, 'default_value').and_return('value') }
   end
 
@@ -72,10 +72,10 @@ describe 'redisget' do
   end
 
   describe 'when an invalid type (non-string) is specified' do
-    before {
+    before do
       mr = MockRedis.new
       Redis.stubs(:new).returns(mr)
-    }
+    end
     [{ 'ha' => 'sh' }, true, 1, %w[an array]].each do |p|
       context "specifing first parameter as <#{p}>" do
         it { is_expected.to run.with_params(p, REDIS_URL).and_raise_error(Puppet::ParseError, /wrong argument type/i) }

--- a/spec/functions/redisget_spec.rb
+++ b/spec/functions/redisget_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 require 'mock_redis'
 require 'redis'
 
-REDIS_URL='redis://localhost:6379'
-LOCAL_BROKEN_URL='redis://localhost:1234'
-REMOTE_BROKEN_URL='redis://redis.example.com:1234'
+REDIS_URL='redis://localhost:6379'.freeze
+LOCAL_BROKEN_URL='redis://localhost:1234'.freeze
+REMOTE_BROKEN_URL='redis://redis.example.com:1234'.freeze
 
 describe 'redisget' do
   context 'should error if connection to remote redis server cannot be made and no default is specified' do

--- a/spec/functions/redisget_spec.rb
+++ b/spec/functions/redisget_spec.rb
@@ -8,7 +8,7 @@ REMOTE_BROKEN_URL = 'redis://redis.example.com:1234'.freeze
 
 describe 'redisget' do
   context 'should error if connection to remote redis server cannot be made and no default is specified' do
-    it { is_expected.to run.with_params('nonexistent_key', REMOTE_BROKEN_URL).and_raise_error(Puppet::Error, /connection to redis server failed - getaddrinfo/) }
+    it { is_expected.to run.with_params('nonexistent_key', REMOTE_BROKEN_URL).and_raise_error(Puppet::Error, %r{connection to redis server failed - getaddrinfo}) }
   end
 
   context 'should return default value if connection to remote redis server cannot be made and default is specified' do
@@ -16,7 +16,7 @@ describe 'redisget' do
   end
 
   context 'should error if connection to local redis server cannot be made and no default is specified' do
-    it { is_expected.to run.with_params('nonexistent_key', LOCAL_BROKEN_URL).and_raise_error(Puppet::Error, /connection to redis server failed - Error connecting to Redis on localhost:1234/) }
+    it { is_expected.to run.with_params('nonexistent_key', LOCAL_BROKEN_URL).and_raise_error(Puppet::Error, %r{connection to redis server failed - Error connecting to Redis on localhost:1234}) }
   end
 
   context 'should return default value if connection to local redis server cannot be made and default is specified' do
@@ -59,15 +59,15 @@ describe 'redisget' do
 
   describe 'with incorrect arguments' do
     context 'with no argument specified' do
-      it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
+      it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
     end
 
     context 'with only one argument specified' do
-      it { is_expected.to run.with_params('some_key').and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
+      it { is_expected.to run.with_params('some_key').and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
     end
 
     context 'with more than three arguments specified' do
-      it { is_expected.to run.with_params('way', 'too', 'many', 'args').and_raise_error(Puppet::ParseError, /wrong number of arguments/i) }
+      it { is_expected.to run.with_params('way', 'too', 'many', 'args').and_raise_error(Puppet::ParseError, %r{wrong number of arguments}i) }
     end
   end
 
@@ -78,15 +78,15 @@ describe 'redisget' do
     end
     [{ 'ha' => 'sh' }, true, 1, %w[an array]].each do |p|
       context "specifing first parameter as <#{p}>" do
-        it { is_expected.to run.with_params(p, REDIS_URL).and_raise_error(Puppet::ParseError, /wrong argument type/i) }
+        it { is_expected.to run.with_params(p, REDIS_URL).and_raise_error(Puppet::ParseError, %r{wrong argument type}i) }
       end
 
       context "specifing second parameter as <#{p}>" do
-        it { is_expected.to run.with_params('valid', p).and_raise_error(Puppet::ParseError, /wrong argument type/i) }
+        it { is_expected.to run.with_params('valid', p).and_raise_error(Puppet::ParseError, %r{wrong argument type}i) }
       end
 
       context "specifing third parameter as <#{p}>" do
-        it { is_expected.to run.with_params('valid', p).and_raise_error(Puppet::ParseError, /wrong argument type/i) }
+        it { is_expected.to run.with_params('valid', p).and_raise_error(Puppet::ParseError, %r{wrong argument type}i) }
       end
     end
   end

--- a/spec/functions/redisget_spec.rb
+++ b/spec/functions/redisget_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 require 'mock_redis'
 require 'redis'
 
-REDIS_URL='redis://localhost:6379'.freeze
-LOCAL_BROKEN_URL='redis://localhost:1234'.freeze
-REMOTE_BROKEN_URL='redis://redis.example.com:1234'.freeze
+REDIS_URL = 'redis://localhost:6379'.freeze
+LOCAL_BROKEN_URL = 'redis://localhost:1234'.freeze
+REMOTE_BROKEN_URL = 'redis://redis.example.com:1234'.freeze
 
 describe 'redisget' do
   context 'should error if connection to remote redis server cannot be made and no default is specified' do

--- a/spec/functions/redisget_spec.rb
+++ b/spec/functions/redisget_spec.rb
@@ -76,7 +76,7 @@ describe 'redisget' do
       mr = MockRedis.new
       Redis.stubs(:new).returns(mr)
     }
-    [{ 'ha' => 'sh'}, true, 1, %w[an array]].each do |p|
+    [{ 'ha' => 'sh' }, true, 1, %w[an array]].each do |p|
       context "specifing first parameter as <#{p}>" do
         it { is_expected.to run.with_params(p, REDIS_URL).and_raise_error(Puppet::ParseError, /wrong argument type/i) }
       end

--- a/spec/functions/redisget_spec.rb
+++ b/spec/functions/redisget_spec.rb
@@ -76,7 +76,7 @@ describe 'redisget' do
       mr = MockRedis.new
       Redis.stubs(:new).returns(mr)
     }
-    [{ 'ha' => 'sh'}, true, 1, ['an', 'array']].each do |p|
+    [{ 'ha' => 'sh'}, true, 1, %w[an array]].each do |p|
       context "specifing first parameter as <#{p}>" do
         it { is_expected.to run.with_params(p, REDIS_URL).and_raise_error(Puppet::ParseError, /wrong argument type/i) }
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,7 +80,7 @@ def centos_facts
   {
     operatingsystem: 'CentOS',
     osfamily: 'RedHat',
-    puppetversion: '4.5.2',
+    puppetversion: '4.5.2'
   }
 end
 
@@ -90,7 +90,7 @@ def debian_facts
     osfamily: 'Debian',
     operatingsystemmajrelease: '8',
     puppetversion: '4.5.2',
-    lsbdistcodename: 'jessie',
+    lsbdistcodename: 'jessie'
   }
 end
 
@@ -98,7 +98,7 @@ def freebsd_facts
   {
     operatingsystem: 'FreeBSD',
     osfamily: 'FreeBSD',
-    puppetversion: '4.5.2',
+    puppetversion: '4.5.2'
   }
 end
 
@@ -107,7 +107,7 @@ def centos_6_facts
     operatingsystem: 'CentOS',
     osfamily: 'RedHat',
     operatingsystemmajrelease: '6',
-    puppetversion: '4.5.2',
+    puppetversion: '4.5.2'
   }
 end
 
@@ -116,7 +116,7 @@ def centos_7_facts
     operatingsystem: 'CentOS',
     osfamily: 'RedHat',
     operatingsystemmajrelease: '7',
-    puppetversion: '4.5.2',
+    puppetversion: '4.5.2'
   }
 end
 
@@ -126,7 +126,7 @@ def debian_wheezy_facts
     osfamily: 'Debian',
     operatingsystemmajrelease: '8',
     puppetversion: '4.5.2',
-    lsbdistcodename: 'wheezy',
+    lsbdistcodename: 'wheezy'
   }
 end
 
@@ -136,7 +136,7 @@ def ubuntu_1404_facts
     osfamily: 'Debian',
     operatingsystemmajrelease: '14.04',
     puppetversion: '4.5.2',
-    lsbdistcodename: 'trusty',
+    lsbdistcodename: 'trusty'
   }
 end
 
@@ -146,7 +146,7 @@ def ubuntu_1604_facts
     osfamily: 'Debian',
     operatingsystemmajrelease: '16.04',
     puppetversion: '4.5.2',
-    lsbdistcodename: 'xenial',
+    lsbdistcodename: 'xenial'
   }
 end
 
@@ -154,7 +154,7 @@ def archlinux_facts
   {
     operatingsystem: 'Archlinux',
     osfamily: 'Archlinux',
-    puppetversion: '4.5.2',
+    puppetversion: '4.5.2'
   }
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,7 @@ end
 def get_spec_fixtures_dir
   spec_dir = File.expand_path(File.dirname(__FILE__) + '/fixtures')
 
-  raise "The directory #{spec_dir} does not exist" unless Dir.exists? spec_dir
+  raise "The directory #{spec_dir} does not exist" unless Dir.exist? spec_dir
 
   spec_dir
 end
@@ -41,7 +41,7 @@ end
 def read_fixture_file(filename)
   filename = get_spec_fixtures_dir + "/#{filename}"
 
-  raise "The fixture file #{filename} doesn't exist" unless File.exists? filename
+  raise "The fixture file #{filename} doesn't exist" unless File.exist? filename
 
   File.read(filename)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,6 @@ def read_fixture_file(filename)
 end
 
 def manifest_vars
-
   vars = {}
 
   case facts[:osfamily].to_s

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,83 +79,83 @@ end
 
 def centos_facts
   {
-    :operatingsystem => 'CentOS',
-    :osfamily        => 'RedHat',
-    :puppetversion   => '4.5.2',
+    operatingsystem: 'CentOS',
+    osfamily: 'RedHat',
+    puppetversion: '4.5.2',
   }
 end
 
 def debian_facts
   {
-    :operatingsystem           => 'Debian',
-    :osfamily                  => 'Debian',
-    :operatingsystemmajrelease => '8',
-    :puppetversion             => '4.5.2',
-    :lsbdistcodename           => 'jessie',
+    operatingsystem: 'Debian',
+    osfamily: 'Debian',
+    operatingsystemmajrelease: '8',
+    puppetversion: '4.5.2',
+    lsbdistcodename: 'jessie',
   }
 end
 
 def freebsd_facts
   {
-    :operatingsystem => 'FreeBSD',
-    :osfamily        => 'FreeBSD',
-    :puppetversion   => '4.5.2',
+    operatingsystem: 'FreeBSD',
+    osfamily: 'FreeBSD',
+    puppetversion: '4.5.2',
   }
 end
 
 def centos_6_facts
   {
-    :operatingsystem => 'CentOS',
-    :osfamily        => 'RedHat',
-    :operatingsystemmajrelease => '6',
-    :puppetversion   => '4.5.2',
+    operatingsystem: 'CentOS',
+    osfamily: 'RedHat',
+    operatingsystemmajrelease: '6',
+    puppetversion: '4.5.2',
   }
 end
 
 def centos_7_facts
   {
-    :operatingsystem => 'CentOS',
-    :osfamily        => 'RedHat',
-    :operatingsystemmajrelease => '7',
-    :puppetversion   => '4.5.2',
+    operatingsystem: 'CentOS',
+    osfamily: 'RedHat',
+    operatingsystemmajrelease: '7',
+    puppetversion: '4.5.2',
   }
 end
 
 def debian_wheezy_facts
   {
-    :operatingsystem           => 'Debian',
-    :osfamily                  => 'Debian',
-    :operatingsystemmajrelease => '8',
-    :puppetversion             => '4.5.2',
-    :lsbdistcodename           => 'wheezy',
+    operatingsystem: 'Debian',
+    osfamily: 'Debian',
+    operatingsystemmajrelease: '8',
+    puppetversion: '4.5.2',
+    lsbdistcodename: 'wheezy',
   }
 end
 
 def ubuntu_1404_facts
   {
-    :operatingsystem           => 'Ubuntu',
-    :osfamily                  => 'Debian',
-    :operatingsystemmajrelease => '14.04',
-    :puppetversion             => '4.5.2',
-    :lsbdistcodename           => 'trusty',
+    operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
+    operatingsystemmajrelease: '14.04',
+    puppetversion: '4.5.2',
+    lsbdistcodename: 'trusty',
   }
 end
 
 def ubuntu_1604_facts
   {
-    :operatingsystem           => 'Ubuntu',
-    :osfamily                  => 'Debian',
-    :operatingsystemmajrelease => '16.04',
-    :puppetversion             => '4.5.2',
-    :lsbdistcodename           => 'xenial',
+    operatingsystem: 'Ubuntu',
+    osfamily: 'Debian',
+    operatingsystemmajrelease: '16.04',
+    puppetversion: '4.5.2',
+    lsbdistcodename: 'xenial',
   }
 end
 
 def archlinux_facts
   {
-    :operatingsystem => 'Archlinux',
-    :osfamily        => 'Archlinux',
-    :puppetversion   => '4.5.2',
+    operatingsystem: 'Archlinux',
+    osfamily: 'Archlinux',
+    puppetversion: '4.5.2',
   }
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ def get_spec_fixtures_dir
   spec_dir
 end
 
-def read_fixture_file filename
+def read_fixture_file(filename)
   filename = get_spec_fixtures_dir + "/#{filename}"
 
   raise "The fixture file #{filename} doesn't exist" unless File.exists? filename

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'puppet/indirector/catalog/compiler'
 
 # Magic to add a catalog.exported_resources accessor
 class Puppet::Resource::Catalog::Compiler
-  alias_method :filter_exclude_exported_resources, :filter
+  alias filter_exclude_exported_resources filter
   def filter(catalog)
     filter_exclude_exported_resources(catalog).tap do |filtered|
       # Every time we filter a catalog, add a .exported_resources to it.

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -72,7 +72,6 @@ RSpec.configure do |c|
   c.formatter = :documentation
 
   c.before :suite do
-
     hosts.each do |host|
       if fact('osfamily') == 'Debian'
         # These should be on all Deb-flavor machines by default...

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,7 +29,7 @@ def run_task(task_name:, params: nil, password: DEFAULT_PASSWORD)
 end
 
 def run_bolt_task(task_name:, params: nil, password: DEFAULT_PASSWORD)
-  on(master, "/opt/puppetlabs/puppet/bin/bolt task run #{task_name} --modules /etc/puppetlabs/code/modules/ --nodes localhost --user root --password #{password} #{params}", acceptable_exit_codes: [0, 1]).stdout # rubocop:disable Metrics/LineLength
+  on(master, "/opt/puppetlabs/puppet/bin/bolt task run #{task_name} --modules /etc/puppetlabs/code/modules/ --nodes localhost --user root --password #{password} #{params}", acceptable_exit_codes: [0, 1]).stdout
 end
 
 def expect_multiple_regexes(result:, regexes:)

--- a/tasks/redis_cli.rb
+++ b/tasks/redis_cli.rb
@@ -4,7 +4,7 @@ require 'open3'
 require 'puppet'
 
 def redis_cli(command)
-  stdout, stderr, status = Open3.capture3("redis-cli", command)
+  stdout, stderr, status = Open3.capture3('redis-cli', command)
   raise Puppet::Error, stderr if status != 0
   { status: stdout.strip }
 end


### PR DESCRIPTION
This is in preparation of doing the first Vox Pupuli modulesync.

The following cops can not be autocorrected.
```
100  Lint/ParenthesesAsGroupedExpression
21   Style/RegexpLiteral
4    Style/GlobalVars
2    RSpec/MultipleExpectations
1    Lint/RescueException
1    Lint/UselessAssignment
1    Style/AccessorMethodName
1    Style/GuardClause
--
131  Total
```