### PR TITLE
Add service_enable parameter to sentinel.pp

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -195,7 +195,7 @@ class redis::sentinel (
   $service_group          = $::redis::params::service_group,
   $service_name           = $::redis::params::sentinel_service_name,
   $service_ensure         = $::redis::params::service_ensure,
-  $service_enable         = $::redis::params::service_enable,
+  Boolean $service_enable = $::redis::params::service_enable,
   $service_user           = $::redis::params::service_user,
   $working_dir            = $::redis::params::sentinel_working_dir,
   $notification_script    = $::redis::params::sentinel_notification_script,

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -137,6 +137,11 @@
 #
 #   Default: redis
 #
+# [*service_enable*]
+#   Enable the service at boot time.
+#
+#   Default: true
+#
 # [*working_dir*]
 #   The directory into which sentinel will change to avoid mount
 #   conflicts.
@@ -190,6 +195,7 @@ class redis::sentinel (
   $service_group          = $::redis::params::service_group,
   $service_name           = $::redis::params::sentinel_service_name,
   $service_ensure         = $::redis::params::service_ensure,
+  $service_enable         = $::redis::params::service_enable,
   $service_user           = $::redis::params::service_user,
   $working_dir            = $::redis::params::sentinel_working_dir,
   $notification_script    = $::redis::params::sentinel_notification_script,
@@ -253,7 +259,7 @@ class redis::sentinel (
 
   service { $service_name:
     ensure     => $service_ensure,
-    enable     => $::redis::params::service_enable,
+    enable     => $service_enable,
     hasrestart => $::redis::params::service_hasrestart,
     hasstatus  => $::redis::params::service_hasstatus,
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Add service_enable parameter to sentinel.pp so that the state of sentinel on boot can be controlled independently of redis.


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
