### PR TITLE
Drop support for puppet 3 and 4

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,6 +29,12 @@
     "redis",
     "sentinel"
   ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 5.5.8 < 7.0.0"
+    }
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",


### PR DESCRIPTION
The next release of this module was always going to drop puppet 3
support.  At Vox Pupuli, we also no longer officially support puppet 4
and won't be testing against it.