### PR TITLE
fix service template

### DIFF
--- a/templates/service_templates/redis.service.erb
+++ b/templates/service_templates/redis.service.erb
@@ -3,6 +3,8 @@ Description=Advanced key-value store for <%= @title %>
 After=network.target
 
 [Service]
+RuntimeDirectory=redis
+RuntimeDirectoryMode=0755
 Type=forking
 ExecStart=/usr/bin/redis-server <%= @redis_file_name %>
 ExecStop=/usr/bin/redis-server -p <%= @port %> shutdown

--- a/templates/service_templates/redis.service.erb
+++ b/templates/service_templates/redis.service.erb
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 RuntimeDirectory=redis
-RuntimeDirectoryMode=0755
+RuntimeDirectoryMode=2755
 Type=forking
 ExecStart=/usr/bin/redis-server <%= @redis_file_name %>
 ExecStop=/usr/bin/redis-server -p <%= @port %> shutdown


### PR DESCRIPTION
#### Pull Request (PR) description
If you don't change the default socket pid file ($pid_file) it's necessary to create the redis-folder via systemd-unit-file otherwise you will face the problem "Opening Unix socket: bind: No such file or directory" on service start.
