### PR TITLE
Stricter data types

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -15,7 +15,6 @@ _Private Classes_
 
 * `redis::config`: This class provides configuration for Redis.
 * `redis::install`: This class installs the application.
-* `redis::instances` : This class manages multiple instances.
 * `redis::params`: This class provides a number of parameters.
 * `redis::preinstall`: Provides anything required by the install class, such as package
 repositories.
@@ -32,6 +31,7 @@ repositories.
 
 **Data types**
 
+* [`Redis::LogLevel`](#redisloglevel): Specify the server verbosity level.
 * [`Redis::RedisUrl`](#redisredisurl): 
 
 **Tasks**
@@ -83,67 +83,67 @@ The following parameters are available in the `redis` class.
 
 ##### `activerehashing`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable active rehashing.
 
-Default value: $redis::params::activerehashing
+Default value: `true`
 
 ##### `aof_load_truncated`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable loading truncated AOF file
 
-Default value: $redis::params::aof_load_truncated
+Default value: `true`
 
 ##### `aof_rewrite_incremental_fsync`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable fsync for AOF file
 
-Default value: $redis::params::aof_rewrite_incremental_fsync
+Default value: `true`
 
 ##### `appendfilename`
 
-Data type: `String`
+Data type: `String[1]`
 
 The name of the append only file
 
-Default value: $redis::params::appendfilename
+Default value: 'appendonly.aof'
 
 ##### `appendfsync`
 
 Data type: `Enum['no', 'always', 'everysec']`
 
-Adjust fsync mode. Default: `everysec`
+Adjust fsync mode
 
-Default value: $redis::params::appendfsync
+Default value: 'everysec'
 
 ##### `appendonly`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable appendonly mode.
 
-Default value: $redis::params::appendonly
+Default value: `false`
 
 ##### `auto_aof_rewrite_min_size`
 
-Data type: `String`
+Data type: `String[1]`
 
 Adjust minimum size for auto-aof-rewrite.
 
-Default value: $redis::params::auto_aof_rewrite_min_size
+Default value: '64mb'
 
 ##### `auto_aof_rewrite_percentage`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Adjust percentatge for auto-aof-rewrite.
 
-Default value: $redis::params::auto_aof_rewrite_percentage
+Default value: 100
 
 ##### `bind`
 
@@ -151,7 +151,7 @@ Data type: `Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]]`
 
 Configure which IP address(es) to listen on. To bind on all interfaces, use an empty array.
 
-Default value: $redis::params::bind
+Default value: ['127.0.0.1']
 
 ##### `config_dir`
 
@@ -171,7 +171,7 @@ Default value: $redis::params::config_dir_mode
 
 ##### `config_file_orig`
 
-Data type: `String`
+Data type: `Stdlib::Absolutepath`
 
 The location and name of a config file that provides the source
 
@@ -179,7 +179,7 @@ Default value: $redis::params::config_file_orig
 
 ##### `config_file`
 
-Data type: `String`
+Data type: `Stdlib::Absolutepath`
 
 Adjust main configuration file.
 
@@ -191,11 +191,11 @@ Data type: `Stdlib::Filemode`
 
 Adjust permissions for configuration files.
 
-Default value: $redis::params::config_file_mode
+Default value: '0644'
 
 ##### `config_group`
 
-Data type: `String`
+Data type: `String[1]`
 
 Adjust filesystem group for config files.
 
@@ -203,7 +203,7 @@ Default value: $redis::params::config_group
 
 ##### `config_owner`
 
-Data type: `String`
+Data type: `String[1]`
 
 Adjust filesystem owner for config files.
 
@@ -211,19 +211,19 @@ Default value: $redis::params::config_owner
 
 ##### `conf_template`
 
-Data type: `String`
+Data type: `String[1]`
 
 Define which template to use.
 
-Default value: $redis::params::conf_template
+Default value: 'redis/redis.conf.erb'
 
 ##### `daemonize`
 
-Data type: `String`
+Data type: `Boolean`
 
 Have Redis run as a daemon.
 
-Default value: $redis::params::daemonize
+Default value: `true`
 
 ##### `default_install`
 
@@ -231,87 +231,87 @@ Data type: `Boolean`
 
 Configure a default install of redis.
 
-Default value: $redis::params::default_install
+Default value: `true`
 
 ##### `databases`
 
-Data type: `String`
+Data type: `Integer[1]`
 
 Set the number of databases.
 
-Default value: $redis::params::databases
+Default value: 16
 
 ##### `dbfilename`
 
-Data type: `String`
+Data type: `Variant[String[1], Boolean]`
 
 The filename where to dump the DB
 
-Default value: $redis::params::dbfilename
+Default value: 'dump.rdb'
 
 ##### `extra_config_file`
 
-Data type: `String`
+Data type: `Optional[String]`
 
-Description
+Optional extra config file to include
 
-Default value: $redis::params::extra_config_file
+Default value: `undef`
 
 ##### `hash_max_ziplist_entries`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max ziplist entries for hashes.
 
-Default value: $redis::params::hash_max_ziplist_entries
+Default value: 512
 
 ##### `hash_max_ziplist_value`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max ziplist values for hashes.
 
-Default value: $redis::params::hash_max_ziplist_value
+Default value: 64
 
 ##### `hll_sparse_max_bytes`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 HyperLogLog sparse representation bytes limit
 
-Default value: $redis::params::hll_sparse_max_bytes
+Default value: 3000
 
 ##### `hz`
 
-Data type: `String`
+Data type: `Integer[1, 500]`
 
 Set redis background tasks frequency
 
-Default value: $redis::params::hz
+Default value: 10
 
 ##### `latency_monitor_threshold`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Latency monitoring threshold in milliseconds
 
-Default value: $redis::params::latency_monitor_threshold
+Default value: 0
 
 ##### `list_max_ziplist_entries`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max ziplist entries for lists.
 
-Default value: $redis::params::list_max_ziplist_entries
+Default value: 512
 
 ##### `list_max_ziplist_value`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max ziplist values for lists.
 
-Default value: $redis::params::list_max_ziplist_value
+Default value: 64
 
 ##### `log_dir`
 
@@ -319,7 +319,7 @@ Data type: `Stdlib::Absolutepath`
 
 Specify directory where to write log entries.
 
-Default value: $redis::params::log_dir
+Default value: '/var/log/redis'
 
 ##### `log_dir_mode`
 
@@ -335,15 +335,15 @@ Data type: `Stdlib::Absolutepath`
 
 Specify file where to write log entries.
 
-Default value: $redis::params::log_file
+Default value: '/var/log/redis/redis.log'
 
 ##### `log_level`
 
-Data type: `String`
+Data type: `Redis::LogLevel`
 
 Specify the server verbosity level.
 
-Default value: $redis::params::log_level
+Default value: 'notice'
 
 ##### `manage_repo`
 
@@ -351,7 +351,7 @@ Data type: `Boolean`
 
 Enable/disable upstream repository configuration.
 
-Default value: $redis::params::manage_repo
+Default value: `false`
 
 ##### `manage_package`
 
@@ -359,107 +359,107 @@ Data type: `Boolean`
 
 Enable/disable management of package
 
-Default value: $redis::params::manage_package
+Default value: `true`
 
 ##### `managed_by_cluster_manager`
 
-Data type: `String`
+Data type: `Boolean`
 
 Choose if redis will be managed by a cluster manager such as pacemaker or rgmanager
 
-Default value: $redis::params::managed_by_cluster_manager
+Default value: `false`
 
 ##### `masterauth`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
 If the master is password protected (using the "requirepass" configuration
 
-Default value: $redis::params::masterauth
+Default value: `undef`
 
 ##### `maxclients`
 
-Data type: `String`
+Data type: `Integer[1]`
 
 Set the max number of connected clients at the same time.
 
-Default value: $redis::params::maxclients
+Default value: 10000
 
 ##### `maxmemory`
 
-Data type: `String`
+Data type: `Any`
 
 Don't use more memory than the specified amount of bytes.
 
-Default value: $redis::params::maxmemory
+Default value: `undef`
 
 ##### `maxmemory_policy`
 
-Data type: `String`
+Data type: `Any`
 
 How Redis will select what to remove when maxmemory is reached.
 
-Default value: $redis::params::maxmemory_policy
+Default value: `undef`
 
 ##### `maxmemory_samples`
 
-Data type: `String`
+Data type: `Any`
 
 Select as well the sample size to check.
 
-Default value: $redis::params::maxmemory_samples
+Default value: `undef`
 
 ##### `min_slaves_max_lag`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 The lag in seconds
 
-Default value: $redis::params::min_slaves_max_lag
+Default value: 10
 
 ##### `min_slaves_to_write`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Minimum number of slaves to be in "online" state
 
-Default value: $redis::params::min_slaves_to_write
+Default value: 0
 
 ##### `no_appendfsync_on_rewrite`
 
-Data type: `String`
+Data type: `Boolean`
 
 If you have latency problems turn this to 'true'. Otherwise leave it as
 
-Default value: $redis::params::no_appendfsync_on_rewrite
+Default value: `false`
 
 ##### `notify_keyspace_events`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
 Which events to notify Pub/Sub clients about events happening
 
-Default value: $redis::params::notify_keyspace_events
+Default value: `undef`
 
 ##### `notify_service`
 
-Data type: `String`
+Data type: `Boolean`
 
 You may disable service reloads when config files change if you
 
-Default value: $redis::params::notify_service
+Default value: `true`
 
 ##### `package_ensure`
 
-Data type: `String`
+Data type: `String[1]`
 
 Default action for package.
 
-Default value: $redis::params::package_ensure
+Default value: 'present'
 
 ##### `package_name`
 
-Data type: `String`
+Data type: `String[1]`
 
 Upstream package name.
 
@@ -467,7 +467,7 @@ Default value: $redis::params::package_name
 
 ##### `pid_file`
 
-Data type: `String`
+Data type: `Stdlib::Absolutepath`
 
 Where to store the pid.
 
@@ -475,23 +475,23 @@ Default value: $redis::params::pid_file
 
 ##### `port`
 
-Data type: `Stdlib::Port`
+Data type: `Stdlib::Port::Unprivileged`
 
 Configure which port to listen on.
 
-Default value: $redis::params::port
+Default value: 6379
 
 ##### `protected_mode`
 
-Data type: `String`
+Data type: `Boolean`
 
 Whether protected mode is enabled or not.  Only applicable when no bind is set.
 
-Default value: $redis::params::protected_mode
+Default value: `true`
 
 ##### `ppa_repo`
 
-Data type: `String`
+Data type: `Optional[String]`
 
 Specify upstream (Ubuntu) PPA entry.
 
@@ -499,35 +499,35 @@ Default value: $redis::params::ppa_repo
 
 ##### `rdbcompression`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable compression of string objects using LZF when dumping.
 
-Default value: $redis::params::rdbcompression
+Default value: `true`
 
 ##### `repl_backlog_size`
 
-Data type: `String`
+Data type: `String[1]`
 
 The replication backlog size
 
-Default value: $redis::params::repl_backlog_size
+Default value: '1mb'
 
 ##### `repl_backlog_ttl`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 The number of seconds to elapse before freeing backlog buffer
 
-Default value: $redis::params::repl_backlog_ttl
+Default value: 3600
 
 ##### `repl_disable_tcp_nodelay`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable TCP_NODELAY on the slave socket after SYNC
 
-Default value: $redis::params::repl_disable_tcp_nodelay
+Default value: `false`
 
 ##### `repl_ping_slave_period`
 
@@ -535,40 +535,39 @@ Data type: `Integer[1]`
 
 Slaves send PINGs to server in a predefined interval. It's possible
 
-Default value: $redis::params::repl_ping_slave_period
+Default value: 10
 
 ##### `repl_timeout`
 
-Data type: `String`
+Data type: `Integer[1]`
 
 Set the replication timeout for:
 
-Default value: $redis::params::repl_timeout
+Default value: 60
 
 ##### `requirepass`
 
-Data type: `String`
+Data type: `Optional[String]`
 
-Require clients to issue AUTH <PASSWORD> before processing any
-other commands.
+Require clients to issue AUTH <PASSWORD> before processing any other commands.
 
-Default value: $redis::params::requirepass
+Default value: `undef`
 
 ##### `save_db_to_disk`
 
-Data type: `String`
+Data type: `Boolean`
 
 Set if save db to disk.
 
-Default value: $redis::params::save_db_to_disk
+Default value: `true`
 
 ##### `save_db_to_disk_interval`
 
-Data type: `String`
+Data type: `Hash`
 
 save the dataset every N seconds if there are at least M changes in the dataset
 
-Default value: $redis::params::save_db_to_disk_interval
+Default value: {'900' =>'1', '300' => '10', '60' => '10000'}
 
 ##### `service_manage`
 
@@ -576,27 +575,27 @@ Data type: `Boolean`
 
 Specify if the service should be part of the catalog.
 
-Default value: $redis::params::service_manage
+Default value: `true`
 
 ##### `service_enable`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable daemon at boot.
 
-Default value: $redis::params::service_enable
+Default value: `true`
 
 ##### `service_ensure`
 
-Data type: `String`
+Data type: `Stdlib::Ensure::Service`
 
 Specify if the server should be running.
 
-Default value: $redis::params::service_ensure
+Default value: 'running'
 
 ##### `service_group`
 
-Data type: `String`
+Data type: `String[1]`
 
 Specify which group to run as.
 
@@ -604,23 +603,23 @@ Default value: $redis::params::service_group
 
 ##### `service_hasrestart`
 
-Data type: `String`
+Data type: `Boolean`
 
 Does the init script support restart?
 
-Default value: $redis::params::service_hasrestart
+Default value: `true`
 
 ##### `service_hasstatus`
 
-Data type: `String`
+Data type: `Boolean`
 
 Does the init script support status?
 
-Default value: $redis::params::service_hasstatus
+Default value: `true`
 
 ##### `service_name`
 
-Data type: `String`
+Data type: `String[1]`
 
 Specify the service name for Init or Systemd.
 
@@ -628,167 +627,158 @@ Default value: $redis::params::service_name
 
 ##### `service_provider`
 
-Data type: `String`
+Data type: `Optional[String]`
 
 Specify the service provider to use
 
-Default value: $redis::params::service_provider
+Default value: `undef`
 
 ##### `service_user`
 
-Data type: `String`
+Data type: `String[1]`
 
 Specify which user to run as.
 
-Default value: $redis::params::service_user
+Default value: 'redis'
 
 ##### `set_max_intset_entries`
 
-Data type: `String`
+Data type: `Integer[0]`
 
-The following configuration setting sets the limit in the size of the
-set in order to use this special memory saving encoding.
-Default: 512
+The following configuration setting sets the limit in the size of the set
+in order to use this special memory saving encoding.
 
-Default value: $redis::params::set_max_intset_entries
+Default value: 512
 
 ##### `slave_priority`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 The priority number for slave promotion by Sentinel
 
-Default value: $redis::params::slave_priority
+Default value: 100
 
 ##### `slave_read_only`
 
-Data type: `String`
+Data type: `Boolean`
 
 You can configure a slave instance to accept writes or not.
 
-Default value: $redis::params::slave_read_only
+Default value: `true`
 
 ##### `slave_serve_stale_data`
 
-Data type: `String`
+Data type: `Boolean`
 
 When a slave loses its connection with the master, or when the replication
 is still in progress, the slave can act in two different ways:
 1) if slave-serve-stale-data is set to 'yes' (the default) the slave will
    still reply to client requests, possibly with out of date data, or the
    data set may just be empty if this is the first synchronization.
-
 2) if slave-serve-stale-data is set to 'no' the slave will reply with
    an error "SYNC with master in progress" to all the kind of commands
    but to INFO and SLAVEOF.
 
-Default: true
-
-Default value: $redis::params::slave_serve_stale_data
+Default value: `true`
 
 ##### `slaveof`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
 Use slaveof to make a Redis instance a copy of another Redis server.
 
-Default value: $redis::params::slaveof
+Default value: `undef`
 
 ##### `slowlog_log_slower_than`
 
-Data type: `String`
+Data type: `Integer[0]`
 
-Tells Redis what is the execution time, in microseconds, to exceed
-in order for the command to get logged.
-Default: 10000
+Tells Redis what is the execution time, in microseconds, to exceed in order
+for the command to get logged.
 
-Default value: $redis::params::slowlog_log_slower_than
+Default value: 10000
 
 ##### `slowlog_max_len`
 
-Data type: `String`
+Data type: `Integer[0]`
 
-Tells Redis what is the length to exceed in order for the command
-to get logged.
-Default: 1024
+Tells Redis what is the length to exceed in order for the command to get
+logged.
 
-Default value: $redis::params::slowlog_max_len
+Default value: 1024
 
 ##### `stop_writes_on_bgsave_error`
 
-Data type: `String`
+Data type: `Boolean`
 
-If false then Redis will continue to work as usual even if there
-are problems with disk, permissions, and so forth.
-Default: true
+If false then Redis will continue to work as usual even if there are
+problems with disk, permissions, and so forth.
 
-Default value: $redis::params::stop_writes_on_bgsave_error
+Default value: `true`
 
 ##### `syslog_enabled`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable logging to the system logger.
 
-Default value: $redis::params::syslog_enabled
+Default value: `false`
 
 ##### `syslog_facility`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
-Specify the syslog facility.
-Must be USER or between LOCAL0-LOCAL7.
-Default: undef
+Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
 
-Default value: $redis::params::syslog_facility
+Default value: `undef`
 
 ##### `tcp_backlog`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Sets the TCP backlog
 
-Default value: $redis::params::tcp_backlog
+Default value: 511
 
 ##### `tcp_keepalive`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 TCP keepalive.
 
-Default value: $redis::params::tcp_keepalive
+Default value: 0
 
 ##### `timeout`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Close the connection after a client is idle for N seconds (0 to disable).
 
-Default value: $redis::params::timeout
+Default value: 0
 
 ##### `ulimit`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Limit the use of system-wide resources.
 
-Default value: $redis::params::ulimit
+Default value: 65536
 
 ##### `unixsocket`
 
-Data type: `String`
+Data type: `Stdlib::Absolutepath`
 
 Define unix socket path
 
-Default value: $redis::params::unixsocket
+Default value: '/var/run/redis/redis.sock'
 
 ##### `unixsocketperm`
 
-Data type: `String`
+Data type: `Stdlib::Filemode`
 
 Define unix socket file permissions
 
-Default value: $redis::params::unixsocketperm
+Default value: '0755'
 
 ##### `workdir`
 
@@ -796,7 +786,6 @@ Data type: `Stdlib::Absolutepath`
 
 The DB will be written inside this directory, with the filename specified
 above using the 'dbfilename' configuration directive.
-Default: /var/lib/redis/
 
 Default value: $redis::params::workdir
 
@@ -806,23 +795,23 @@ Data type: `Stdlib::Filemode`
 
 Adjust mode for data directory.
 
-Default value: $redis::params::workdir_mode
+Default value: '0750'
 
 ##### `zset_max_ziplist_entries`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max entries for sorted sets.
 
-Default value: $redis::params::zset_max_ziplist_entries
+Default value: 128
 
 ##### `zset_max_ziplist_value`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max values for sorted sets.
 
-Default value: $redis::params::zset_max_ziplist_value
+Default value: 64
 
 ##### `cluster_enabled`
 
@@ -830,27 +819,24 @@ Data type: `Boolean`
 
 Enables redis 3.0 cluster functionality
 
-Default value: $redis::params::cluster_enabled
+Default value: `false`
 
 ##### `cluster_config_file`
 
-Data type: `String`
+Data type: `String[1]`
 
-Config file for saving cluster nodes configuration. This file is never touched by humans.
-Only set if cluster_enabled is true
-Default: nodes.conf
+Config file for saving cluster nodes configuration. This file is never
+touched by humans. Only set if cluster_enabled is true
 
-Default value: $redis::params::cluster_config_file
+Default value: 'nodes.conf'
 
 ##### `cluster_node_timeout`
 
-Data type: `String`
+Data type: `Integer[1]`
 
-Node timeout
-Only set if cluster_enabled is true
-Default: 5000
+Node timeout. Only set if cluster_enabled is true
 
-Default value: $redis::params::cluster_node_timeout
+Default value: 5000
 
 ##### `cluster_slave_validity_factor`
 
@@ -858,9 +844,8 @@ Data type: `Integer[0]`
 
 Control variable to disable promoting slave in case of disconnection from master
 Only set if cluster_enabled is true
-Default: 0
 
-Default value: $redis::params::cluster_slave_validity_factor
+Default value: 0
 
 ##### `cluster_require_full_coverage`
 
@@ -868,35 +853,42 @@ Data type: `Boolean`
 
 If false Redis Cluster will server queries even if requests about a subset of keys can be processed
 Only set if cluster_enabled is true
-Default: true
 
-Default value: $redis::params::cluster_require_full_coverage
+Default value: `true`
 
 ##### `cluster_migration_barrier`
 
 Data type: `Integer[0]`
 
-Minimum number of slaves master will remain connected with, for another slave to migrate to a  master which is no longer covered by any slave
+Minimum number of slaves master will remain connected with, for another
+slave to migrate to a master which is no longer covered by any slave.
 Only set if cluster_enabled is true
-Default: 1
 
-Default value: $redis::params::cluster_migration_barrier
+Default value: 1
+
+##### `instances`
+
+Data type: `Hash[String[1], Hash]`
+
+Iterate through multiple instance configurations
+
+Default value: {}
 
 ##### `output_buffer_limit_slave`
 
-Data type: `Any`
+Data type: `String[1]`
 
 
 
-Default value: $redis::params::output_buffer_limit_slave
+Default value: '256mb 64mb 60'
 
 ##### `output_buffer_limit_pubsub`
 
-Data type: `Any`
+Data type: `String[1]`
 
 
 
-Default value: $redis::params::output_buffer_limit_pubsub
+Default value: '32mb 8mb 60'
 
 ##### `manage_service_file`
 
@@ -904,12 +896,15 @@ Data type: `Boolean`
 
 
 
-Default value: $redis::params::manage_service_file
+Default value: `false`
 
 ### redis::administration
 
 Allows various adminstrative settings for Redis
 As documented in the FAQ and https://redis.io/topics/admin
+
+* **See also**
+https://redis.io/topics/admin
 
 #### Examples
 
@@ -935,7 +930,7 @@ The following parameters are available in the `redis::administration` class.
 
 Data type: `Boolean`
 
-Enable the overcommit memory setting (Defaults to true)
+Enable the overcommit memory setting
 
 Default value: `true`
 
@@ -943,17 +938,17 @@ Default value: `true`
 
 Data type: `Boolean`
 
-Disable Transparent Huge Pages (Defaults to true)
+Disable Transparent Huge Pages
 
 Default value: `true`
 
 ##### `somaxconn`
 
-Data type: `String`
+Data type: `Integer[0]`
 
-Set somaxconn value (Defaults to '65535')
+Set somaxconn value
 
-Default value: '65535'
+Default value: 65535
 
 ### redis::sentinel
 
@@ -982,7 +977,7 @@ The following parameters are available in the `redis::sentinel` class.
 
 ##### `auth_pass`
 
-Data type: `Any`
+Data type: `Optional[String[1]]`
 
 The password to use to authenticate with the master and slaves.
 
@@ -990,7 +985,7 @@ Default value: `undef`
 
 ##### `config_file`
 
-Data type: `Any`
+Data type: `Stdlib::Absolutepath`
 
 The location and name of the sentinel config file.
 
@@ -998,7 +993,7 @@ Default value: $redis::params::sentinel_config_file
 
 ##### `config_file_orig`
 
-Data type: `Any`
+Data type: `Stdlib::Absolutepath`
 
 The location and name of a config file that provides the source
 of the sentinel config file. Two different files are needed
@@ -1026,7 +1021,7 @@ Default value: 'redis/redis-sentinel.conf.erb'
 
 ##### `daemonize`
 
-Data type: `Any`
+Data type: `Boolean`
 
 Have Redis sentinel run as a daemon.
 
@@ -1034,7 +1029,7 @@ Default value: $redis::params::sentinel_daemonize
 
 ##### `down_after`
 
-Data type: `Any`
+Data type: `Integer[1]`
 
 Number of milliseconds the master (or any attached slave or sentinel)
 should be unreachable (as in, not acceptable reply to PING, continuously,
@@ -1044,7 +1039,7 @@ Default value: 30000
 
 ##### `failover_timeout`
 
-Data type: `Any`
+Data type: `Integer[1]`
 
 Specify the failover timeout in milliseconds.
 
@@ -1052,7 +1047,7 @@ Default value: 180000
 
 ##### `init_script`
 
-Data type: `Any`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Specifiy the init script that will be created for sentinel.
 
@@ -1060,19 +1055,19 @@ Default value: $redis::params::sentinel_init_script
 
 ##### `log_file`
 
-Data type: `Any`
+Data type: `Stdlib::Absolutepath`
 
 Specify where to write log entries.
 
-Default value: $redis::params::log_file
+Default value: '/var/log/redis/redis.log'
 
 ##### `log_level`
 
-Data type: `Any`
+Data type: `Redis::LogLevel`
 
 Specify how much we should log.
 
-Default value: $redis::params::log_level
+Default value: 'notice'
 
 ##### `master_name`
 
@@ -1093,15 +1088,15 @@ Default value: '127.0.0.1'
 
 ##### `redis_port`
 
-Data type: `Stdlib::Port`
+Data type: `Stdlib::Port::Unprivileged`
 
 Specify the port of the master redis server.
 
-Default value: $redis::params::port
+Default value: 6379
 
 ##### `package_name`
 
-Data type: `Any`
+Data type: `String[1]`
 
 The name of the package that installs sentinel.
 
@@ -1134,7 +1129,7 @@ Default value: '/var/run/redis/redis-sentinel.pid'
 
 ##### `quorum`
 
-Data type: `Integer[0]`
+Data type: `Integer[1]`
 
 Number of sentinels that must agree that a master is down to
 signal sdown state.
@@ -1143,7 +1138,7 @@ Default value: 2
 
 ##### `sentinel_bind`
 
-Data type: `Any`
+Data type: `Variant[Undef, Stdlib::IP::Address, Array[Stdlib::IP::Address]]`
 
 Allow optional sentinel server ip binding.  Can help overcome
 issues arising from protect-mode added Redis 3.2
@@ -1152,7 +1147,7 @@ Default value: `undef`
 
 ##### `sentinel_port`
 
-Data type: `Stdlib::Port`
+Data type: `Stdlib::Port::Unprivileged`
 
 The port of sentinel server.
 
@@ -1160,7 +1155,7 @@ Default value: 26379
 
 ##### `service_group`
 
-Data type: `Any`
+Data type: `String[1]`
 
 The group of the config file.
 
@@ -1174,9 +1169,13 @@ The name of the service (for puppet to manage).
 
 Default value: 'redis-sentinel'
 
-##### `service_owner`
+##### `service_user`
+
+Data type: `String[1]`
 
 The owner of the config file.
+
+Default value: 'redis'
 
 ##### `service_enable`
 
@@ -1184,7 +1183,7 @@ Data type: `Boolean`
 
 Enable the service at boot time.
 
-Default value: $redis::params::service_enable
+Default value: `true`
 
 ##### `working_dir`
 
@@ -1197,7 +1196,7 @@ Default value: '/tmp'
 
 ##### `notification_script`
 
-Data type: `Any`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Path to the notification script
 
@@ -1205,7 +1204,7 @@ Default value: `undef`
 
 ##### `client_reconfig_script`
 
-Data type: `Any`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 Path to the client-reconfig script
 
@@ -1221,19 +1220,11 @@ Default value: 'redis/redis-sentinel.init.erb'
 
 ##### `service_ensure`
 
-Data type: `Any`
+Data type: `Stdlib::Ensure::Service`
 
 
 
-Default value: $redis::params::service_ensure
-
-##### `service_user`
-
-Data type: `Any`
-
-
-
-Default value: $redis::params::service_user
+Default value: 'running'
 
 ## Defined types
 
@@ -1258,7 +1249,7 @@ The following parameters are available in the `redis::instance` defined type.
 
 ##### `activerehashing`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable active rehashing.
 
@@ -1266,7 +1257,7 @@ Default value: $redis::activerehashing
 
 ##### `aof_load_truncated`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable loading truncated AOF file
 
@@ -1274,7 +1265,7 @@ Default value: $redis::aof_load_truncated
 
 ##### `aof_rewrite_incremental_fsync`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable fsync for AOF file
 
@@ -1282,7 +1273,7 @@ Default value: $redis::aof_rewrite_incremental_fsync
 
 ##### `appendfilename`
 
-Data type: `String`
+Data type: `String[1]`
 
 The name of the append only file
 
@@ -1292,13 +1283,13 @@ Default value: $redis::appendfilename
 
 Data type: `Enum['no', 'always', 'everysec']`
 
-Adjust fsync mode. Valid options: always, everysec, no. Default:  everysec
+Adjust fsync mode. Valid options: always, everysec, no.
 
 Default value: $redis::appendfsync
 
 ##### `appendonly`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable appendonly mode.
 
@@ -1306,7 +1297,7 @@ Default value: $redis::appendonly
 
 ##### `auto_aof_rewrite_min_size`
 
-Data type: `String`
+Data type: `String[1]`
 
 Adjust minimum size for auto-aof-rewrite.
 
@@ -1314,7 +1305,7 @@ Default value: $redis::auto_aof_rewrite_min_size
 
 ##### `auto_aof_rewrite_percentage`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Adjust percentatge for auto-aof-rewrite.
 
@@ -1346,7 +1337,7 @@ Default value: $redis::config_dir_mode
 
 ##### `config_file_orig`
 
-Data type: `String`
+Data type: `Stdlib::Absolutepath`
 
 The location and name of a config file that provides the source
 
@@ -1354,7 +1345,7 @@ Default value: $redis::config_file_orig
 
 ##### `config_file`
 
-Data type: `String`
+Data type: `Stdlib::Absolutepath`
 
 Adjust main configuration file.
 
@@ -1370,7 +1361,7 @@ Default value: $redis::config_file_mode
 
 ##### `config_group`
 
-Data type: `String`
+Data type: `String[1]`
 
 Adjust filesystem group for config files.
 
@@ -1378,7 +1369,7 @@ Default value: $redis::config_group
 
 ##### `config_owner`
 
-Data type: `String`
+Data type: `String[1]`
 
 Adjust filesystem owner for config files.
 
@@ -1386,7 +1377,7 @@ Default value: $redis::config_owner
 
 ##### `conf_template`
 
-Data type: `String`
+Data type: `String[1]`
 
 Define which template to use.
 
@@ -1394,7 +1385,7 @@ Default value: $redis::conf_template
 
 ##### `daemonize`
 
-Data type: `String`
+Data type: `Boolean`
 
 Have Redis run as a daemon.
 
@@ -1402,7 +1393,7 @@ Default value: $redis::daemonize
 
 ##### `databases`
 
-Data type: `String`
+Data type: `Integer[1]`
 
 Set the number of databases.
 
@@ -1410,7 +1401,7 @@ Default value: $redis::databases
 
 ##### `dbfilename`
 
-Data type: `String`
+Data type: `Variant[String[1], Boolean]`
 
 The filename where to dump the DB
 
@@ -1418,15 +1409,15 @@ Default value: $redis::dbfilename
 
 ##### `extra_config_file`
 
-Data type: `String`
+Data type: `Optional[String]`
 
-Description
+Optional extra config file to include
 
 Default value: $redis::extra_config_file
 
 ##### `hash_max_ziplist_entries`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max ziplist entries for hashes.
 
@@ -1434,7 +1425,7 @@ Default value: $redis::hash_max_ziplist_entries
 
 ##### `hash_max_ziplist_value`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max ziplist values for hashes.
 
@@ -1442,7 +1433,7 @@ Default value: $redis::hash_max_ziplist_value
 
 ##### `hll_sparse_max_bytes`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 HyperLogLog sparse representation bytes limit
 
@@ -1450,7 +1441,7 @@ Default value: $redis::hll_sparse_max_bytes
 
 ##### `hz`
 
-Data type: `String`
+Data type: `Integer[1, 500]`
 
 Set redis background tasks frequency
 
@@ -1458,7 +1449,7 @@ Default value: $redis::hz
 
 ##### `latency_monitor_threshold`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Latency monitoring threshold in milliseconds
 
@@ -1466,7 +1457,7 @@ Default value: $redis::latency_monitor_threshold
 
 ##### `list_max_ziplist_entries`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max ziplist entries for lists.
 
@@ -1474,7 +1465,7 @@ Default value: $redis::list_max_ziplist_entries
 
 ##### `list_max_ziplist_value`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max ziplist values for lists.
 
@@ -1506,7 +1497,7 @@ Default value: `undef`
 
 ##### `log_level`
 
-Data type: `String`
+Data type: `Redis::LogLevel`
 
 Specify the server verbosity level.
 
@@ -1514,7 +1505,7 @@ Default value: $redis::log_level
 
 ##### `masterauth`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
 If the master is password protected (using the "requirepass" configuration
 
@@ -1522,7 +1513,7 @@ Default value: $redis::masterauth
 
 ##### `maxclients`
 
-Data type: `String`
+Data type: `Integer[1]`
 
 Set the max number of connected clients at the same time.
 
@@ -1530,7 +1521,7 @@ Default value: $redis::maxclients
 
 ##### `maxmemory`
 
-Data type: `String`
+Data type: `Any`
 
 Don't use more memory than the specified amount of bytes.
 
@@ -1538,7 +1529,7 @@ Default value: $redis::maxmemory
 
 ##### `maxmemory_policy`
 
-Data type: `String`
+Data type: `Any`
 
 How Redis will select what to remove when maxmemory is reached.
 
@@ -1546,7 +1537,7 @@ Default value: $redis::maxmemory_policy
 
 ##### `maxmemory_samples`
 
-Data type: `String`
+Data type: `Any`
 
 Select as well the sample size to check.
 
@@ -1554,7 +1545,7 @@ Default value: $redis::maxmemory_samples
 
 ##### `min_slaves_max_lag`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 The lag in seconds
 
@@ -1562,7 +1553,7 @@ Default value: $redis::min_slaves_max_lag
 
 ##### `min_slaves_to_write`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Minimum number of slaves to be in "online" state
 
@@ -1570,7 +1561,7 @@ Default value: $redis::min_slaves_to_write
 
 ##### `no_appendfsync_on_rewrite`
 
-Data type: `String`
+Data type: `Boolean`
 
 If you have latency problems turn this to 'true'. Otherwise leave it as
 
@@ -1578,7 +1569,7 @@ Default value: $redis::no_appendfsync_on_rewrite
 
 ##### `notify_keyspace_events`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
 Which events to notify Pub/Sub clients about events happening
 
@@ -1586,7 +1577,7 @@ Default value: $redis::notify_keyspace_events
 
 ##### `pid_file`
 
-Data type: `String`
+Data type: `Stdlib::Absolutepath`
 
 Where to store the pid.
 
@@ -1594,7 +1585,7 @@ Default value: "/var/run/redis/redis-server-${name}.pid"
 
 ##### `port`
 
-Data type: `Stdlib::Port`
+Data type: `Stdlib::Port::Unprivileged`
 
 Configure which port to listen on.
 
@@ -1602,7 +1593,7 @@ Default value: $redis::port
 
 ##### `protected_mode`
 
-Data type: `String`
+Data type: `Boolean`
 
 Whether protected mode is enabled or not.  Only applicable when no bind is set.
 
@@ -1610,7 +1601,7 @@ Default value: $redis::protected_mode
 
 ##### `rdbcompression`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable compression of string objects using LZF when dumping.
 
@@ -1618,7 +1609,7 @@ Default value: $redis::rdbcompression
 
 ##### `repl_backlog_size`
 
-Data type: `String`
+Data type: `String[1]`
 
 The replication backlog size
 
@@ -1626,7 +1617,7 @@ Default value: $redis::repl_backlog_size
 
 ##### `repl_backlog_ttl`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 The number of seconds to elapse before freeing backlog buffer
 
@@ -1634,7 +1625,7 @@ Default value: $redis::repl_backlog_ttl
 
 ##### `repl_disable_tcp_nodelay`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable TCP_NODELAY on the slave socket after SYNC
 
@@ -1650,7 +1641,7 @@ Default value: $redis::repl_ping_slave_period
 
 ##### `repl_timeout`
 
-Data type: `String`
+Data type: `Integer[1]`
 
 Set the replication timeout for:
 
@@ -1658,16 +1649,16 @@ Default value: $redis::repl_timeout
 
 ##### `requirepass`
 
-Data type: `String`
+Data type: `Optional[String]`
 
-Require clients to issue AUTH <PASSWORD> before processing any
-other commands.
+Require clients to issue AUTH <PASSWORD> before processing any other
+commands.
 
 Default value: $redis::requirepass
 
 ##### `save_db_to_disk`
 
-Data type: `String`
+Data type: `Boolean`
 
 Set if save db to disk.
 
@@ -1675,7 +1666,7 @@ Default value: $redis::save_db_to_disk
 
 ##### `save_db_to_disk_interval`
 
-Data type: `String`
+Data type: `Hash`
 
 save the dataset every N seconds if there are at least M changes in the dataset
 
@@ -1683,7 +1674,7 @@ Default value: $redis::save_db_to_disk_interval
 
 ##### `service_enable`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable daemon at boot.
 
@@ -1691,7 +1682,7 @@ Default value: $redis::service_enable
 
 ##### `service_ensure`
 
-Data type: `String`
+Data type: `Stdlib::Ensure::Service`
 
 Specify if the server should be running.
 
@@ -1699,7 +1690,7 @@ Default value: $redis::service_ensure
 
 ##### `service_group`
 
-Data type: `String`
+Data type: `String[1]`
 
 Specify which group to run as.
 
@@ -1707,7 +1698,7 @@ Default value: $redis::service_group
 
 ##### `service_hasrestart`
 
-Data type: `String`
+Data type: `Boolean`
 
 Does the init script support restart?
 
@@ -1715,7 +1706,7 @@ Default value: $redis::service_hasrestart
 
 ##### `service_hasstatus`
 
-Data type: `String`
+Data type: `Boolean`
 
 Does the init script support status?
 
@@ -1723,7 +1714,7 @@ Default value: $redis::service_hasstatus
 
 ##### `service_user`
 
-Data type: `String`
+Data type: `String[1]`
 
 Specify which user to run as.
 
@@ -1731,17 +1722,16 @@ Default value: $redis::service_user
 
 ##### `set_max_intset_entries`
 
-Data type: `String`
+Data type: `Integer[0]`
 
-The following configuration setting sets the limit in the size of the
-set in order to use this special memory saving encoding.
-Default: 512
+The following configuration setting sets the limit in the size of the set
+in order to use this special memory saving encoding.
 
 Default value: $redis::set_max_intset_entries
 
 ##### `slave_priority`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 The priority number for slave promotion by Sentinel
 
@@ -1749,7 +1739,7 @@ Default value: $redis::slave_priority
 
 ##### `slave_read_only`
 
-Data type: `String`
+Data type: `Boolean`
 
 You can configure a slave instance to accept writes or not.
 
@@ -1757,25 +1747,22 @@ Default value: $redis::slave_read_only
 
 ##### `slave_serve_stale_data`
 
-Data type: `String`
+Data type: `Boolean`
 
 When a slave loses its connection with the master, or when the replication
 is still in progress, the slave can act in two different ways:
 1) if slave-serve-stale-data is set to 'yes' (the default) the slave will
    still reply to client requests, possibly with out of date data, or the
    data set may just be empty if this is the first synchronization.
-
 2) if slave-serve-stale-data is set to 'no' the slave will reply with
    an error "SYNC with master in progress" to all the kind of commands
    but to INFO and SLAVEOF.
-
-Default: true
 
 Default value: $redis::slave_serve_stale_data
 
 ##### `slaveof`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
 Use slaveof to make a Redis instance a copy of another Redis server.
 
@@ -1783,37 +1770,34 @@ Default value: $redis::slaveof
 
 ##### `slowlog_log_slower_than`
 
-Data type: `String`
+Data type: `Integer[0]`
 
-Tells Redis what is the execution time, in microseconds, to exceed
-in order for the command to get logged.
-Default: 10000
+Tells Redis what is the execution time, in microseconds, to exceed in order
+for the command to get logged.
 
 Default value: $redis::slowlog_log_slower_than
 
 ##### `slowlog_max_len`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Tells Redis what is the length to exceed in order for the command
 to get logged.
-Default: 1024
 
 Default value: $redis::slowlog_max_len
 
 ##### `stop_writes_on_bgsave_error`
 
-Data type: `String`
+Data type: `Boolean`
 
 If false then Redis will continue to work as usual even if there
 are problems with disk, permissions, and so forth.
-Default: true
 
 Default value: $redis::stop_writes_on_bgsave_error
 
 ##### `syslog_enabled`
 
-Data type: `String`
+Data type: `Boolean`
 
 Enable/disable logging to the system logger.
 
@@ -1821,17 +1805,15 @@ Default value: $redis::syslog_enabled
 
 ##### `syslog_facility`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
-Specify the syslog facility.
-Must be USER or between LOCAL0-LOCAL7.
-Default: undef
+Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
 
 Default value: $redis::syslog_facility
 
 ##### `tcp_backlog`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Sets the TCP backlog
 
@@ -1839,7 +1821,7 @@ Default value: $redis::tcp_backlog
 
 ##### `tcp_keepalive`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 TCP keepalive.
 
@@ -1847,7 +1829,7 @@ Default value: $redis::tcp_keepalive
 
 ##### `timeout`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Close the connection after a client is idle for N seconds (0 to disable).
 
@@ -1855,7 +1837,7 @@ Default value: $redis::timeout
 
 ##### `ulimit`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Limit the use of system-wide resources.
 
@@ -1863,7 +1845,7 @@ Default value: $redis::ulimit
 
 ##### `unixsocket`
 
-Data type: `String`
+Data type: `Stdlib::Absolutepath`
 
 Define unix socket path
 
@@ -1871,7 +1853,7 @@ Default value: "/var/run/redis/redis-server-${name}.sock"
 
 ##### `unixsocketperm`
 
-Data type: `String`
+Data type: `Stdlib::Filemode`
 
 Define unix socket file permissions
 
@@ -1883,7 +1865,6 @@ Data type: `Stdlib::Absolutepath`
 
 The DB will be written inside this directory, with the filename specified
 above using the 'dbfilename' configuration directive.
-Default: /var/lib/redis/
 
 Default value: "${redis::workdir}/redis-server-${name}"
 
@@ -1897,7 +1878,7 @@ Default value: $redis::workdir_mode
 
 ##### `zset_max_ziplist_entries`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max entries for sorted sets.
 
@@ -1905,7 +1886,7 @@ Default value: $redis::zset_max_ziplist_entries
 
 ##### `zset_max_ziplist_value`
 
-Data type: `String`
+Data type: `Integer[0]`
 
 Set max values for sorted sets.
 
@@ -1921,21 +1902,18 @@ Default value: $redis::cluster_enabled
 
 ##### `cluster_config_file`
 
-Data type: `String`
+Data type: `String[1]`
 
-Config file for saving cluster nodes configuration. This file is never touched by humans.
-Only set if cluster_enabled is true
-Default: nodes.conf
+Config file for saving cluster nodes configuration. This file is never
+touched by humans.  Only set if cluster_enabled is true
 
 Default value: $redis::cluster_config_file
 
 ##### `cluster_node_timeout`
 
-Data type: `String`
+Data type: `Integer[1]`
 
-Node timeout
-Only set if cluster_enabled is true
-Default: 5000
+Node timeout. Only set if cluster_enabled is true
 
 Default value: $redis::cluster_node_timeout
 
@@ -1943,9 +1921,8 @@ Default value: $redis::cluster_node_timeout
 
 Data type: `Integer[0]`
 
-Control variable to disable promoting slave in case of disconnection from master
-Only set if cluster_enabled is true
-Default: 0
+Control variable to disable promoting slave in case of disconnection from
+master Only set if cluster_enabled is true
 
 Default value: $redis::cluster_slave_validity_factor
 
@@ -1953,9 +1930,8 @@ Default value: $redis::cluster_slave_validity_factor
 
 Data type: `Boolean`
 
-If false Redis Cluster will server queries even if requests about a subset of keys can be processed
-Only set if cluster_enabled is true
-Default: true
+If false Redis Cluster will server queries even if requests about a subset
+of keys can be processed Only set if cluster_enabled is true
 
 Default value: $redis::cluster_require_full_coverage
 
@@ -1963,15 +1939,15 @@ Default value: $redis::cluster_require_full_coverage
 
 Data type: `Integer[0]`
 
-Minimum number of slaves master will remain connected with, for another slave to migrate to a  master which is no longer covered by any slave
-Only set if cluster_enabled is true
-Default: 1
+Minimum number of slaves master will remain connected with, for another
+slave to migrate to a  master which is no longer covered by any slave Only
+set if cluster_enabled is true
 
 Default value: $redis::cluster_migration_barrier
 
 ##### `output_buffer_limit_slave`
 
-Data type: `Any`
+Data type: `String[1]`
 
 
 
@@ -1979,7 +1955,7 @@ Default value: $redis::output_buffer_limit_slave
 
 ##### `output_buffer_limit_pubsub`
 
-Data type: `Any`
+Data type: `String[1]`
 
 
 
@@ -1987,7 +1963,7 @@ Default value: $redis::output_buffer_limit_pubsub
 
 ##### `minimum_version`
 
-Data type: `Any`
+Data type: `String[1]`
 
 
 
@@ -1995,7 +1971,7 @@ Default value: $redis::minimum_version
 
 ##### `managed_by_cluster_manager`
 
-Data type: `Any`
+Data type: `Boolean`
 
 
 
@@ -2003,7 +1979,7 @@ Default value: $redis::managed_by_cluster_manager
 
 ##### `package_ensure`
 
-Data type: `Any`
+Data type: `String[1]`
 
 
 
@@ -2011,7 +1987,7 @@ Default value: $redis::package_ensure
 
 ##### `manage_service_file`
 
-Data type: `Any`
+Data type: `Boolean`
 
 
 
@@ -2070,6 +2046,16 @@ Data type: `Optional[String]`
 The value to return if the key is not found or the connection to Redis fails
 
 ## Data types
+
+### Redis::LogLevel
+
+This can be one of:
+* debug (a lot of information, useful for development/testing)
+* verbose (many rarely useful info, but not a mess like the debug level)
+* notice (moderately verbose, what you want in production probably)
+* warning (only very important / critical messages are logged)
+
+Alias of `Enum['debug', 'verbose', 'notice', 'warning']`
 
 ### Redis::RedisUrl
 

--- a/manifests/administration.pp
+++ b/manifests/administration.pp
@@ -9,16 +9,20 @@
 #     disable_thp => false,
 #   }
 #
-# @param [Boolean] enable_overcommit_memory Enable the overcommit memory setting (Defaults to true)
-# @param [Boolean] disable_thp Disable Transparent Huge Pages (Defaults to true)
-# @param [String] somaxconn Set somaxconn value (Defaults to '65535')
+# @param enable_overcommit_memory
+#   Enable the overcommit memory setting
+# @param disable_thp
+#   Disable Transparent Huge Pages
+# @param somaxconn
+#   Set somaxconn value
 #
 # @author - Peter Souter
+# @see https://redis.io/topics/admin
 #
 class redis::administration(
-  $enable_overcommit_memory = true,
-  $disable_thp              = true,
-  $somaxconn                = '65535',
+  Boolean $enable_overcommit_memory = true,
+  Boolean $disable_thp              = true,
+  Integer[0] $somaxconn             = 65535,
 ) {
 
   if $enable_overcommit_memory {
@@ -37,7 +41,7 @@ class redis::administration(
     }
   }
 
-  if $somaxconn {
+  if $somaxconn > 0 {
     sysctl { 'net.core.somaxconn':
       ensure => 'present',
       value  => $somaxconn,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,241 +19,317 @@
 #     bind => [],
 #   }
 #
-# @param [String] activerehashing   Enable/disable active rehashing.
-# @param [String] aof_load_truncated   Enable/disable loading truncated AOF file
-# @param [String] aof_rewrite_incremental_fsync   Enable/disable fsync for AOF file
-# @param [String] appendfilename   The name of the append only file
-# @param appendfsync Adjust fsync mode. Default: `everysec`
-# @param [String] appendonly   Enable/disable appendonly mode.
-# @param [String] auto_aof_rewrite_min_size   Adjust minimum size for auto-aof-rewrite.
-# @param [String] auto_aof_rewrite_percentage   Adjust percentatge for auto-aof-rewrite.
-# @param bind Configure which IP address(es) to listen on. To bind on all interfaces, use an empty array.
-# @param config_dir Directory containing the configuration files.
-# @param config_dir_mode Adjust mode for directory containing configuration files.
-# @param [String] config_file_orig   The location and name of a config file that provides the source
-# @param [String] config_file   Adjust main configuration file.
-# @param config_file_mode Adjust permissions for configuration files.
-# @param [String] config_group   Adjust filesystem group for config files.
-# @param [String] config_owner   Adjust filesystem owner for config files.
-# @param [String] conf_template   Define which template to use.
-# @param [String] daemonize   Have Redis run as a daemon.
-# @param default_install Configure a default install of redis.
-# @param [String] databases   Set the number of databases.
-# @param [String] dbfilename   The filename where to dump the DB
-# @param [String] extra_config_file   Description
-# @param [String] hash_max_ziplist_entries   Set max ziplist entries for hashes.
-# @param [String] hash_max_ziplist_value   Set max ziplist values for hashes.
-# @param [String] hll_sparse_max_bytes   HyperLogLog sparse representation bytes limit
-# @param [String] hz   Set redis background tasks frequency
-# @param [String] latency_monitor_threshold   Latency monitoring threshold in milliseconds
-# @param [String] list_max_ziplist_entries   Set max ziplist entries for lists.
-# @param [String] list_max_ziplist_value   Set max ziplist values for lists.
-# @param log_dir Specify directory where to write log entries.
-# @param log_dir_mode Adjust mode for directory containing log files.
-# @param log_file Specify file where to write log entries.
-# @param [String] log_level   Specify the server verbosity level.
-# @param manage_repo Enable/disable upstream repository configuration.
-# @param manage_package Enable/disable management of package
-# @param [String] managed_by_cluster_manager Choose if redis will be managed by a cluster manager such as pacemaker or rgmanager
-# @param [String] masterauth   If the master is password protected (using the "requirepass" configuration
-# @param [String] maxclients   Set the max number of connected clients at the same time.
-# @param [String] maxmemory   Don't use more memory than the specified amount of bytes.
-# @param [String] maxmemory_policy   How Redis will select what to remove when maxmemory is reached.
-# @param [String] maxmemory_samples   Select as well the sample size to check.
-# @param [String] min_slaves_max_lag   The lag in seconds
-# @param [String] min_slaves_to_write   Minimum number of slaves to be in "online" state
-# @param [String] no_appendfsync_on_rewrite   If you have latency problems turn this to 'true'. Otherwise leave it as
-# @param [String] notify_keyspace_events   Which events to notify Pub/Sub clients about events happening
-# @param [String] notify_service   You may disable service reloads when config files change if you
-# @param [String] package_ensure   Default action for package.
-# @param [String] package_name   Upstream package name.
-# @param [String] pid_file   Where to store the pid.
-# @param port Configure which port to listen on.
-# @param [String] protected_mode  Whether protected mode is enabled or not.  Only applicable when no bind is set.
-# @param [String] ppa_repo   Specify upstream (Ubuntu) PPA entry.
-# @param [String] rdbcompression   Enable/disable compression of string objects using LZF when dumping.
-# @param [String] repl_backlog_size   The replication backlog size
-# @param [String] repl_backlog_ttl   The number of seconds to elapse before freeing backlog buffer
-# @param [String] repl_disable_tcp_nodelay   Enable/disable TCP_NODELAY on the slave socket after SYNC
-# @param [Integer] repl_ping_slave_period   Slaves send PINGs to server in a predefined interval. It's possible
-# @param [String] repl_timeout   Set the replication timeout for:
-# @param [String] requirepass   Require clients to issue AUTH <PASSWORD> before processing any
-#   other commands.
-# @param [String] save_db_to_disk   Set if save db to disk.
-# @param [String] save_db_to_disk_interval    save the dataset every N seconds if there are at least M changes in the dataset
-# @param service_manage Specify if the service should be part of the catalog.
-# @param [String] service_enable   Enable/disable daemon at boot.
-# @param [String] service_ensure   Specify if the server should be running.
-# @param [String] service_group   Specify which group to run as.
-# @param [String] service_hasrestart   Does the init script support restart?
-# @param [String] service_hasstatus   Does the init script support status?
-# @param [String] service_name   Specify the service name for Init or Systemd.
-# @param [String] service_provider   Specify the service provider to use
-# @param [String] service_user   Specify which user to run as.
-# @param [String] set_max_intset_entries   The following configuration setting sets the limit in the size of the
-#   set in order to use this special memory saving encoding.
-#   Default: 512
-# @param [String] slave_priority   The priority number for slave promotion by Sentinel
-# @param [String] slave_read_only   You can configure a slave instance to accept writes or not.
-# @param [String] slave_serve_stale_data   When a slave loses its connection with the master, or when the replication
+# @param activerehashing
+#   Enable/disable active rehashing.
+# @param aof_load_truncated
+#   Enable/disable loading truncated AOF file
+# @param aof_rewrite_incremental_fsync
+#   Enable/disable fsync for AOF file
+# @param appendfilename
+#   The name of the append only file
+# @param appendfsync
+#   Adjust fsync mode
+# @param appendonly
+#   Enable/disable appendonly mode.
+# @param auto_aof_rewrite_min_size
+#   Adjust minimum size for auto-aof-rewrite.
+# @param auto_aof_rewrite_percentage
+#   Adjust percentatge for auto-aof-rewrite.
+# @param bind
+#   Configure which IP address(es) to listen on. To bind on all interfaces, use an empty array.
+# @param config_dir
+#   Directory containing the configuration files.
+# @param config_dir_mode
+#   Adjust mode for directory containing configuration files.
+# @param config_file_orig
+#   The location and name of a config file that provides the source
+# @param config_file
+#   Adjust main configuration file.
+# @param config_file_mode
+#   Adjust permissions for configuration files.
+# @param config_group
+#   Adjust filesystem group for config files.
+# @param config_owner
+#   Adjust filesystem owner for config files.
+# @param conf_template
+#   Define which template to use.
+# @param daemonize
+#   Have Redis run as a daemon.
+# @param default_install
+#   Configure a default install of redis.
+# @param databases
+#   Set the number of databases.
+# @param dbfilename
+#   The filename where to dump the DB
+# @param extra_config_file
+#   Optional extra config file to include
+# @param hash_max_ziplist_entries
+#   Set max ziplist entries for hashes.
+# @param hash_max_ziplist_value
+#   Set max ziplist values for hashes.
+# @param hll_sparse_max_bytes
+#   HyperLogLog sparse representation bytes limit
+# @param hz
+#   Set redis background tasks frequency
+# @param latency_monitor_threshold
+#   Latency monitoring threshold in milliseconds
+# @param list_max_ziplist_entries
+#   Set max ziplist entries for lists.
+# @param list_max_ziplist_value
+#   Set max ziplist values for lists.
+# @param log_dir
+#   Specify directory where to write log entries.
+# @param log_dir_mode
+#   Adjust mode for directory containing log files.
+# @param log_file
+#   Specify file where to write log entries.
+# @param log_level
+#   Specify the server verbosity level.
+# @param manage_repo
+#   Enable/disable upstream repository configuration.
+# @param manage_package
+#   Enable/disable management of package
+# @param managed_by_cluster_manager
+#   Choose if redis will be managed by a cluster manager such as pacemaker or rgmanager
+# @param masterauth
+#   If the master is password protected (using the "requirepass" configuration
+# @param maxclients
+#   Set the max number of connected clients at the same time.
+# @param maxmemory
+#   Don't use more memory than the specified amount of bytes.
+# @param maxmemory_policy
+#   How Redis will select what to remove when maxmemory is reached.
+# @param maxmemory_samples
+#   Select as well the sample size to check.
+# @param min_slaves_max_lag
+#   The lag in seconds
+# @param min_slaves_to_write
+#   Minimum number of slaves to be in "online" state
+# @param no_appendfsync_on_rewrite
+#   If you have latency problems turn this to 'true'. Otherwise leave it as
+# @param notify_keyspace_events
+#   Which events to notify Pub/Sub clients about events happening
+# @param notify_service
+#   You may disable service reloads when config files change if you
+# @param package_ensure
+#   Default action for package.
+# @param package_name
+#   Upstream package name.
+# @param pid_file
+#   Where to store the pid.
+# @param port
+#   Configure which port to listen on.
+# @param protected_mode
+#   Whether protected mode is enabled or not.  Only applicable when no bind is set.
+# @param ppa_repo
+#   Specify upstream (Ubuntu) PPA entry.
+# @param rdbcompression
+#   Enable/disable compression of string objects using LZF when dumping.
+# @param repl_backlog_size
+#   The replication backlog size
+# @param repl_backlog_ttl
+#   The number of seconds to elapse before freeing backlog buffer
+# @param repl_disable_tcp_nodelay
+#   Enable/disable TCP_NODELAY on the slave socket after SYNC
+# @param repl_ping_slave_period
+#   Slaves send PINGs to server in a predefined interval. It's possible
+# @param repl_timeout
+#   Set the replication timeout for:
+# @param requirepass
+#   Require clients to issue AUTH <PASSWORD> before processing any other commands.
+# @param save_db_to_disk
+#   Set if save db to disk.
+# @param save_db_to_disk_interval
+#   save the dataset every N seconds if there are at least M changes in the dataset
+# @param service_manage
+#   Specify if the service should be part of the catalog.
+# @param service_enable
+#   Enable/disable daemon at boot.
+# @param service_ensure
+#   Specify if the server should be running.
+# @param service_group
+#   Specify which group to run as.
+# @param service_hasrestart
+#   Does the init script support restart?
+# @param service_hasstatus
+#   Does the init script support status?
+# @param service_name
+#   Specify the service name for Init or Systemd.
+# @param service_provider
+#   Specify the service provider to use
+# @param service_user
+#   Specify which user to run as.
+# @param set_max_intset_entries
+#   The following configuration setting sets the limit in the size of the set
+#   in order to use this special memory saving encoding.
+# @param slave_priority
+#   The priority number for slave promotion by Sentinel
+# @param slave_read_only
+#   You can configure a slave instance to accept writes or not.
+# @param slave_serve_stale_data
+#   When a slave loses its connection with the master, or when the replication
 #   is still in progress, the slave can act in two different ways:
 #   1) if slave-serve-stale-data is set to 'yes' (the default) the slave will
 #      still reply to client requests, possibly with out of date data, or the
 #      data set may just be empty if this is the first synchronization.
-#
 #   2) if slave-serve-stale-data is set to 'no' the slave will reply with
 #      an error "SYNC with master in progress" to all the kind of commands
 #      but to INFO and SLAVEOF.
-#
-#   Default: true
-#
-# @param [String] slaveof   Use slaveof to make a Redis instance a copy of another Redis server.
-# @param [String] slowlog_log_slower_than   Tells Redis what is the execution time, in microseconds, to exceed
-#   in order for the command to get logged.
-#   Default: 10000
-#
-# @param [String] slowlog_max_len   Tells Redis what is the length to exceed in order for the command
-#   to get logged.
-#   Default: 1024
-#
-# @param [String] stop_writes_on_bgsave_error   If false then Redis will continue to work as usual even if there
-#   are problems with disk, permissions, and so forth.
-#   Default: true
-#
-# @param [String] syslog_enabled   Enable/disable logging to the system logger.
-# @param [String] syslog_facility   Specify the syslog facility.
-#   Must be USER or between LOCAL0-LOCAL7.
-#   Default: undef
-#
-# @param [String] tcp_backlog   Sets the TCP backlog
-# @param [String] tcp_keepalive   TCP keepalive.
-# @param [String] timeout   Close the connection after a client is idle for N seconds (0 to disable).
-# @param [String] ulimit   Limit the use of system-wide resources.
-# @param [String] unixsocket   Define unix socket path
-# @param [String] unixsocketperm   Define unix socket file permissions
-# @param workdir The DB will be written inside this directory, with the filename specified
+# @param slaveof
+#   Use slaveof to make a Redis instance a copy of another Redis server.
+# @param slowlog_log_slower_than
+#   Tells Redis what is the execution time, in microseconds, to exceed in order
+#   for the command to get logged.
+# @param slowlog_max_len
+#   Tells Redis what is the length to exceed in order for the command to get
+#   logged.
+# @param stop_writes_on_bgsave_error
+#   If false then Redis will continue to work as usual even if there are
+#   problems with disk, permissions, and so forth.
+# @param syslog_enabled
+#   Enable/disable logging to the system logger.
+# @param syslog_facility
+#   Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
+# @param tcp_backlog
+#   Sets the TCP backlog
+# @param tcp_keepalive
+#   TCP keepalive.
+# @param timeout
+#   Close the connection after a client is idle for N seconds (0 to disable).
+# @param ulimit
+#   Limit the use of system-wide resources.
+# @param unixsocket
+#   Define unix socket path
+# @param unixsocketperm
+#   Define unix socket file permissions
+# @param workdir
+#   The DB will be written inside this directory, with the filename specified
 #   above using the 'dbfilename' configuration directive.
-#   Default: /var/lib/redis/
-# @param workdir_mode   Adjust mode for data directory.
-# @param [String] zset_max_ziplist_entries   Set max entries for sorted sets.
-# @param [String] zset_max_ziplist_value   Set max values for sorted sets.
-# @param cluster_enabled Enables redis 3.0 cluster functionality
-# @param [String] cluster_config_file   Config file for saving cluster nodes configuration. This file is never touched by humans.
+# @param workdir_mode
+#   Adjust mode for data directory.
+# @param zset_max_ziplist_entries
+#   Set max entries for sorted sets.
+# @param zset_max_ziplist_value
+#   Set max values for sorted sets.
+# @param cluster_enabled
+#   Enables redis 3.0 cluster functionality
+# @param cluster_config_file
+#   Config file for saving cluster nodes configuration. This file is never
+#   touched by humans. Only set if cluster_enabled is true
+# @param cluster_node_timeout
+#   Node timeout. Only set if cluster_enabled is true
+# @param cluster_slave_validity_factor
+#   Control variable to disable promoting slave in case of disconnection from master
 #   Only set if cluster_enabled is true
-#   Default: nodes.conf
-# @param [String] cluster_node_timeout   Node timeout
+# @param cluster_require_full_coverage
+#   If false Redis Cluster will server queries even if requests about a subset of keys can be processed
 #   Only set if cluster_enabled is true
-#   Default: 5000
-# @param [Integer] cluster_slave_validity_factor   Control variable to disable promoting slave in case of disconnection from master
+# @param cluster_migration_barrier
+#   Minimum number of slaves master will remain connected with, for another
+#   slave to migrate to a master which is no longer covered by any slave.
 #   Only set if cluster_enabled is true
-#   Default: 0
-# @param [Boolean] cluster_require_full_coverage   If false Redis Cluster will server queries even if requests about a subset of keys can be processed
-#   Only set if cluster_enabled is true
-#   Default: true
-# @param [Integer] cluster_migration_barrier    Minimum number of slaves master will remain connected with, for another slave to migrate to a  master which is no longer covered by any slave
-#   Only set if cluster_enabled is true
-#   Default: 1
-# @param [Hash] instances   Iterate through multiple instance configurations
+# @param instances
+#   Iterate through multiple instance configurations
 class redis (
-  $activerehashing                                               = $redis::params::activerehashing,
-  $aof_load_truncated                                            = $redis::params::aof_load_truncated,
-  $aof_rewrite_incremental_fsync                                 = $redis::params::aof_rewrite_incremental_fsync,
-  $appendfilename                                                = $redis::params::appendfilename,
-  Enum['no', 'always', 'everysec'] $appendfsync                  = $redis::params::appendfsync,
-  $appendonly                                                    = $redis::params::appendonly,
-  $auto_aof_rewrite_min_size                                     = $redis::params::auto_aof_rewrite_min_size,
-  $auto_aof_rewrite_percentage                                   = $redis::params::auto_aof_rewrite_percentage,
-  Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]] $bind = $redis::params::bind,
-  $output_buffer_limit_slave                                     = $redis::params::output_buffer_limit_slave,
-  $output_buffer_limit_pubsub                                    = $redis::params::output_buffer_limit_pubsub,
-  $conf_template                                                 = $redis::params::conf_template,
+  Boolean $activerehashing                                       = true,
+  Boolean $aof_load_truncated                                    = true,
+  Boolean $aof_rewrite_incremental_fsync                         = true,
+  String[1] $appendfilename                                      = 'appendonly.aof',
+  Enum['no', 'always', 'everysec'] $appendfsync                  = 'everysec',
+  Boolean $appendonly                                            = false,
+  String[1] $auto_aof_rewrite_min_size                           = '64mb',
+  Integer[0] $auto_aof_rewrite_percentage                        = 100,
+  Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]] $bind = ['127.0.0.1'],
+  String[1] $output_buffer_limit_slave                           = '256mb 64mb 60',
+  String[1] $output_buffer_limit_pubsub                          = '32mb 8mb 60',
+  String[1] $conf_template                                       = 'redis/redis.conf.erb',
   Stdlib::Absolutepath $config_dir                               = $redis::params::config_dir,
   Stdlib::Filemode $config_dir_mode                              = $redis::params::config_dir_mode,
-  $config_file                                                   = $redis::params::config_file,
-  Stdlib::Filemode $config_file_mode                             = $redis::params::config_file_mode,
-  $config_file_orig                                              = $redis::params::config_file_orig,
-  $config_group                                                  = $redis::params::config_group,
-  $config_owner                                                  = $redis::params::config_owner,
-  $daemonize                                                     = $redis::params::daemonize,
-  $databases                                                     = $redis::params::databases,
-  Boolean $default_install                                       = $redis::params::default_install,
-  $dbfilename                                                    = $redis::params::dbfilename,
-  $extra_config_file                                             = $redis::params::extra_config_file,
-  $hash_max_ziplist_entries                                      = $redis::params::hash_max_ziplist_entries,
-  $hash_max_ziplist_value                                        = $redis::params::hash_max_ziplist_value,
-  $hll_sparse_max_bytes                                          = $redis::params::hll_sparse_max_bytes,
-  $hz                                                            = $redis::params::hz,
-  $latency_monitor_threshold                                     = $redis::params::latency_monitor_threshold,
-  $list_max_ziplist_entries                                      = $redis::params::list_max_ziplist_entries,
-  $list_max_ziplist_value                                        = $redis::params::list_max_ziplist_value,
-  Stdlib::Absolutepath $log_dir                                  = $redis::params::log_dir,
+  Stdlib::Absolutepath $config_file                              = $redis::params::config_file,
+  Stdlib::Filemode $config_file_mode                             = '0644',
+  Stdlib::Absolutepath $config_file_orig                         = $redis::params::config_file_orig,
+  String[1] $config_group                                        = $redis::params::config_group,
+  String[1] $config_owner                                        = $redis::params::config_owner,
+  Boolean $daemonize                                             = true,
+  Integer[1] $databases                                          = 16,
+  Boolean $default_install                                       = true,
+  Variant[String[1], Boolean] $dbfilename                        = 'dump.rdb',
+  Optional[String] $extra_config_file                            = undef,
+  Integer[0] $hash_max_ziplist_entries                           = 512,
+  Integer[0] $hash_max_ziplist_value                             = 64,
+  Integer[0] $hll_sparse_max_bytes                               = 3000,
+  Integer[1, 500] $hz                                            = 10,
+  Integer[0] $latency_monitor_threshold                          = 0,
+  Integer[0] $list_max_ziplist_entries                           = 512,
+  Integer[0] $list_max_ziplist_value                             = 64,
+  Stdlib::Absolutepath $log_dir                                  = '/var/log/redis',
   Stdlib::Filemode $log_dir_mode                                 = $redis::params::log_dir_mode,
-  Stdlib::Absolutepath $log_file                                 = $redis::params::log_file,
-  $log_level                                                     = $redis::params::log_level,
-  Boolean $manage_service_file                                   = $redis::params::manage_service_file,
-  Boolean $manage_package                                        = $redis::params::manage_package,
-  Boolean $manage_repo                                           = $redis::params::manage_repo,
-  $masterauth                                                    = $redis::params::masterauth,
-  $maxclients                                                    = $redis::params::maxclients,
-  $maxmemory                                                     = $redis::params::maxmemory,
-  $maxmemory_policy                                              = $redis::params::maxmemory_policy,
-  $maxmemory_samples                                             = $redis::params::maxmemory_samples,
-  $min_slaves_max_lag                                            = $redis::params::min_slaves_max_lag,
-  $min_slaves_to_write                                           = $redis::params::min_slaves_to_write,
-  $no_appendfsync_on_rewrite                                     = $redis::params::no_appendfsync_on_rewrite,
-  $notify_keyspace_events                                        = $redis::params::notify_keyspace_events,
-  $notify_service                                                = $redis::params::notify_service,
-  $managed_by_cluster_manager                                    = $redis::params::managed_by_cluster_manager,
-  $package_ensure                                                = $redis::params::package_ensure,
-  $package_name                                                  = $redis::params::package_name,
-  $pid_file                                                      = $redis::params::pid_file,
-  Stdlib::Port $port                                             = $redis::params::port,
-  $protected_mode                                                = $redis::params::protected_mode,
-  $ppa_repo                                                      = $redis::params::ppa_repo,
-  $rdbcompression                                                = $redis::params::rdbcompression,
-  $repl_backlog_size                                             = $redis::params::repl_backlog_size,
-  $repl_backlog_ttl                                              = $redis::params::repl_backlog_ttl,
-  $repl_disable_tcp_nodelay                                      = $redis::params::repl_disable_tcp_nodelay,
-  Integer[1] $repl_ping_slave_period                             = $redis::params::repl_ping_slave_period,
-  $repl_timeout                                                  = $redis::params::repl_timeout,
-  $requirepass                                                   = $redis::params::requirepass,
-  $save_db_to_disk                                               = $redis::params::save_db_to_disk,
-  $save_db_to_disk_interval                                      = $redis::params::save_db_to_disk_interval,
-  $service_enable                                                = $redis::params::service_enable,
-  $service_ensure                                                = $redis::params::service_ensure,
-  $service_group                                                 = $redis::params::service_group,
-  $service_hasrestart                                            = $redis::params::service_hasrestart,
-  $service_hasstatus                                             = $redis::params::service_hasstatus,
-  Boolean $service_manage                                        = $redis::params::service_manage,
-  $service_name                                                  = $redis::params::service_name,
-  $service_provider                                              = $redis::params::service_provider,
-  $service_user                                                  = $redis::params::service_user,
-  $set_max_intset_entries                                        = $redis::params::set_max_intset_entries,
-  $slave_priority                                                = $redis::params::slave_priority,
-  $slave_read_only                                               = $redis::params::slave_read_only,
-  $slave_serve_stale_data                                        = $redis::params::slave_serve_stale_data,
-  $slaveof                                                       = $redis::params::slaveof,
-  $slowlog_log_slower_than                                       = $redis::params::slowlog_log_slower_than,
-  $slowlog_max_len                                               = $redis::params::slowlog_max_len,
-  $stop_writes_on_bgsave_error                                   = $redis::params::stop_writes_on_bgsave_error,
-  $syslog_enabled                                                = $redis::params::syslog_enabled,
-  $syslog_facility                                               = $redis::params::syslog_facility,
-  $tcp_backlog                                                   = $redis::params::tcp_backlog,
-  $tcp_keepalive                                                 = $redis::params::tcp_keepalive,
-  $timeout                                                       = $redis::params::timeout,
-  $unixsocket                                                    = $redis::params::unixsocket,
-  $unixsocketperm                                                = $redis::params::unixsocketperm,
-  $ulimit                                                        = $redis::params::ulimit,
+  Stdlib::Absolutepath $log_file                                 = '/var/log/redis/redis.log',
+  Redis::LogLevel $log_level                                     = 'notice',
+  Boolean $manage_service_file                                   = false,
+  Boolean $manage_package                                        = true,
+  Boolean $manage_repo                                           = false,
+  Optional[String[1]] $masterauth                                = undef,
+  Integer[1] $maxclients                                         = 10000,
+  $maxmemory                                                     = undef,
+  $maxmemory_policy                                              = undef,
+  $maxmemory_samples                                             = undef,
+  Integer[0] $min_slaves_max_lag                                 = 10,
+  Integer[0] $min_slaves_to_write                                = 0,
+  Boolean $no_appendfsync_on_rewrite                             = false,
+  Optional[String[1]] $notify_keyspace_events                    = undef,
+  Boolean $notify_service                                        = true,
+  Boolean $managed_by_cluster_manager                            = false,
+  String[1] $package_ensure                                      = 'present',
+  String[1] $package_name                                        = $redis::params::package_name,
+  Stdlib::Absolutepath $pid_file                                 = $redis::params::pid_file,
+  Stdlib::Port::Unprivileged $port                               = 6379,
+  Boolean $protected_mode                                        = true,
+  Optional[String] $ppa_repo                                     = $redis::params::ppa_repo,
+  Boolean $rdbcompression                                        = true,
+  String[1] $repl_backlog_size                                   = '1mb',
+  Integer[0] $repl_backlog_ttl                                   = 3600,
+  Boolean $repl_disable_tcp_nodelay                              = false,
+  Integer[1] $repl_ping_slave_period                             = 10,
+  Integer[1] $repl_timeout                                       = 60,
+  Optional[String] $requirepass                                  = undef,
+  Boolean $save_db_to_disk                                       = true,
+  Hash $save_db_to_disk_interval                                 = {'900' =>'1', '300' => '10', '60' => '10000'},
+  Boolean $service_enable                                        = true,
+  Stdlib::Ensure::Service $service_ensure                        = 'running',
+  String[1] $service_group                                       = $redis::params::service_group,
+  Boolean $service_hasrestart                                    = true,
+  Boolean $service_hasstatus                                     = true,
+  Boolean $service_manage                                        = true,
+  String[1] $service_name                                        = $redis::params::service_name,
+  Optional[String] $service_provider                             = undef,
+  String[1] $service_user                                        = 'redis',
+  Integer[0] $set_max_intset_entries                             = 512,
+  Integer[0] $slave_priority                                     = 100,
+  Boolean $slave_read_only                                       = true,
+  Boolean $slave_serve_stale_data                                = true,
+  Optional[String[1]] $slaveof                                   = undef,
+  Integer[0] $slowlog_log_slower_than                            = 10000,
+  Integer[0] $slowlog_max_len                                    = 1024,
+  Boolean $stop_writes_on_bgsave_error                           = true,
+  Boolean $syslog_enabled                                        = false,
+  Optional[String[1]] $syslog_facility                           = undef,
+  Integer[0] $tcp_backlog                                        = 511,
+  Integer[0] $tcp_keepalive                                      = 0,
+  Integer[0] $timeout                                            = 0,
+  Stdlib::Absolutepath $unixsocket                               = '/var/run/redis/redis.sock',
+  Stdlib::Filemode $unixsocketperm                               = '0755',
+  Integer[0] $ulimit                                             = 65536,
   Stdlib::Absolutepath $workdir                                  = $redis::params::workdir,
-  Stdlib::Filemode $workdir_mode                                 = $redis::params::workdir_mode,
-  $zset_max_ziplist_entries                                      = $redis::params::zset_max_ziplist_entries,
-  $zset_max_ziplist_value                                        = $redis::params::zset_max_ziplist_value,
-  Boolean $cluster_enabled                                       = $redis::params::cluster_enabled,
-  $cluster_config_file                                           = $redis::params::cluster_config_file,
-  $cluster_node_timeout                                          = $redis::params::cluster_node_timeout,
-  Integer[0] $cluster_slave_validity_factor                      = $redis::params::cluster_slave_validity_factor,
-  Boolean $cluster_require_full_coverage                         = $redis::params::cluster_require_full_coverage,
-  Integer[0] $cluster_migration_barrier                          = $redis::params::cluster_migration_barrier,
+  Stdlib::Filemode $workdir_mode                                 = '0750',
+  Integer[0] $zset_max_ziplist_entries                           = 128,
+  Integer[0] $zset_max_ziplist_value                             = 64,
+  Boolean $cluster_enabled                                       = false,
+  String[1] $cluster_config_file                                 = 'nodes.conf',
+  Integer[1] $cluster_node_timeout                               = 5000,
+  Integer[0] $cluster_slave_validity_factor                      = 0,
+  Boolean $cluster_require_full_coverage                         = true,
+  Integer[0] $cluster_migration_barrier                          = 1,
   Hash[String[1], Hash] $instances                               = {},
 ) inherits redis::params {
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -8,221 +8,286 @@
 #     port => 6380,
 #   }
 #
-# @param [String] activerehashing   Enable/disable active rehashing.
-# @param [String] aof_load_truncated   Enable/disable loading truncated AOF file
-# @param [String] aof_rewrite_incremental_fsync   Enable/disable fsync for AOF file
-# @param [String] appendfilename   The name of the append only file
-# @param appendfsync Adjust fsync mode. Valid options: always, everysec, no. Default:  everysec
-# @param [String] appendonly   Enable/disable appendonly mode.
-# @param [String] auto_aof_rewrite_min_size   Adjust minimum size for auto-aof-rewrite.
-# @param [String] auto_aof_rewrite_percentage   Adjust percentatge for auto-aof-rewrite.
-# @param bind Configure which IP address(es) to listen on. To bind on all interfaces, use an empty array.
-# @param config_dir Directory containing the configuration files.
-# @param config_dir_mode Adjust mode for directory containing configuration files.
-# @param [String] config_file_orig   The location and name of a config file that provides the source
-# @param [String] config_file   Adjust main configuration file.
-# @param config_file_mode Adjust permissions for configuration files.
-# @param [String] config_group   Adjust filesystem group for config files.
-# @param [String] config_owner   Adjust filesystem owner for config files.
-# @param [String] conf_template   Define which template to use.
-# @param [String] daemonize   Have Redis run as a daemon.
-# @param [String] databases   Set the number of databases.
-# @param [String] dbfilename   The filename where to dump the DB
-# @param [String] extra_config_file   Description
-# @param [String] hash_max_ziplist_entries   Set max ziplist entries for hashes.
-# @param [String] hash_max_ziplist_value   Set max ziplist values for hashes.
-# @param [String] hll_sparse_max_bytes   HyperLogLog sparse representation bytes limit
-# @param [String] hz   Set redis background tasks frequency
-# @param [String] latency_monitor_threshold   Latency monitoring threshold in milliseconds
-# @param [String] list_max_ziplist_entries   Set max ziplist entries for lists.
-# @param [String] list_max_ziplist_value   Set max ziplist values for lists.
-# @param log_dir Specify directory where to write log entries.
-# @param log_dir_mode Adjust mode for directory containing log files.
-# @param log_file Specify file where to write log entries.
-# @param [String] log_level   Specify the server verbosity level.
-# @param [String] masterauth   If the master is password protected (using the "requirepass" configuration
-# @param [String] maxclients   Set the max number of connected clients at the same time.
-# @param [String] maxmemory   Don't use more memory than the specified amount of bytes.
-# @param [String] maxmemory_policy   How Redis will select what to remove when maxmemory is reached.
-# @param [String] maxmemory_samples   Select as well the sample size to check.
-# @param [String] min_slaves_max_lag   The lag in seconds
-# @param [String] min_slaves_to_write   Minimum number of slaves to be in "online" state
-# @param [String] no_appendfsync_on_rewrite   If you have latency problems turn this to 'true'. Otherwise leave it as
-# @param [String] notify_keyspace_events   Which events to notify Pub/Sub clients about events happening
-# @param [String] pid_file   Where to store the pid.
-# @param port Configure which port to listen on.
-# @param [String] protected_mode  Whether protected mode is enabled or not.  Only applicable when no bind is set.
-# @param [String] rdbcompression   Enable/disable compression of string objects using LZF when dumping.
-# @param [String] repl_backlog_size   The replication backlog size
-# @param [String] repl_backlog_ttl   The number of seconds to elapse before freeing backlog buffer
-# @param [String] repl_disable_tcp_nodelay   Enable/disable TCP_NODELAY on the slave socket after SYNC
-# @param [Integer] repl_ping_slave_period   Slaves send PINGs to server in a predefined interval. It's possible
-# @param [String] repl_timeout   Set the replication timeout for:
-# @param [String] requirepass   Require clients to issue AUTH <PASSWORD> before processing any
-#   other commands.
-# @param [String] save_db_to_disk   Set if save db to disk.
-# @param [String] save_db_to_disk_interval    save the dataset every N seconds if there are at least M changes in the dataset
-# @param [String] service_enable   Enable/disable daemon at boot.
-# @param [String] service_ensure   Specify if the server should be running.
-# @param [String] service_group   Specify which group to run as.
-# @param [String] service_hasrestart   Does the init script support restart?
-# @param [String] service_hasstatus   Does the init script support status?
-# @param [String] service_user   Specify which user to run as.
-# @param [String] set_max_intset_entries   The following configuration setting sets the limit in the size of the
-#   set in order to use this special memory saving encoding.
-#   Default: 512
-# @param [String] slave_priority   The priority number for slave promotion by Sentinel
-# @param [String] slave_read_only   You can configure a slave instance to accept writes or not.
-# @param [String] slave_serve_stale_data   When a slave loses its connection with the master, or when the replication
+# @param activerehashing
+#   Enable/disable active rehashing.
+# @param aof_load_truncated
+#   Enable/disable loading truncated AOF file
+# @param aof_rewrite_incremental_fsync
+#   Enable/disable fsync for AOF file
+# @param appendfilename
+#   The name of the append only file
+# @param appendfsync
+#   Adjust fsync mode. Valid options: always, everysec, no.
+# @param appendonly
+#   Enable/disable appendonly mode.
+# @param auto_aof_rewrite_min_size
+#   Adjust minimum size for auto-aof-rewrite.
+# @param auto_aof_rewrite_percentage
+#   Adjust percentatge for auto-aof-rewrite.
+# @param bind
+#   Configure which IP address(es) to listen on. To bind on all interfaces, use an empty array.
+# @param config_dir
+#   Directory containing the configuration files.
+# @param config_dir_mode
+#   Adjust mode for directory containing configuration files.
+# @param config_file_orig
+#   The location and name of a config file that provides the source
+# @param config_file
+#   Adjust main configuration file.
+# @param config_file_mode
+#   Adjust permissions for configuration files.
+# @param config_group
+#   Adjust filesystem group for config files.
+# @param config_owner
+#   Adjust filesystem owner for config files.
+# @param conf_template
+#   Define which template to use.
+# @param daemonize
+#   Have Redis run as a daemon.
+# @param databases
+#   Set the number of databases.
+# @param dbfilename
+#   The filename where to dump the DB
+# @param extra_config_file
+#   Optional extra config file to include
+# @param hash_max_ziplist_entries
+#   Set max ziplist entries for hashes.
+# @param hash_max_ziplist_value
+#   Set max ziplist values for hashes.
+# @param hll_sparse_max_bytes
+#   HyperLogLog sparse representation bytes limit
+# @param hz
+#   Set redis background tasks frequency
+# @param latency_monitor_threshold
+#   Latency monitoring threshold in milliseconds
+# @param list_max_ziplist_entries
+#   Set max ziplist entries for lists.
+# @param list_max_ziplist_value
+#   Set max ziplist values for lists.
+# @param log_dir
+#   Specify directory where to write log entries.
+# @param log_dir_mode
+#   Adjust mode for directory containing log files.
+# @param log_file
+#   Specify file where to write log entries.
+# @param log_level
+#   Specify the server verbosity level.
+# @param masterauth
+#   If the master is password protected (using the "requirepass" configuration
+# @param maxclients
+#   Set the max number of connected clients at the same time.
+# @param maxmemory
+#   Don't use more memory than the specified amount of bytes.
+# @param maxmemory_policy
+#   How Redis will select what to remove when maxmemory is reached.
+# @param maxmemory_samples
+#   Select as well the sample size to check.
+# @param min_slaves_max_lag
+#   The lag in seconds
+# @param min_slaves_to_write
+#   Minimum number of slaves to be in "online" state
+# @param no_appendfsync_on_rewrite
+#   If you have latency problems turn this to 'true'. Otherwise leave it as
+# @param notify_keyspace_events
+#   Which events to notify Pub/Sub clients about events happening
+# @param pid_file
+#   Where to store the pid.
+# @param port
+#   Configure which port to listen on.
+# @param protected_mode
+#   Whether protected mode is enabled or not.  Only applicable when no bind is set.
+# @param rdbcompression
+#   Enable/disable compression of string objects using LZF when dumping.
+# @param repl_backlog_size
+#   The replication backlog size
+# @param repl_backlog_ttl
+#   The number of seconds to elapse before freeing backlog buffer
+# @param repl_disable_tcp_nodelay
+#   Enable/disable TCP_NODELAY on the slave socket after SYNC
+# @param repl_ping_slave_period
+#   Slaves send PINGs to server in a predefined interval. It's possible
+# @param repl_timeout
+#   Set the replication timeout for:
+# @param requirepass
+#   Require clients to issue AUTH <PASSWORD> before processing any other
+#   commands.
+# @param save_db_to_disk
+#   Set if save db to disk.
+# @param save_db_to_disk_interval
+#   save the dataset every N seconds if there are at least M changes in the dataset
+# @param service_enable
+#   Enable/disable daemon at boot.
+# @param service_ensure
+#   Specify if the server should be running.
+# @param service_group
+#   Specify which group to run as.
+# @param service_hasrestart
+#   Does the init script support restart?
+# @param service_hasstatus
+#   Does the init script support status?
+# @param service_user
+#   Specify which user to run as.
+# @param set_max_intset_entries
+#   The following configuration setting sets the limit in the size of the set
+#   in order to use this special memory saving encoding.
+# @param slave_priority
+#   The priority number for slave promotion by Sentinel
+# @param slave_read_only
+#   You can configure a slave instance to accept writes or not.
+# @param slave_serve_stale_data
+#   When a slave loses its connection with the master, or when the replication
 #   is still in progress, the slave can act in two different ways:
 #   1) if slave-serve-stale-data is set to 'yes' (the default) the slave will
 #      still reply to client requests, possibly with out of date data, or the
 #      data set may just be empty if this is the first synchronization.
-#
 #   2) if slave-serve-stale-data is set to 'no' the slave will reply with
 #      an error "SYNC with master in progress" to all the kind of commands
 #      but to INFO and SLAVEOF.
-#
-#   Default: true
-#
-# @param [String] slaveof   Use slaveof to make a Redis instance a copy of another Redis server.
-# @param [String] slowlog_log_slower_than   Tells Redis what is the execution time, in microseconds, to exceed
-#   in order for the command to get logged.
-#   Default: 10000
-#
-# @param [String] slowlog_max_len   Tells Redis what is the length to exceed in order for the command
+# @param slaveof
+#   Use slaveof to make a Redis instance a copy of another Redis server.
+# @param slowlog_log_slower_than
+#   Tells Redis what is the execution time, in microseconds, to exceed in order
+#   for the command to get logged.
+# @param slowlog_max_len
+#   Tells Redis what is the length to exceed in order for the command
 #   to get logged.
-#   Default: 1024
-#
-# @param [String] stop_writes_on_bgsave_error   If false then Redis will continue to work as usual even if there
+# @param stop_writes_on_bgsave_error
+#   If false then Redis will continue to work as usual even if there
 #   are problems with disk, permissions, and so forth.
-#   Default: true
-#
-# @param [String] syslog_enabled   Enable/disable logging to the system logger.
-# @param [String] syslog_facility   Specify the syslog facility.
-#   Must be USER or between LOCAL0-LOCAL7.
-#   Default: undef
-#
-# @param [String] tcp_backlog   Sets the TCP backlog
-# @param [String] tcp_keepalive   TCP keepalive.
-# @param [String] timeout   Close the connection after a client is idle for N seconds (0 to disable).
-# @param [String] ulimit   Limit the use of system-wide resources.
-# @param [String] unixsocket   Define unix socket path
-# @param [String] unixsocketperm   Define unix socket file permissions
-# @param workdir The DB will be written inside this directory, with the filename specified
+# @param syslog_enabled
+#   Enable/disable logging to the system logger.
+# @param syslog_facility
+#   Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
+# @param tcp_backlog
+#   Sets the TCP backlog
+# @param tcp_keepalive
+#   TCP keepalive.
+# @param timeout
+#   Close the connection after a client is idle for N seconds (0 to disable).
+# @param ulimit
+#   Limit the use of system-wide resources.
+# @param unixsocket
+#   Define unix socket path
+# @param unixsocketperm
+#   Define unix socket file permissions
+# @param workdir
+#   The DB will be written inside this directory, with the filename specified
 #   above using the 'dbfilename' configuration directive.
-#   Default: /var/lib/redis/
-# @param workdir_mode   Adjust mode for data directory.
-# @param [String] zset_max_ziplist_entries   Set max entries for sorted sets.
-# @param [String] zset_max_ziplist_value   Set max values for sorted sets.
-# @param cluster_enabled Enables redis 3.0 cluster functionality
-# @param [String] cluster_config_file   Config file for saving cluster nodes configuration. This file is never touched by humans.
-#   Only set if cluster_enabled is true
-#   Default: nodes.conf
-# @param [String] cluster_node_timeout   Node timeout
-#   Only set if cluster_enabled is true
-#   Default: 5000
-# @param [Integer] cluster_slave_validity_factor   Control variable to disable promoting slave in case of disconnection from master
-#   Only set if cluster_enabled is true
-#   Default: 0
-# @param [Boolean] cluster_require_full_coverage   If false Redis Cluster will server queries even if requests about a subset of keys can be processed
-#   Only set if cluster_enabled is true
-#   Default: true
-# @param [Integer] cluster_migration_barrier    Minimum number of slaves master will remain connected with, for another slave to migrate to a  master which is no longer covered by any slave
-#   Only set if cluster_enabled is true
-#   Default: 1
+# @param workdir_mode
+#   Adjust mode for data directory.
+# @param zset_max_ziplist_entries
+#   Set max entries for sorted sets.
+# @param zset_max_ziplist_value
+#   Set max values for sorted sets.
+# @param cluster_enabled
+#   Enables redis 3.0 cluster functionality
+# @param cluster_config_file
+#   Config file for saving cluster nodes configuration. This file is never
+#   touched by humans.  Only set if cluster_enabled is true
+# @param cluster_node_timeout
+#   Node timeout. Only set if cluster_enabled is true
+# @param cluster_slave_validity_factor
+#   Control variable to disable promoting slave in case of disconnection from
+#   master Only set if cluster_enabled is true
+# @param cluster_require_full_coverage
+#   If false Redis Cluster will server queries even if requests about a subset
+#   of keys can be processed Only set if cluster_enabled is true
+# @param cluster_migration_barrier
+#   Minimum number of slaves master will remain connected with, for another
+#   slave to migrate to a  master which is no longer covered by any slave Only
+#   set if cluster_enabled is true
 define redis::instance (
-  $activerehashing                                               = $redis::activerehashing,
-  $aof_load_truncated                                            = $redis::aof_load_truncated,
-  $aof_rewrite_incremental_fsync                                 = $redis::aof_rewrite_incremental_fsync,
-  $appendfilename                                                = $redis::appendfilename,
+  Boolean $activerehashing                                       = $redis::activerehashing,
+  Boolean $aof_load_truncated                                    = $redis::aof_load_truncated,
+  Boolean $aof_rewrite_incremental_fsync                         = $redis::aof_rewrite_incremental_fsync,
+  String[1] $appendfilename                                      = $redis::appendfilename,
   Enum['no', 'always', 'everysec'] $appendfsync                  = $redis::appendfsync,
-  $appendonly                                                    = $redis::appendonly,
-  $auto_aof_rewrite_min_size                                     = $redis::auto_aof_rewrite_min_size,
-  $auto_aof_rewrite_percentage                                   = $redis::auto_aof_rewrite_percentage,
+  Boolean $appendonly                                            = $redis::appendonly,
+  String[1] $auto_aof_rewrite_min_size                           = $redis::auto_aof_rewrite_min_size,
+  Integer[0] $auto_aof_rewrite_percentage                        = $redis::auto_aof_rewrite_percentage,
   Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]] $bind = $redis::bind,
-  $output_buffer_limit_slave                                     = $redis::output_buffer_limit_slave,
-  $output_buffer_limit_pubsub                                    = $redis::output_buffer_limit_pubsub,
-  $conf_template                                                 = $redis::conf_template,
+  String[1] $output_buffer_limit_slave                           = $redis::output_buffer_limit_slave,
+  String[1] $output_buffer_limit_pubsub                          = $redis::output_buffer_limit_pubsub,
+  String[1] $conf_template                                       = $redis::conf_template,
   Stdlib::Absolutepath $config_dir                               = $redis::config_dir,
   Stdlib::Filemode $config_dir_mode                              = $redis::config_dir_mode,
-  $config_file                                                   = $redis::config_file,
+  Stdlib::Absolutepath $config_file                              = $redis::config_file,
   Stdlib::Filemode $config_file_mode                             = $redis::config_file_mode,
-  $config_file_orig                                              = $redis::config_file_orig,
-  $config_group                                                  = $redis::config_group,
-  $config_owner                                                  = $redis::config_owner,
-  $daemonize                                                     = $redis::daemonize,
-  $databases                                                     = $redis::databases,
-  $dbfilename                                                    = $redis::dbfilename,
-  $extra_config_file                                             = $redis::extra_config_file,
-  $hash_max_ziplist_entries                                      = $redis::hash_max_ziplist_entries,
-  $hash_max_ziplist_value                                        = $redis::hash_max_ziplist_value,
-  $hll_sparse_max_bytes                                          = $redis::hll_sparse_max_bytes,
-  $hz                                                            = $redis::hz,
-  $latency_monitor_threshold                                     = $redis::latency_monitor_threshold,
-  $list_max_ziplist_entries                                      = $redis::list_max_ziplist_entries,
-  $list_max_ziplist_value                                        = $redis::list_max_ziplist_value,
+  Stdlib::Absolutepath $config_file_orig                         = $redis::config_file_orig,
+  String[1] $config_group                                        = $redis::config_group,
+  String[1] $config_owner                                        = $redis::config_owner,
+  Boolean $daemonize                                             = $redis::daemonize,
+  Integer[1] $databases                                          = $redis::databases,
+  Variant[String[1], Boolean] $dbfilename                        = $redis::dbfilename,
+  Optional[String] $extra_config_file                            = $redis::extra_config_file,
+  Integer[0] $hash_max_ziplist_entries                           = $redis::hash_max_ziplist_entries,
+  Integer[0] $hash_max_ziplist_value                             = $redis::hash_max_ziplist_value,
+  Integer[0] $hll_sparse_max_bytes                               = $redis::hll_sparse_max_bytes,
+  Integer[1, 500] $hz                                            = $redis::hz,
+  Integer[0] $latency_monitor_threshold                          = $redis::latency_monitor_threshold,
+  Integer[0] $list_max_ziplist_entries                           = $redis::list_max_ziplist_entries,
+  Integer[0] $list_max_ziplist_value                             = $redis::list_max_ziplist_value,
   Stdlib::Absolutepath $log_dir                                  = $redis::log_dir,
   Stdlib::Filemode $log_dir_mode                                 = $redis::log_dir_mode,
-  $log_level                                                     = $redis::log_level,
-  $minimum_version                                               = $redis::minimum_version,
-  $masterauth                                                    = $redis::masterauth,
-  $maxclients                                                    = $redis::maxclients,
+  Redis::LogLevel $log_level                                     = $redis::log_level,
+  String[1] $minimum_version                                     = $redis::minimum_version,
+  Optional[String[1]] $masterauth                                = $redis::masterauth,
+  Integer[1] $maxclients                                         = $redis::maxclients,
   $maxmemory                                                     = $redis::maxmemory,
   $maxmemory_policy                                              = $redis::maxmemory_policy,
   $maxmemory_samples                                             = $redis::maxmemory_samples,
-  $min_slaves_max_lag                                            = $redis::min_slaves_max_lag,
-  $min_slaves_to_write                                           = $redis::min_slaves_to_write,
-  $no_appendfsync_on_rewrite                                     = $redis::no_appendfsync_on_rewrite,
-  $notify_keyspace_events                                        = $redis::notify_keyspace_events,
-  $managed_by_cluster_manager                                    = $redis::managed_by_cluster_manager,
-  $package_ensure                                                = $redis::package_ensure,
-  Stdlib::Port $port                                             = $redis::port,
-  $protected_mode                                                = $redis::protected_mode,
-  $rdbcompression                                                = $redis::rdbcompression,
-  $repl_backlog_size                                             = $redis::repl_backlog_size,
-  $repl_backlog_ttl                                              = $redis::repl_backlog_ttl,
-  $repl_disable_tcp_nodelay                                      = $redis::repl_disable_tcp_nodelay,
+  Integer[0] $min_slaves_max_lag                                 = $redis::min_slaves_max_lag,
+  Integer[0] $min_slaves_to_write                                = $redis::min_slaves_to_write,
+  Boolean $no_appendfsync_on_rewrite                             = $redis::no_appendfsync_on_rewrite,
+  Optional[String[1]] $notify_keyspace_events                    = $redis::notify_keyspace_events,
+  Boolean $managed_by_cluster_manager                            = $redis::managed_by_cluster_manager,
+  String[1] $package_ensure                                      = $redis::package_ensure,
+  Stdlib::Port::Unprivileged $port                               = $redis::port,
+  Boolean $protected_mode                                        = $redis::protected_mode,
+  Boolean $rdbcompression                                        = $redis::rdbcompression,
+  String[1] $repl_backlog_size                                   = $redis::repl_backlog_size,
+  Integer[0] $repl_backlog_ttl                                   = $redis::repl_backlog_ttl,
+  Boolean $repl_disable_tcp_nodelay                              = $redis::repl_disable_tcp_nodelay,
   Integer[1] $repl_ping_slave_period                             = $redis::repl_ping_slave_period,
-  $repl_timeout                                                  = $redis::repl_timeout,
-  $requirepass                                                   = $redis::requirepass,
-  $save_db_to_disk                                               = $redis::save_db_to_disk,
-  $save_db_to_disk_interval                                      = $redis::save_db_to_disk_interval,
-  $service_user                                                  = $redis::service_user,
-  $set_max_intset_entries                                        = $redis::set_max_intset_entries,
-  $slave_priority                                                = $redis::slave_priority,
-  $slave_read_only                                               = $redis::slave_read_only,
-  $slave_serve_stale_data                                        = $redis::slave_serve_stale_data,
-  $slaveof                                                       = $redis::slaveof,
-  $slowlog_log_slower_than                                       = $redis::slowlog_log_slower_than,
-  $slowlog_max_len                                               = $redis::slowlog_max_len,
-  $stop_writes_on_bgsave_error                                   = $redis::stop_writes_on_bgsave_error,
-  $syslog_enabled                                                = $redis::syslog_enabled,
-  $syslog_facility                                               = $redis::syslog_facility,
-  $tcp_backlog                                                   = $redis::tcp_backlog,
-  $tcp_keepalive                                                 = $redis::tcp_keepalive,
-  $timeout                                                       = $redis::timeout,
-  $unixsocketperm                                                = $redis::unixsocketperm,
-  $ulimit                                                        = $redis::ulimit,
+  Integer[1] $repl_timeout                                       = $redis::repl_timeout,
+  Optional[String] $requirepass                                  = $redis::requirepass,
+  Boolean $save_db_to_disk                                       = $redis::save_db_to_disk,
+  Hash $save_db_to_disk_interval                                 = $redis::save_db_to_disk_interval,
+  String[1] $service_user                                        = $redis::service_user,
+  Integer[0] $set_max_intset_entries                             = $redis::set_max_intset_entries,
+  Integer[0] $slave_priority                                     = $redis::slave_priority,
+  Boolean $slave_read_only                                       = $redis::slave_read_only,
+  Boolean $slave_serve_stale_data                                = $redis::slave_serve_stale_data,
+  Optional[String[1]] $slaveof                                   = $redis::slaveof,
+  Integer[0] $slowlog_log_slower_than                            = $redis::slowlog_log_slower_than,
+  Integer[0] $slowlog_max_len                                    = $redis::slowlog_max_len,
+  Boolean $stop_writes_on_bgsave_error                           = $redis::stop_writes_on_bgsave_error,
+  Boolean $syslog_enabled                                        = $redis::syslog_enabled,
+  Optional[String[1]] $syslog_facility                           = $redis::syslog_facility,
+  Integer[0] $tcp_backlog                                        = $redis::tcp_backlog,
+  Integer[0] $tcp_keepalive                                      = $redis::tcp_keepalive,
+  Integer[0] $timeout                                            = $redis::timeout,
+  Stdlib::Filemode $unixsocketperm                               = $redis::unixsocketperm,
+  Integer[0] $ulimit                                             = $redis::ulimit,
   Stdlib::Filemode $workdir_mode                                 = $redis::workdir_mode,
-  $zset_max_ziplist_entries                                      = $redis::zset_max_ziplist_entries,
-  $zset_max_ziplist_value                                        = $redis::zset_max_ziplist_value,
+  Integer[0] $zset_max_ziplist_entries                           = $redis::zset_max_ziplist_entries,
+  Integer[0] $zset_max_ziplist_value                             = $redis::zset_max_ziplist_value,
   Boolean $cluster_enabled                                       = $redis::cluster_enabled,
-  $cluster_config_file                                           = $redis::cluster_config_file,
-  $cluster_node_timeout                                          = $redis::cluster_node_timeout,
+  String[1] $cluster_config_file                                 = $redis::cluster_config_file,
+  Integer[1] $cluster_node_timeout                               = $redis::cluster_node_timeout,
   Integer[0] $cluster_slave_validity_factor                      = $redis::cluster_slave_validity_factor,
   Boolean $cluster_require_full_coverage                         = $redis::cluster_require_full_coverage,
   Integer[0] $cluster_migration_barrier                          = $redis::cluster_migration_barrier,
-  $service_ensure                                                = $redis::service_ensure,
-  $service_enable                                                = $redis::service_enable,
-  $service_group                                                 = $redis::service_group,
-  $service_hasrestart                                            = $redis::service_hasrestart,
-  $service_hasstatus                                             = $redis::service_hasstatus,
+  Stdlib::Ensure::Service $service_ensure                        = $redis::service_ensure,
+  Boolean $service_enable                                        = $redis::service_enable,
+  String[1] $service_group                                       = $redis::service_group,
+  Boolean $service_hasrestart                                    = $redis::service_hasrestart,
+  Boolean $service_hasstatus                                     = $redis::service_hasstatus,
   # Defaults for redis::instance
-  $manage_service_file                                           = true,
+  Boolean $manage_service_file                                   = true,
   Optional[Stdlib::Absolutepath] $log_file                       = undef,
-  $pid_file                                                      = "/var/run/redis/redis-server-${name}.pid",
-  $unixsocket                                                    = "/var/run/redis/redis-server-${name}.sock",
+  Stdlib::Absolutepath $pid_file                                 = "/var/run/redis/redis-server-${name}.pid",
+  Stdlib::Absolutepath $unixsocket                               = "/var/run/redis/redis-server-${name}.sock",
   Stdlib::Absolutepath $workdir                                  = "${redis::workdir}/redis-server-${name}",
 ) {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,102 +1,15 @@
 # @summary This class provides a number of parameters.
 # @api private
 class redis::params {
-  # Generic
-  $manage_repo                = false
-  $manage_package             = true
-  $managed_by_cluster_manager = false
-
-  # redis.conf.erb
-  $activerehashing                 = true
-  $aof_load_truncated              = true
-  $aof_rewrite_incremental_fsync   = true
-  $appendfilename                  = 'appendonly.aof'
-  $appendfsync                     = 'everysec'
-  $appendonly                      = false
-  $auto_aof_rewrite_min_size       = '64mb'
-  $auto_aof_rewrite_percentage     = 100
-  $bind                            = ['127.0.0.1']
-  $output_buffer_limit_slave       = '256mb 64mb 60'
-  $output_buffer_limit_pubsub      = '32mb 8mb 60'
-  $conf_template                   = 'redis/redis.conf.erb'
-  $default_install                 = true
-  $databases                       = 16
-  $dbfilename                      = 'dump.rdb'
-  $extra_config_file               = undef
-  $hash_max_ziplist_entries        = 512
-  $hash_max_ziplist_value          = 64
-  $hll_sparse_max_bytes            = 3000
-  $hz                              = 10
-  $latency_monitor_threshold       = 0
-  $list_max_ziplist_entries        = 512
-  $list_max_ziplist_value          = 64
-  $log_dir                         = '/var/log/redis'
-  $log_file                        = '/var/log/redis/redis.log'
-  $log_level                       = 'notice'
-  $manage_service_file             = false
-  $maxclients                      = 10000
-  $maxmemory                       = undef
-  $maxmemory_policy                = undef
-  $maxmemory_samples               = undef
-  $no_appendfsync_on_rewrite       = false
-  $notify_keyspace_events          = undef
-  $notify_service                  = true
-  $port                            = 6379
-  $protected_mode                  = 'yes'
-  $rdbcompression                  = true
-  $requirepass                     = undef
-  $save_db_to_disk                 = true
-  $save_db_to_disk_interval        = {'900' =>'1', '300' => '10', '60' => '10000'}
-  $service_provider                = undef
-  $set_max_intset_entries          = 512
-  $slave_priority                  = 100
-  $slowlog_log_slower_than         = 10000
-  $slowlog_max_len                 = 1024
-  $stop_writes_on_bgsave_error     = true
-  $syslog_enabled                  = undef
-  $syslog_facility                 = undef
-  $tcp_backlog                     = 511
-  $tcp_keepalive                   = 0
-  $timeout                         = 0
-  $ulimit                          = 65536
-  $unixsocket                      = '/var/run/redis/redis.sock'
-  $unixsocketperm                  = 755
-  $zset_max_ziplist_entries        = 128
-  $zset_max_ziplist_value          = 64
-
-  # redis.conf.erb - replication
-  $masterauth               = undef
-  $min_slaves_to_write      = 0
-  $min_slaves_max_lag       = 10
-  $repl_backlog_size        = '1mb'
-  $repl_backlog_ttl         = 3600
-  $repl_disable_tcp_nodelay = false
-  $repl_ping_slave_period   = 10
-  $repl_timeout             = 60
-  $slave_read_only          = true
-  $slave_serve_stale_data   = true
-  $slaveof                  = undef
-
-  # redis.conf.erb - redis 3.0 clustering
-  $cluster_enabled        = false
-  $cluster_config_file    = 'nodes.conf'
-  $cluster_node_timeout   = 5000
-  $cluster_slave_validity_factor = 0
-  $cluster_require_full_coverage = true
-  $cluster_migration_barrier = 1
-
   case $::osfamily {
     'Debian': {
       $config_dir                = '/etc/redis'
       $config_dir_mode           = '0755'
       $config_file               = '/etc/redis/redis.conf'
-      $config_file_mode          = '0644'
       $config_file_orig          = '/etc/redis/redis.conf.puppet'
 
       $config_owner              = 'redis'
-      $daemonize                 = true
       $log_dir_mode              = '0755'
-      $package_ensure            = 'present'
       $package_name              = 'redis-server'
       $pid_file                  = '/var/run/redis/redis-server.pid'
       $sentinel_config_file      = '/etc/redis/sentinel.conf'
@@ -104,17 +17,10 @@ class redis::params {
       $sentinel_daemonize        = true
       $sentinel_init_script      = '/etc/init.d/redis-sentinel'
       $sentinel_package_name     = 'redis-sentinel'
-      $service_manage            = true
-      $service_enable            = true
-      $service_ensure            = 'running'
       $service_group             = 'redis'
-      $service_hasrestart        = true
-      $service_hasstatus         = true
       $service_name              = 'redis-server'
-      $service_user              = 'redis'
       $ppa_repo                  = 'ppa:chris-lea/redis-server'
       $workdir                   = '/var/lib/redis'
-      $workdir_mode              = '0750'
 
       case $facts['os']['name'] {
         'Ubuntu': {
@@ -136,13 +42,10 @@ class redis::params {
       $config_dir                = '/etc/redis'
       $config_dir_mode           = '0755'
       $config_file               = '/etc/redis.conf'
-      $config_file_mode          = '0644'
       $config_file_orig          = '/etc/redis.conf.puppet'
       $config_group              = 'root'
       $config_owner              = 'redis'
-      $daemonize                 = true
       $log_dir_mode              = '0755'
-      $package_ensure            = 'present'
       $package_name              = 'redis'
       $pid_file                  = '/var/run/redis/redis.pid'
       $sentinel_config_file      = '/etc/redis-sentinel.conf'
@@ -150,16 +53,9 @@ class redis::params {
       $sentinel_daemonize        = false
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
-      $service_manage            = true
-      $service_enable            = true
-      $service_ensure            = 'running'
-      $service_hasrestart        = true
-      $service_hasstatus         = true
       $service_name              = 'redis'
-      $service_user              = 'redis'
       $ppa_repo                  = undef
       $workdir                   = '/var/lib/redis'
-      $workdir_mode              = '0755'
 
       # EPEL 6 and newer have 3.2 so we can assume all EL is 3.2+
       $minimum_version           = '3.2.10'
@@ -174,13 +70,10 @@ class redis::params {
       $config_dir                = '/usr/local/etc/redis'
       $config_dir_mode           = '0755'
       $config_file               = '/usr/local/etc/redis.conf'
-      $config_file_mode          = '0644'
       $config_file_orig          = '/usr/local/etc/redis.conf.puppet'
       $config_group              = 'wheel'
       $config_owner              = 'redis'
-      $daemonize                 = true
       $log_dir_mode              = '0755'
-      $package_ensure            = 'present'
       $package_name              = 'redis'
       $pid_file                  = '/var/run/redis/redis.pid'
       $sentinel_config_file      = '/usr/local/etc/redis-sentinel.conf'
@@ -188,17 +81,10 @@ class redis::params {
       $sentinel_daemonize        = true
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
-      $service_manage            = true
-      $service_enable            = true
-      $service_ensure            = 'running'
       $service_group             = 'redis'
-      $service_hasrestart        = true
-      $service_hasstatus         = true
       $service_name              = 'redis'
-      $service_user              = 'redis'
       $ppa_repo                  = undef
       $workdir                   = '/var/db/redis'
-      $workdir_mode              = '0750'
 
       # pkg version
       $minimum_version           = '3.2.4'
@@ -208,12 +94,9 @@ class redis::params {
       $config_dir                = '/etc/redis'
       $config_dir_mode           = '0750'
       $config_file               = '/etc/redis/redis-server.conf'
-      $config_file_mode          = '0644'
       $config_group              = 'redis'
       $config_owner              = 'redis'
-      $daemonize                 = true
       $log_dir_mode              = '0750'
-      $package_ensure            = 'present'
       $package_name              = 'redis'
       $pid_file                  = '/var/run/redis/redis-server.pid'
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
@@ -221,17 +104,10 @@ class redis::params {
       $sentinel_daemonize        = true
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
-      $service_manage            = true
-      $service_enable            = true
-      $service_ensure            = 'running'
       $service_group             = 'redis'
-      $service_hasrestart        = true
-      $service_hasstatus         = true
       $service_name              = 'redis'
-      $service_user              = 'redis'
       $ppa_repo                  = undef
       $workdir                   = '/var/lib/redis'
-      $workdir_mode              = '0750'
 
       # suse package version
       $minimum_version           = '3.0.5'
@@ -241,13 +117,10 @@ class redis::params {
       $config_dir                = '/etc/redis'
       $config_dir_mode           = '0755'
       $config_file               = '/etc/redis/redis.conf'
-      $config_file_mode          = '0644'
       $config_file_orig          = '/etc/redis/redis.conf.puppet'
       $config_group              = 'root'
       $config_owner              = 'root'
-      $daemonize                 = true
       $log_dir_mode              = '0755'
-      $package_ensure            = 'present'
       $package_name              = 'redis'
       $pid_file                  = '/var/run/redis.pid'
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
@@ -255,17 +128,10 @@ class redis::params {
       $sentinel_daemonize        = true
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
-      $service_manage            = true
-      $service_enable            = true
-      $service_ensure            = 'running'
       $service_group             = 'redis'
-      $service_hasrestart        = true
-      $service_hasstatus         = true
       $service_name              = 'redis'
-      $service_user              = 'redis'
       $ppa_repo                  = undef
       $workdir                   = '/var/lib/redis'
-      $workdir_mode              = '0750'
 
       # pkg version
       $minimum_version           = '3.2.4'

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -79,7 +79,7 @@
 # @param service_name
 #   The name of the service (for puppet to manage).
 #
-# @param service_owner
+# @param service_user
 #   The owner of the config file.
 #
 # @param service_enable
@@ -105,36 +105,36 @@
 #   }
 #
 class redis::sentinel (
-  $auth_pass              = undef,
-  $config_file            = $redis::params::sentinel_config_file,
-  $config_file_orig       = $redis::params::sentinel_config_file_orig,
+  Optional[String[1]] $auth_pass = undef,
+  Stdlib::Absolutepath $config_file = $redis::params::sentinel_config_file,
+  Stdlib::Absolutepath $config_file_orig = $redis::params::sentinel_config_file_orig,
   Stdlib::Filemode $config_file_mode = '0644',
   String[1] $conf_template = 'redis/redis-sentinel.conf.erb',
-  $daemonize              = $redis::params::sentinel_daemonize,
-  $down_after             = 30000,
-  $failover_timeout       = 180000,
-  $init_script            = $redis::params::sentinel_init_script,
+  Boolean $daemonize = $redis::params::sentinel_daemonize,
+  Integer[1] $down_after = 30000,
+  Integer[1] $failover_timeout = 180000,
+  Optional[Stdlib::Absolutepath] $init_script = $redis::params::sentinel_init_script,
   String[1] $init_template = 'redis/redis-sentinel.init.erb',
-  $log_level              = $redis::params::log_level,
-  $log_file               = $redis::params::log_file,
+  Redis::LogLevel $log_level = 'notice',
+  Stdlib::Absolutepath $log_file = '/var/log/redis/redis.log',
   String[1] $master_name  = 'mymaster',
   Stdlib::Host $redis_host = '127.0.0.1',
-  Stdlib::Port $redis_port = $redis::params::port,
-  $package_name           = $redis::params::sentinel_package_name,
+  Stdlib::Port::Unprivileged $redis_port = 6379,
+  String[1] $package_name = $redis::params::sentinel_package_name,
   String[1] $package_ensure = 'present',
   Integer[0] $parallel_sync = 1,
   Stdlib::Absolutepath $pid_file = '/var/run/redis/redis-sentinel.pid',
-  Integer[0] $quorum      = 2,
-  $sentinel_bind          = undef,
-  Stdlib::Port $sentinel_port = 26379,
-  $service_group          = $redis::params::service_group,
+  Integer[1] $quorum = 2,
+  Variant[Undef, Stdlib::IP::Address, Array[Stdlib::IP::Address]] $sentinel_bind = undef,
+  Stdlib::Port::Unprivileged $sentinel_port = 26379,
+  String[1] $service_group = $redis::params::service_group,
   String[1] $service_name = 'redis-sentinel',
-  $service_ensure         = $redis::params::service_ensure,
-  Boolean $service_enable = $redis::params::service_enable,
-  $service_user           = $redis::params::service_user,
+  Stdlib::Ensure::Service $service_ensure = 'running',
+  Boolean $service_enable = true,
+  String[1] $service_user = 'redis',
   Stdlib::Absolutepath $working_dir = '/tmp',
-  $notification_script    = undef,
-  $client_reconfig_script = undef,
+  Optional[Stdlib::Absolutepath] $notification_script = undef,
+  Optional[Stdlib::Absolutepath] $client_reconfig_script = undef,
 ) inherits redis::params {
 
   require 'redis'

--- a/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
@@ -13,7 +13,7 @@ describe 'redis::sentinel' do
 
     $master_name      = 'mymaster'
     $redis_master     = '127.0.0.1'
-    $failover_timeout = '10000'
+    $failover_timeout = 10000
 
     # We're testing with `manage_repo` true.  In redis-sentinel 5, the daemon has its own rundir
     if $::operatingsystem == 'Ubuntu' {

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -69,8 +69,8 @@ CONFIG
             down_after: 6000,
             log_file: '/tmp/barn-sentinel.log',
             failover_timeout: 28_000,
-            notification_script: 'bar.sh',
-            client_reconfig_script: 'foo.sh'
+            notification_script: '/path/to/bar.sh',
+            client_reconfig_script: '/path/to/foo.sh'
           }
         end
 
@@ -87,8 +87,8 @@ sentinel down-after-milliseconds cow 6000
 sentinel parallel-syncs cow 1
 sentinel failover-timeout cow 28000
 sentinel auth-pass cow password
-sentinel notification-script cow bar.sh
-sentinel client-reconfig-script cow foo.sh
+sentinel notification-script cow /path/to/bar.sh
+sentinel client-reconfig-script cow /path/to/foo.sh
 
 loglevel notice
 logfile /tmp/barn-sentinel.log

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -72,7 +72,7 @@ describe 'redis' do
       end
 
       context 'with ulimit' do
-        let(:params) { { ulimit: '7777' } }
+        let(:params) { { ulimit: 7777 } }
 
         it { is_expected.to compile.with_all_deps }
         it do
@@ -183,11 +183,11 @@ describe 'redis' do
       describe 'with parameter auto_aof_rewrite_percentage' do
         let(:params) do
           {
-            auto_aof_rewrite_percentage: '_VALUE_'
+            auto_aof_rewrite_percentage: 75
           }
         end
 
-        it { is_expected.to contain_file(config_file_orig).with_content(%r{auto-aof-rewrite-percentage.*_VALUE_}) }
+        it { is_expected.to contain_file(config_file_orig).with_content(%r{auto-aof-rewrite-percentage 75}) }
       end
 
       describe 'parameter bind' do
@@ -256,9 +256,9 @@ describe 'redis' do
       end
 
       describe 'with parameter: config_file_orig' do
-        let(:params) { { config_file_orig: '_VALUE_' } }
+        let(:params) { { config_file_orig: '/path/to/orig' } }
 
-        it { is_expected.to contain_file('_VALUE_') }
+        it { is_expected.to contain_file('/path/to/orig') }
       end
 
       describe 'with parameter: config_file_mode' do
@@ -296,13 +296,13 @@ describe 'redis' do
       describe 'with parameter databases' do
         let(:params) do
           {
-            databases: '_VALUE_'
+            databases: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{databases.*_VALUE_}
+            'content' => %r{databases 42}
           )
         }
       end
@@ -334,13 +334,13 @@ describe 'redis' do
       describe 'with parameter hash_max_ziplist_entries' do
         let(:params) do
           {
-            hash_max_ziplist_entries: '_VALUE_'
+            hash_max_ziplist_entries: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{hash-max-ziplist-entries.*_VALUE_}
+            'content' => %r{hash-max-ziplist-entries 42}
           )
         }
       end
@@ -348,27 +348,28 @@ describe 'redis' do
       describe 'with parameter hash_max_ziplist_value' do
         let(:params) do
           {
-            hash_max_ziplist_value: '_VALUE_'
+            hash_max_ziplist_value: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{hash-max-ziplist-value.*_VALUE_}
+            'content' => %r{hash-max-ziplist-value 42}
           )
         }
       end
 
+      # TODO: Only present in 3.0
       describe 'with parameter list_max_ziplist_entries' do
         let(:params) do
           {
-            list_max_ziplist_entries: '_VALUE_'
+            list_max_ziplist_entries: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{list-max-ziplist-entries.*_VALUE_}
+            'content' => %r{list-max-ziplist-entries 42}
           )
         }
       end
@@ -376,13 +377,13 @@ describe 'redis' do
       describe 'with parameter list_max_ziplist_value' do
         let(:params) do
           {
-            list_max_ziplist_value: '_VALUE_'
+            list_max_ziplist_value: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{list-max-ziplist-value.*_VALUE_}
+            'content' => %r{list-max-ziplist-value 42}
           )
         }
       end
@@ -418,13 +419,13 @@ describe 'redis' do
       describe 'with parameter log_level' do
         let(:params) do
           {
-            log_level: '_VALUE_'
+            log_level: 'debug'
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{loglevel.*_VALUE_}
+            'content' => %r{^loglevel debug$}
           )
         }
       end
@@ -507,13 +508,13 @@ describe 'redis' do
       describe 'with parameter maxclients' do
         let(:params) do
           {
-            maxclients: '_VALUE_'
+            maxclients: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{maxclients.*_VALUE_}
+            'content' => %r{^maxclients 42$}
           )
         }
       end
@@ -563,13 +564,13 @@ describe 'redis' do
       describe 'with parameter min_slaves_max_lag' do
         let(:params) do
           {
-            min_slaves_max_lag: '_VALUE_'
+            min_slaves_max_lag: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{min-slaves-max-lag.*_VALUE_}
+            'content' => %r{^min-slaves-max-lag 42$}
           )
         }
       end
@@ -577,13 +578,13 @@ describe 'redis' do
       describe 'with parameter min_slaves_to_write' do
         let(:params) do
           {
-            min_slaves_to_write: '_VALUE_'
+            min_slaves_to_write: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{min-slaves-to-write.*_VALUE_}
+            'content' => %r{^min-slaves-to-write 42$}
           )
         }
       end
@@ -648,13 +649,13 @@ describe 'redis' do
       describe 'with parameter pid_file' do
         let(:params) do
           {
-            pid_file: '_VALUE_'
+            pid_file: '/path/to/redis.pid'
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{pidfile.*_VALUE_}
+            'content' => %r{^pidfile /path/to/redis.pid$}
           )
         }
       end
@@ -676,15 +677,15 @@ describe 'redis' do
       describe 'with parameter protected-mode' do
         let(:params) do
           {
-            protected_mode: '_VALUE_'
+            protected_mode: false
           }
         end
 
         it do
           if facts[:operatingsystem] == 'Ubuntu' && facts[:operatingsystemmajrelease] == '16.04'
-            is_expected.not_to contain_file(config_file_orig).with_content(%r{protected-mode.*_VALUE_})
+            is_expected.not_to contain_file(config_file_orig).with_content(%r{protected-mode})
           else
-            is_expected.to contain_file(config_file_orig).with_content(%r{protected-mode.*_VALUE_})
+            is_expected.to contain_file(config_file_orig).with_content(%r{^protected-mode no$})
           end
         end
       end
@@ -692,13 +693,13 @@ describe 'redis' do
       describe 'with parameter hll_sparse_max_bytes' do
         let(:params) do
           {
-            hll_sparse_max_bytes: '_VALUE_'
+            hll_sparse_max_bytes: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{hll-sparse-max-bytes.*_VALUE_}
+            'content' => %r{^hll-sparse-max-bytes 42$}
           )
         }
       end
@@ -706,13 +707,13 @@ describe 'redis' do
       describe 'with parameter hz' do
         let(:params) do
           {
-            hz: '_VALUE_'
+            hz: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{hz.*_VALUE_}
+            'content' => %r{^hz 42$}
           )
         }
       end
@@ -720,13 +721,13 @@ describe 'redis' do
       describe 'with parameter latency_monitor_threshold' do
         let(:params) do
           {
-            latency_monitor_threshold: '_VALUE_'
+            latency_monitor_threshold: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{latency-monitor-threshold.*_VALUE_}
+            'content' => %r{^latency-monitor-threshold 42$}
           )
         }
       end
@@ -762,13 +763,13 @@ describe 'redis' do
       describe 'with parameter repl_backlog_ttl' do
         let(:params) do
           {
-            repl_backlog_ttl: '_VALUE_'
+            repl_backlog_ttl: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{repl-backlog-ttl.*_VALUE_}
+            'content' => %r{^repl-backlog-ttl 42$}
           )
         }
       end
@@ -921,10 +922,10 @@ describe 'redis' do
       end
 
       describe 'with parameter: service_ensure' do
-        let(:params) { { service_ensure: '_VALUE_' } }
+        let(:params) { { service_ensure: 'stopped' } }
         let(:package_name) { manifest_vars[:package_name] }
 
-        it { is_expected.to contain_service(package_name).with_ensure('_VALUE_') }
+        it { is_expected.to contain_service(package_name).with_ensure('stopped') }
       end
 
       describe 'with parameter: service_group' do
@@ -962,13 +963,13 @@ describe 'redis' do
       describe 'with parameter set_max_intset_entries' do
         let(:params) do
           {
-            set_max_intset_entries: '_VALUE_'
+            set_max_intset_entries: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{set-max-intset-entries.*_VALUE_}
+            'content' => %r{^set-max-intset-entries 42$}
           )
         }
       end
@@ -976,13 +977,13 @@ describe 'redis' do
       describe 'with parameter slave_priority' do
         let(:params) do
           {
-            slave_priority: '_VALUE_'
+            slave_priority: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{slave-priority.*_VALUE_}
+            'content' => %r{^slave-priority 42$}
           )
         }
       end
