### PR TITLE
Finishing touches for multi-instance support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,3 +11,6 @@ fixtures:
     yumrepo_core:
       repo: "https://github.com/puppetlabs/puppetlabs-yumrepo_core"
       puppet_version: ">= 6.0.0"
+    systemd:
+      repo: 'https://github.com/camptocamp/puppet-systemd.git'
+      puppet_version: "< 6.1.0"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,33 @@ class { '::redis':
 }
 ```
 
+### Multiple instances
+
+
+```puppet
+$listening_ports = [6379,6380,6381,6382]
+
+class { '::redis':
+  default_install => false,
+  service_enable  => false,
+  service_ensure  => 'stopped',
+}
+
+$listening_ports.each |$port| {
+  $port_string = sprintf('%d',$port)
+  redis::instance { $port_string:
+    service_enable => true,
+    service_ensure => 'running',
+    port           => $port,
+    bind           => $facts['networking']['ip'],
+    dbfilename     => "${port}-dump.rdb",
+    appendfilename => "${port}-appendonly.aof",
+    appendfsync    => 'always',
+    require        => Class['Redis'],
+  }
+}
+```
+
 ### Manage repositories
 
 Disabled by default but if you really want the module to manage the required
@@ -103,6 +130,10 @@ class { '::redis::sentinel':
   failover_timeout => 30000,
 }
 ```
+
+### Soft dependency
+
+This module requires `camptocamp/systemd` on Puppet versions older than 6.1.0.
 
 ## `redis::get()` function
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -353,10 +353,4 @@ class redis (
     ~> Class['redis::service']
   }
 
-  exec { 'systemd-reload-redis':
-    command     => 'systemctl daemon-reload',
-    refreshonly => true,
-    path        => '/bin:/usr/bin:/usr/local/bin',
-  }
-
 }

--- a/manifests/ulimit.pp
+++ b/manifests/ulimit.pp
@@ -49,9 +49,12 @@ class redis::ulimit {
         "defnode nofile Service/LimitNOFILE \"\"",
         "set \$nofile/value \"${redis::ulimit}\"",
       ],
