### PR TITLE
Support binding to all interfaces

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,16 @@
 #     slaveof => '10.0.1.1 6379',
 #   }
 #
+# @example Binding on multiple interfaces
+#   class { 'redis':
+#     bind => ['127.0.0.1', '10.0.0.1', '10.1.0.1'],
+#   }
+#
+# @example Binding on all interfaces
+#   class { 'redis':
+#     bind => [],
+#   }
+#
 # @param [String] activerehashing   Enable/disable active rehashing.
 # @param [String] aof_load_truncated   Enable/disable loading truncated AOF file
 # @param [String] aof_rewrite_incremental_fsync   Enable/disable fsync for AOF file
@@ -17,7 +27,7 @@
 # @param [String] appendonly   Enable/disable appendonly mode.
 # @param [String] auto_aof_rewrite_min_size   Adjust minimum size for auto-aof-rewrite.
 # @param [String] auto_aof_rewrite_percentage   Adjust percentatge for auto-aof-rewrite.
-# @param [String] bind   Configure which IP address to listen on.
+# @param bind Configure which IP address(es) to listen on. To bind on all interfaces, use an empty array.
 # @param [String] config_dir   Directory containing the configuration files.
 # @param [String] config_dir_mode   Adjust mode for directory containing configuration files.
 # @param [String] config_file_orig   The location and name of a config file that provides the source
@@ -143,7 +153,7 @@ class redis (
   $appendonly                    = $::redis::params::appendonly,
   $auto_aof_rewrite_min_size     = $::redis::params::auto_aof_rewrite_min_size,
   $auto_aof_rewrite_percentage   = $::redis::params::auto_aof_rewrite_percentage,
-  $bind                          = $::redis::params::bind,
+  Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]] $bind = $::redis::params::bind,
   $output_buffer_limit_slave     = $::redis::params::output_buffer_limit_slave,
   $output_buffer_limit_pubsub    = $::redis::params::output_buffer_limit_pubsub,
   $conf_template                 = $::redis::params::conf_template,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,7 @@ class redis::params {
   $appendonly                      = false
   $auto_aof_rewrite_min_size       = '64mb'
   $auto_aof_rewrite_percentage     = 100
-  $bind                            = '127.0.0.1'
+  $bind                            = ['127.0.0.1']
   $output_buffer_limit_slave       = '256mb 64mb 60'
   $output_buffer_limit_pubsub      = '32mb 8mb 60'
   $conf_template                   = 'redis/redis.conf.erb'
@@ -61,6 +61,7 @@ class redis::params {
   $sentinel_parallel_sync          = 1
   $sentinel_port                   = 26379
   $sentinel_quorum                 = 2
+  $sentinel_redis_host             = '127.0.0.1'
   $sentinel_service_name           = 'redis-sentinel'
   $sentinel_working_dir            = '/tmp'
   $sentinel_init_template          = 'redis/redis-sentinel.init.erb'

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -178,7 +178,7 @@ class redis::sentinel (
   $log_level              = $::redis::params::log_level,
   $log_file               = $::redis::params::log_file,
   $master_name            = $::redis::params::sentinel_master_name,
-  $redis_host             = $::redis::params::bind,
+  Stdlib::Host $redis_host = $::redis::params::sentinel_redis_host,
   $redis_port             = $::redis::params::port,
   $package_name           = $::redis::params::sentinel_package_name,
   $package_ensure         = $::redis::params::sentinel_package_ensure,

--- a/templates/redis.conf.2.4.10.erb
+++ b/templates/redis.conf.2.4.10.erb
@@ -24,10 +24,12 @@ pidfile <%= @pid_file %>
 # If port 0 is specified Redis will not listen on a TCP socket.
 port <%= @port %>
 
+<% unless @bind_arr.empty? -%>
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
 #
-bind <%= @bind %>
+bind <%= @bind_arr.join(' ') %>
+<% end -%>
 
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen

--- a/templates/redis.conf.2.8.erb
+++ b/templates/redis.conf.2.8.erb
@@ -63,6 +63,7 @@ port <%= @port %>
 tcp-backlog <%= @tcp_backlog %>
 <% end -%>
 
+<% unless @bind_arr.empty? -%>
 # By default Redis listens for connections from all the network interfaces
 # available on the server. It is possible to listen to just one or multiple
 # interfaces using the "bind" configuration directive, followed by one or
@@ -72,7 +73,8 @@ tcp-backlog <%= @tcp_backlog %>
 #
 # bind 192.168.1.100 10.0.0.1
 # bind 127.0.0.1
-bind <%= @bind %>
+bind <%= @bind_arr.join(' ') %>
+<% end -%>
 
 # Specify the path for the Unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen

--- a/templates/redis.conf.3.2.erb
+++ b/templates/redis.conf.3.2.erb
@@ -52,10 +52,13 @@ port <%= @port %>
 # in order to get the desired effect.
 tcp-backlog <%= @tcp_backlog %>
 
-# If you want you can bind a single interface, if the bind option is not
-# specified all the interfaces will listen for incoming connections.
-#
-bind <%= @bind %>
+<% unless @bind_arr.empty? -%>
+# By default, if no "bind" configuration directive is specified, Redis listens
+# for connections from all the network interfaces available on the server.
+# It is possible to listen to just one or multiple selected interfaces using
+# the "bind" configuration directive, followed by one or more IP addresses.
+bind <%= @bind_arr.join(' ') %>
+<% end -%>
 
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -33,10 +33,12 @@ port <%= @port %>
 # in order to get the desired effect.
 tcp-backlog <%= @tcp_backlog %>
 
+<% unless @bind_arr.empty? -%>
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
 #
-bind <%= @bind %>
+bind <%= @bind_arr.join(' ') %>
+<% end -%>
 
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen


### PR DESCRIPTION
`bind` now takes an array (of IP addresses).
To bind to all interfaces, use `bind => []`.

Due to the new parameter validation, if you were previously using a
single string to specify multiple IP addresses, you will need to change
this to an array.

Fixes #257
Fixes #60