@@ -1050,13 +1051,13 @@ describe 'redis' do
       describe 'with parameter slowlog_log_slower_than' do
         let(:params) do
           {
-            slowlog_log_slower_than: '_VALUE_'
+            slowlog_log_slower_than: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{slowlog-log-slower-than.*_VALUE_}
+            'content' => %r{^slowlog-log-slower-than 42$}
           )
         }
       end
@@ -1064,13 +1065,13 @@ describe 'redis' do
       describe 'with parameter slowlog_max_len' do
         let(:params) do
           {
-            slowlog_max_len: '_VALUE_'
+            slowlog_max_len: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{slowlog-max-len.*_VALUE_}
+            'content' => %r{^slowlog-max-len 42$}
           )
         }
       end
@@ -1121,13 +1122,13 @@ describe 'redis' do
       describe 'with parameter tcp_backlog' do
         let(:params) do
           {
-            tcp_backlog: '_VALUE_'
+            tcp_backlog: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{tcp-backlog.*_VALUE_}
+            'content' => %r{^tcp-backlog 42$}
           )
         }
       end
@@ -1135,13 +1136,13 @@ describe 'redis' do
       describe 'with parameter tcp_keepalive' do
         let(:params) do
           {
-            tcp_keepalive: '_VALUE_'
+            tcp_keepalive: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{tcp-keepalive.*_VALUE_}
+            'content' => %r{^tcp-keepalive 42$}
           )
         }
       end
