### PR TITLE
Debian10 fix

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,6 +7,7 @@
     - set: centos6-64m
     - set: centos7-64m
     - set: debian9-64m
+    - set: debian10-64m
 Gemfile:
   optional:
     ':test':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,14 @@ class redis::params inherits redis::globals {
       $sentinel_daemonize        = true
       $sentinel_init_script      = '/etc/init.d/redis-sentinel'
       $sentinel_package_name     = 'redis-sentinel'
-      $sentinel_pid_file         = '/var/run/sentinel/redis-sentinel.pid'
+      
+     if versioncmp($facts['os']['release']['full'], '10.0.0') >= 0 {
+       $sentinel_pid_file         = '/var/run/sentinel/redis-sentinel.pid'
+      } else {
+       $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
+      }
+
+      
       $sentinel_log_file         = '/var/log/redis/redis-sentinel.log'
       $sentinel_working_dir      = '/var/lib/redis'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class redis::params inherits redis::globals {
       $sentinel_daemonize        = true
       $sentinel_init_script      = '/etc/init.d/redis-sentinel'
       $sentinel_package_name     = 'redis-sentinel'
-      $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
+      $sentinel_pid_file         = '/var/run/sentinel/redis-sentinel.pid'
       $sentinel_log_file         = '/var/log/redis/redis-sentinel.log'
       $sentinel_working_dir      = '/var/lib/redis'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,13 +23,13 @@ class redis::params inherits redis::globals {
       $sentinel_daemonize        = true
       $sentinel_init_script      = '/etc/init.d/redis-sentinel'
       $sentinel_package_name     = 'redis-sentinel'
-      
+
       if versioncmp($facts['os']['release']['full'], '10.0.0') >= 0 {
       $sentinel_pid_file         = '/var/run/sentinel/redis-sentinel.pid'
       } else {
       $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
       }
-      
+
       $sentinel_log_file         = '/var/log/redis/redis-sentinel.log'
       $sentinel_working_dir      = '/var/lib/redis'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,12 +24,11 @@ class redis::params inherits redis::globals {
       $sentinel_init_script      = '/etc/init.d/redis-sentinel'
       $sentinel_package_name     = 'redis-sentinel'
       
-     if versioncmp($facts['os']['release']['full'], '10.0.0') >= 0 {
-       $sentinel_pid_file         = '/var/run/sentinel/redis-sentinel.pid'
+      if versioncmp($facts['os']['release']['full'], '10.0.0') >= 0 {
+      $sentinel_pid_file         = '/var/run/sentinel/redis-sentinel.pid'
       } else {
-       $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
+      $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
       }
-
       
       $sentinel_log_file         = '/var/log/redis/redis-sentinel.log'
       $sentinel_working_dir      = '/var/lib/redis'

--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9"
+        "9",
+        "10"
       ]
     },
     {

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -10,6 +10,8 @@ describe 'redis::sentinel' do
           '/etc/redis/redis-sentinel.conf.puppet'
         when 'Debian'
           '/etc/redis/redis-sentinel.conf.puppet'
+        when 'Ubuntu'
+          '/etc/redis/redis-sentinel.conf.puppet'
         when 'Suse'
           '/etc/redis/redis-sentinel.conf.puppet'
         when 'FreeBSD'


### PR DESCRIPTION
Fix $sentinel_pid_file  for Debian.
Systemd will lookup for the pidfile in /var/run/sentinel/redis-sentinel.pid

#### Pull Request (PR) description
Debian10 default path for pidfile of sentinel will -> /var/run/sentinel/redis-sentinel.pid


#### This Pull Request (PR) fixes the following issues
#322
