### PR TITLE
Fix default service filename for systemd

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -180,6 +180,7 @@ class redis (
   Stdlib::Filemode $log_dir_mode = $::redis::params::log_dir_mode,
   Stdlib::Absolutepath $log_file = $::redis::params::log_file,
   $log_level                     = $::redis::params::log_level,
+  Boolean $manage_service_file   = $::redis::params::manage_service_file,
   Boolean $manage_package        = $::redis::params::manage_package,
   Boolean $manage_repo           = $::redis::params::manage_repo,
   $masterauth                    = $::redis::params::masterauth,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -217,6 +217,7 @@ define redis::instance(
 ) {
 
   if $title == 'default' {
+    $redis_server_name = $::redis::service_name
     $redis_file_name_orig = $config_file_orig
     $redis_file_name      = $config_file
   } else {

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -1191,6 +1191,31 @@ describe 'redis', type: :class do
           )
         }
       end
+
+      describe 'with parameter manage_service_file' do
+        if facts[:operatingsystem] == 'Archlinux'
+          let(:params) do
+            {
+              manage_service_file: true,
+              service_provider: 'systemd'
+            }
+          end
+
+          it {
+            is_expected.to contain_file("/etc/systemd/system/#{service_name}.service")
+          }
+        else
+          let(:params) do
+            {
+              manage_service_file: true
+            }
+          end
+
+          it {
+            is_expected.to contain_file("/etc/init.d/#{service_name}")
+          }
+        end
+      end
     end
   end
 end

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -26,6 +26,12 @@ describe 'redis::instance', type: :define do
         it { is_expected.to contain_service('redis-server-app2').with_enable('true') }
         it { is_expected.to contain_file('/etc/init.d/redis-server-app2').with_content(%r{DAEMON_ARGS=/etc/redis/redis-server-app2\.conf}) }
         it { is_expected.to contain_file('/etc/init.d/redis-server-app2').with_content(%r{PIDFILE=/var/run/redis/redis-server-app2\.pid}) }
+
+        context 'with default title' do
+          let(:title) { 'default' }
+
+          it { is_expected.to contain_file("/etc/init.d/#{manifest_vars[:service_name]}").with_content(%r{DAEMON_ARGS=/etc/redis/redis.conf}) }
+        end
       end
       context '16.04' do
         let(:facts) do
@@ -40,6 +46,12 @@ describe 'redis::instance', type: :define do
         it { is_expected.to contain_service('redis-server-app2').with_ensure('running') }
         it { is_expected.to contain_service('redis-server-app2').with_enable('true') }
         it { is_expected.to contain_file('/etc/systemd/system/redis-server-app2.service').with_content(%r{ExecStart=/usr/bin/redis-server /etc/redis/redis-server-app2\.conf}) }
+
+        context 'with default title' do
+          let(:title) { 'default' }
+
+          it { is_expected.to contain_file("/etc/systemd/system/#{manifest_vars[:service_name]}.service").with_content(%r{ExecStart=/usr/bin/redis-server /etc/redis/redis.conf}) }
+        end
       end
     end
     context 'on CentOS systems' do
@@ -57,6 +69,12 @@ describe 'redis::instance', type: :define do
         it { is_expected.to contain_service('redis-server-app2').with_enable('true') }
         it { is_expected.to contain_file('/etc/init.d/redis-server-app2').with_content(%r{REDIS_CONFIG="/etc/redis-server-app2\.conf"}) }
         it { is_expected.to contain_file('/etc/init.d/redis-server-app2').with_content(%r{pidfile="/var/run/redis/redis-server-app2\.pid"}) }
+
+        context 'with default title' do
+          let(:title) { 'default' }
+
+          it { is_expected.to contain_file("/etc/init.d/#{manifest_vars[:service_name]}").with_content(%r{REDIS_CONFIG="/etc/redis.conf"}) }
+        end
       end
       context '7' do
         let(:facts) do
@@ -71,6 +89,12 @@ describe 'redis::instance', type: :define do
         it { is_expected.to contain_service('redis-server-app2').with_ensure('running') }
         it { is_expected.to contain_service('redis-server-app2').with_enable('true') }
         it { is_expected.to contain_file('/etc/systemd/system/redis-server-app2.service').with_content(%r{ExecStart=/usr/bin/redis-server /etc/redis-server-app2\.conf}) }
+
+        context 'with default title' do
+          let(:title) { 'default' }
+
+          it { is_expected.to contain_file("/etc/systemd/system/#{manifest_vars[:service_name]}.service").with_content(%r{ExecStart=/usr/bin/redis-server /etc/redis.conf}) }
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,12 +76,17 @@ def manifest_vars
   vars
 end
 
-def centos_facts
-  {
-    operatingsystem: 'CentOS',
-    osfamily: 'RedHat',
-    puppetversion: '4.5.2'
-  }
+def redis_service_file(service_name: manifest_vars[:service_name], service_provider: nil)
+  if service_name != manifest_vars[:service_name]
+    service_name = "#{manifest_vars[:service_name]}-#{service_name}"
+  end
+
+  case service_provider
+  when 'systemd'
+    "/etc/systemd/system/#{service_name}.service"
+  else
+    "/etc/init.d/#{service_name}"
+  end
 end
 
 def debian_facts


### PR DESCRIPTION
#### Pull Request (PR) description
The filename for the systemd default service was incorrectly set
as the variable is undefined.

#### This Pull Request (PR) fixes the following issues
Fixes  #310
