### PR TITLE
Update `apt` and `stdlib` dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,16 +8,25 @@
   "project_page": "http://arioch.github.io/puppet-redis/",
   "issues_url": "https://github.com/arioch/puppet-redis/issues",
   "dependencies": [
-    {"name":"puppetlabs/apt","version_requirement":">= 2.3.0 <6.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.2 <5.0.0"},
-    {"name":"stahnma/epel","version_requirement":">= 1.2.2 <2.0.0"},
+    {
+      "name":"puppetlabs/apt",
+      "version_requirement":">= 2.3.0 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.25.0 < 6.0.0"
+    },
+    {
+      "name":"stahnma/epel",
+      "version_requirement":">= 1.2.2 < 2.0.0"
+    },
     {
       "name": "herculesteam/augeasproviders_sysctl",
-      "version_requirement": ">=2.1.0 < 3.0.0"
+      "version_requirement": ">= 2.1.0 < 3.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_core",
-      "version_requirement": ">=2.1.0 < 3.0.0"
+      "version_requirement": ">= 2.1.0 < 3.0.0"
     }
   ],
   "data_provider": null,


### PR DESCRIPTION
* Allow latest `apt` and `stdlib`.
* Increase minimum stdlib version to `4.25.0`
* Reformat dependencies for consistency.