### PR TITLE
stop managing RUNDIR from the init script

### DIFF
--- a/templates/service_templates/redis.Debian.erb
+++ b/templates/service_templates/redis.Debian.erb
@@ -47,10 +47,8 @@ Run_parts () {
 case "$1" in
   start)
   echo -n "Starting $DESC: "
-  mkdir -p $RUNDIR
   touch $PIDFILE
-  chown redis:redis $RUNDIR $PIDFILE
-  chmod 755 $RUNDIR
+  chown redis:redis $PIDFILE
 
   if [ -n "$ULIMIT" ]
   then


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Stop managing RUNDIR from the init script on Debian. Init script on Debian runs chmod 755 $RUNDIR, but puppet module may set this permissions to 775, so the redis instance is restarted on every Puppet run.

#### This Pull Request (PR) fixes the following issues
N/A
