### PR TITLE
Add SCL support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,6 +9,7 @@ _Public Classes_
 
 * [`redis`](#redis): This class installs redis
 * [`redis::administration`](#redisadministration): Allows various adminstrative settings for Redis As documented in the FAQ and https://redis.io/topics/admin
+* [`redis::globals`](#redisglobals): Set a global config for Redis
 * [`redis::sentinel`](#redissentinel): Install redis-sentinel
 
 _Private Classes_
@@ -950,6 +951,22 @@ Set somaxconn value
 
 Default value: 65535
 
+### redis::globals
+
+Set a global config for Redis
+
+#### Parameters
+
+The following parameters are available in the `redis::globals` class.
+
+##### `scl`
+
+Data type: `Optional[String]`
+
+Use a specific Software CoLlection on Red Hat based systems
+
+Default value: `undef`
+
 ### redis::sentinel
 
 Install redis-sentinel
@@ -1167,7 +1184,7 @@ Data type: `String[1]`
 
 The name of the service (for puppet to manage).
 
-Default value: 'redis-sentinel'
+Default value: $redis::params::sentinel_service_name
 
 ##### `service_user`
 

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -1,0 +1,11 @@
+# @summary Set a global config for Redis
+#
+# @param scl
+#   Use a specific Software CoLlection on Red Hat based systems
+class redis::globals(
+  Optional[String] $scl = undef,
+) {
+  if $scl and $facts['os']['family'] != 'RedHat' {
+    fail('SCLs are only supported on the Red Hat OS family')
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 # @summary This class provides a number of parameters.
 # @api private
-class redis::params {
+class redis::params inherits redis::globals {
   case $facts['os']['family'] {
     'Debian': {
       $ppa_repo                  = 'ppa:chris-lea/redis-server'
@@ -19,6 +19,7 @@ class redis::params {
 
       $sentinel_config_file      = '/etc/redis/sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
+      $sentinel_service_name     = 'redis-sentinel'
       $sentinel_daemonize        = true
       $sentinel_init_script      = '/etc/init.d/redis-sentinel'
       $sentinel_package_name     = 'redis-sentinel'
@@ -43,35 +44,60 @@ class redis::params {
     }
 
     'RedHat': {
-      $ppa_repo                  = undef
+      $ppa_repo             = undef
+      $daemonize            = false
+      $config_owner         = 'redis'
+      $config_group         = 'root'
+      $config_dir_mode      = '0755'
+      $log_dir_mode         = '0750'
 
-      $config_dir                = '/etc/redis'
-      $config_dir_mode           = '0755'
-      $config_file               = '/etc/redis.conf'
-      $config_file_orig          = '/etc/redis.conf.puppet'
-      $config_group              = 'root'
-      $config_owner              = 'redis'
-      $log_dir_mode              = '0750'
-      $package_name              = 'redis'
-      $pid_file                  = $facts['os']['release']['major'] ? {
-        '6'     => '/var/run/redis/redis.pid',
-        default => '/var/run/redis_6379.pid',
+      $sentinel_daemonize   = false
+      $sentinel_init_script = undef
+      $sentinel_working_dir = '/tmp'
+
+      $scl = $redis::globals::scl
+      if $scl {
+        $config_dir                = "/etc/opt/rh/${scl}/redis"
+        $config_file               = "/etc/opt/rh/${scl}/redis.conf"
+        $config_file_orig          = "/etc/opt/rh/${scl}/redis.conf.puppet"
+        $package_name              = "${scl}-redis"
+        $pid_file                  = "/var/opt/rh/${scl}/run/redis_6379.pid"
+        $service_name              = "${scl}-redis"
+        $workdir                   = "/var/opt/rh/${scl}/lib/redis"
+
+        $sentinel_config_file      = "${config_dir}/redis-sentinel.conf"
+        $sentinel_config_file_orig = "${config_dir}/redis-sentinel.conf.puppet"
+        $sentinel_service_name     = "${scl}-redis-sentinel"
+        $sentinel_package_name     = $package_name
+        $sentinel_pid_file         = "/var/opt/rh/${scl}/run/redis-sentinel.pid"
+        $sentinel_log_file         = "/var/opt/rh/${scl}/log/redis/sentinel.log"
+
+        $minimum_version = $scl ? {
+          'rh-redis32' => '3.2.13',
+          default      => '5.0.5',
+        }
+      } else {
+        $config_dir                = '/etc/redis'
+        $config_file               = '/etc/redis.conf'
+        $config_file_orig          = '/etc/redis.conf.puppet'
+        $package_name              = 'redis'
+        $pid_file                  = $facts['os']['release']['major'] ? {
+          '6'     => '/var/run/redis/redis.pid',
+          default => '/var/run/redis_6379.pid',
+        }
+        $service_name              = 'redis'
+        $workdir                   = '/var/lib/redis'
+
+        $sentinel_config_file      = '/etc/redis-sentinel.conf'
+        $sentinel_config_file_orig = '/etc/redis-sentinel.conf.puppet'
+        $sentinel_service_name     = 'redis-sentinel'
+        $sentinel_package_name     = 'redis'
+        $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
+        $sentinel_log_file         = '/var/log/redis/sentinel.log'
+
+        # EPEL 6 and newer have 3.2 so we can assume all EL is 3.2+
+        $minimum_version           = '3.2.10'
       }
-      $daemonize                 = false
-      $service_name              = 'redis'
-      $workdir                   = '/var/lib/redis'
-
-      $sentinel_config_file      = '/etc/redis-sentinel.conf'
-      $sentinel_config_file_orig = '/etc/redis-sentinel.conf.puppet'
-      $sentinel_daemonize        = false
-      $sentinel_init_script      = undef
-      $sentinel_package_name     = 'redis'
-      $sentinel_working_dir      = '/tmp'
-      $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
-      $sentinel_log_file         = '/var/log/redis/sentinel.log'
-
-      # EPEL 6 and newer have 3.2 so we can assume all EL is 3.2+
-      $minimum_version           = '3.2.10'
     }
 
     'FreeBSD': {
@@ -92,6 +118,7 @@ class redis::params {
 
       $sentinel_config_file      = '/usr/local/etc/redis-sentinel.conf'
       $sentinel_config_file_orig = '/usr/local/etc/redis-sentinel.conf.puppet'
+      $sentinel_service_name     = 'redis-sentinel'
       $sentinel_daemonize        = true
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
@@ -120,6 +147,7 @@ class redis::params {
 
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
+      $sentinel_service_name     = 'redis-sentinel'
       $sentinel_daemonize        = true
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
@@ -149,6 +177,7 @@ class redis::params {
 
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
+      $sentinel_service_name     = 'redis-sentinel'
       $sentinel_daemonize        = true
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'

--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -4,7 +4,16 @@
 class redis::preinstall {
   if $redis::manage_repo {
     if $facts['os']['family'] == 'RedHat' {
-        require 'epel'
+      if $facts['os']['name'] != 'Fedora' {
+        if $redis::scl {
+          if $facts['os']['name'] == 'CentOS' {
+            ensure_packages(['centos-release-scl-rh'])
+            Package['centos-release-scl-rh'] -> Package[$redis::package_name]
+          }
+        } else {
+          require 'epel'
+        }
+      }
     } elsif $facts['os']['name'] == 'Debian' {
       contain 'apt'
       apt::source { 'dotdeb':

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -128,7 +128,7 @@ class redis::sentinel (
   Variant[Undef, Stdlib::IP::Address, Array[Stdlib::IP::Address]] $sentinel_bind = undef,
   Stdlib::Port $sentinel_port = 26379,
   String[1] $service_group = 'redis',
-  String[1] $service_name = 'redis-sentinel',
+  String[1] $service_name = $redis::params::sentinel_service_name,
   Stdlib::Ensure::Service $service_ensure = 'running',
   Boolean $service_enable = true,
   String[1] $service_user = 'redis',

--- a/spec/acceptance/suites/scl/redis5_spec.rb
+++ b/spec/acceptance/suites/scl/redis5_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper_acceptance'
+
+describe 'redis', if: %w[centos redhat].include?(os[:family]) && os[:release].to_i >= 7 do
+  before(:all) do
+    on hosts, puppet_resource('service', 'redis', 'ensure=stopped', 'enable=false')
+  end
+
+  after(:all) do
+    on hosts, puppet_resource('service', 'rh-redis5-redis', 'ensure=stopped', 'enable=false')
+  end
+
+  it 'runs successfully' do
+    pp = <<-PUPPET
+      class { 'redis::globals':
+        scl => 'rh-redis5',
+      }
+      class { 'redis':
+        manage_repo => true,
+      }
+    PUPPET
+
+    # Apply twice to ensure no errors the second time.
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+
+  describe package('rh-redis5-redis') do
+    it { is_expected.to be_installed }
+  end
+
+  describe service('rh-redis5-redis') do
+    it { is_expected.to be_running }
+    it { is_expected.to be_enabled }
+  end
+
+  context 'redis should respond to ping command' do
+    describe command('scl enable rh-redis5 -- redis-cli ping') do
+      its(:stdout) { is_expected.to match %r{PONG} }
+    end
+  end
+end


### PR DESCRIPTION
On Red Hat the software collections allow for multiple versions. On RHEL this is also supported for customers where EPEL is unsupported.

To implement this, the globals pattern is implemented giving users an easy way to select the SCL at a global level. Acceptance tests are added to ensure it works.

For convenience, it can ensure centos-release-scl-rh is installed on CentOS when manage_repo is true.

This is a draft because I'm still working on verification. The acceptance tests are also expected to fail since it'll attempt to bind on the same port without stopping the old service.