@@ -1149,13 +1150,13 @@ describe 'redis' do
       describe 'with parameter timeout' do
         let(:params) do
           {
-            timeout: '_VALUE_'
+            timeout: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{timeout.*_VALUE_}
+            'content' => %r{^timeout 42$}
           )
         }
       end
@@ -1177,13 +1178,13 @@ describe 'redis' do
       describe 'with parameter zset_max_ziplist_entries' do
         let(:params) do
           {
-            zset_max_ziplist_entries: '_VALUE_'
+            zset_max_ziplist_entries: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{zset-max-ziplist-entries.*_VALUE_}
+            'content' => %r{zset-max-ziplist-entries 42}
           )
         }
       end
@@ -1191,13 +1192,13 @@ describe 'redis' do
       describe 'with parameter zset_max_ziplist_value' do
         let(:params) do
           {
-            zset_max_ziplist_value: '_VALUE_'
+            zset_max_ziplist_value: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{zset-max-ziplist-value.*_VALUE_}
+            'content' => %r{zset-max-ziplist-value 42}
           )
         }
       end
@@ -1249,13 +1250,13 @@ describe 'redis' do
         let(:params) do
           {
             cluster_enabled: true,
-            cluster_node_timeout: '_VALUE_'
+            cluster_node_timeout: 42
           }
         end
 
         it {
           is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{cluster-node-timeout.*_VALUE_}
+            'content' => %r{cluster-node-timeout 42}
           )
         }
       end

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -38,7 +38,7 @@ pidfile <%= @pid_file %>
 # you are sure you want clients from other hosts to connect to Redis
 # even if no authentication is configured, nor a specific set of interfaces
 # are explicitly listed using the "bind" directive.
-protected-mode <%= @protected_mode %>
+protected-mode <%= @protected_mode ? 'yes' : 'no' %>
 
 <% end -%>
 # Accept connections on the specified port, default is 6379.

--- a/types/loglevel.pp
+++ b/types/loglevel.pp
@@ -1,0 +1,7 @@
+# @summary Specify the server verbosity level.
+# This can be one of:
+# * debug (a lot of information, useful for development/testing)
+# * verbose (many rarely useful info, but not a mess like the debug level)
+# * notice (moderately verbose, what you want in production probably)
+# * warning (only very important / critical messages are logged)
+type Redis::LogLevel = Enum['debug', 'verbose', 'notice', 'warning']


### PR DESCRIPTION
This sets data types for most parameters that previously had none. It also moves static defaults from params.pp to inline. While this duplicates a few between Redis and the sentinel, the user would already need to know these were linked. The benefit is a much more readable reference documentation.