-      notify  => [
-        Exec['systemd-reload-redis'],
-      ],
+    }
+    # Only necessary for Puppet < 6.1.0,
+    # See https://github.com/puppetlabs/puppet/commit/f8d5c60ddb130c6429ff12736bfdb4ae669a9fd4
+    if versioncmp($facts['puppetversion'],'6.1.0') < 0 {
+      include systemd::systemctl::daemon_reload
+      Augeas['Systemd redis ulimit'] ~> Class['systemd::systemctl::daemon_reload']
     }
   } else {
     case $facts['os']['family'] {

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -4,11 +4,20 @@ describe 'redis' do
   let(:service_file) { redis_service_file(service_provider: facts['service_provider']) }
   let(:package_name) { manifest_vars[:package_name] }
   let(:service_name) { manifest_vars[:service_name] }
+  let(:config_file) { manifest_vars[:config_file] }
   let(:config_file_orig) { manifest_vars[:config_file_orig] }
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
+
+      if facts[:operatingsystem] == 'Ubuntu' && facts[:operatingsystemmajrelease] == '16.04'
+        let(:systemd) { '' }
+        let(:servicetype) { 'forking' }
+      else
+        let(:systemd) { ' --supervised systemd' }
+        let(:servicetype) { 'notify' }
+      end
 
       describe 'without parameters' do
         it { is_expected.to compile.with_all_deps }
@@ -108,11 +117,20 @@ describe 'redis' do
               with_owner('root').
               with_group('root').
               with_mode('0444')
-            is_expected.to contain_augeas('Systemd redis ulimit').
-              with_incl("/etc/systemd/system/#{service_name}.service.d/limit.conf").
-              with_lens('Systemd.lns').
-              with_changes(['defnode nofile Service/LimitNOFILE ""', 'set $nofile/value "7777"']).
-              that_notifies('Exec[systemd-reload-redis]')
+            # Only necessary for Puppet < 6.1.0,
+            # See https://github.com/puppetlabs/puppet/commit/f8d5c60ddb130c6429ff12736bfdb4ae669a9fd4
+            if Puppet.version < '6.1'
+              is_expected.to contain_augeas('Systemd redis ulimit').
+                with_incl("/etc/systemd/system/#{service_name}.service.d/limit.conf").
+                with_lens('Systemd.lns').
+                with_changes(['defnode nofile Service/LimitNOFILE ""', 'set $nofile/value "7777"']).
+                that_notifies('Class[systemd::systemctl::daemon_reload]')
+            else
+              is_expected.to contain_augeas('Systemd redis ulimit').
+                with_incl("/etc/systemd/system/#{service_name}.service.d/limit.conf").
+                with_lens('Systemd.lns').
+                with_changes(['defnode nofile Service/LimitNOFILE ""', 'set $nofile/value "7777"'])
+            end
           else
             is_expected.not_to contain_file('/etc/systemd/system/redis-server.service.d/limit.conf')
             is_expected.not_to contain_augeas('Systemd redis ulimit')
@@ -1329,6 +1347,36 @@ describe 'redis' do
         end
 
         it { is_expected.to contain_file(service_file) }
+
+        it do
+          content = <<-END.gsub(%r{^\s+\|}, '')
+            |[Unit]
+            |Description=Redis Advanced key-value store for instance default
+            |After=network.target
+            |After=network-online.target
+            |Wants=network-online.target
+            |
+            |[Service]
+            |RuntimeDirectory=redis
+            |RuntimeDirectoryMode=2755
+            |Type=#{servicetype}
+            |ExecStart=/usr/bin/redis-server #{config_file}#{systemd}
+            |ExecStop=/usr/bin/redis-server -p 6379 shutdown
+            |Restart=always
+            |User=redis
+            |Group=redis
+            |LimitNOFILE=65536
+            |
+            |[Install]
+            |WantedBy=multi-user.target
+          END
+
+          if facts['service_provider'] == 'systemd'
+            is_expected.to contain_file(service_file).with_content(content)
+          else
+            is_expected.to contain_file(service_file).with_content(%r{Required-Start:})
+          end
+        end
       end
 
       describe 'with parameter manage_service_file' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -5,6 +5,7 @@ require 'beaker/module_install_helper'
 run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
+install_module_from_forge('camptocamp/systemd', '>= 2.0.0 < 3.0.0')
 
 RSpec.configure do |c|
   # Readable test descriptions

--- a/templates/service_templates/redis.service.erb
+++ b/templates/service_templates/redis.service.erb
@@ -1,17 +1,25 @@
 [Unit]
-Description=Advanced key-value store for <%= @title %>
+Description=Redis Advanced key-value store for instance <%= @title %>
 After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 RuntimeDirectory=redis
 RuntimeDirectoryMode=2755
+<%# Redis on Xenial is too old for systemd integration -%>
+<% if @facts['os']['name'] == 'Ubuntu' and @facts['os']['release']['major'] == '16.04' -%>
 Type=forking
 ExecStart=/usr/bin/redis-server <%= @redis_file_name %>
+<% else -%>
+Type=notify
+ExecStart=/usr/bin/redis-server <%= @redis_file_name %> --supervised systemd
+<% end -%>
 ExecStop=/usr/bin/redis-server -p <%= @port %> shutdown
-TimeoutStopSec=0
 Restart=always
 User=<%= @service_user %>
 Group=<%= @service_user %>
+LimitNOFILE=<%= @ulimit %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This is essentially a stripped-down re-submission of #230. The original author of #230 seems to have abandoned his efforts (the repository is gone).

This PR contains the following enhancements:

* Add an example for multiple instances to the README
* Fix a dependency cycle by using camptocamp/systemd instead of `Exec` to reload systemd
* Updates to the systemd template
* Update tests accordingly

However, this re-submission does not include the `redis-shutdown.erb` template that was present in the original PR, because some users noted that this is not required. I can confirm this from my own testing.

Tested on CentOS 7.7 with Puppet 6.11 and Redis 5.

FWIW, this is the dependency cycle that may occur without the proposed modifications when using multiple instances:

```
Error: Found 1 dependency cycle:
(Exec[systemd-reload-redis] => Class[Redis] => Redis::Instance[6379] => File[/etc/systemd/system/redis-server-6379.service] => Exec[systemd-reload-redis])
```

#### This Pull Request (PR) fixes the following issues
n/a
