### PR TITLE
Update bolt testing to use modern versions

### DIFF
--- a/spec/acceptance/redis_cli_task_spec.rb
+++ b/spec/acceptance/redis_cli_task_spec.rb
@@ -21,20 +21,38 @@ describe 'redis-cli task' do
     end
   end
 
+  subject do
+    on(master, "bolt task run --modulepath /etc/puppetlabs/code/modules --targets localhost #{task_name} #{params}", acceptable_exit_codes: [0, 1]).stdout
+  end
+
+  let(:task_name) { 'redis::redis_cli' }
+
   describe 'ping' do
+    let(:params) { 'command="ping"' }
+
     it 'execute ping' do
-      result = run_task(task_name: 'redis::redis_cli', params: 'command="ping"')
-      expect_multiple_regexes(result: result, regexes: [%r{{"status":"PONG"}}, %r{Ran on 1 node in .+ seconds}])
+      is_expected.to match(%r{{\s*"status":\s*"PONG"\s*}})
+      is_expected.to match(%r{Ran on 1 target in .+ sec})
     end
   end
 
   describe 'security' do
-    it 'stops script injections and escapes' do
-      result = run_task(task_name: 'redis::redis_cli', params: 'command="ping; cat /etc/passwd"')
-      expect_multiple_regexes(result: result, regexes: [%r!{"status":"ERR unknown command ('|`)ping; cat /etc/passwd('|`)!, %r{Ran on 1 node in .+ seconds}])
+    describe 'command with semi colon' do
+      let(:params) { 'command="ping; cat /etc/passwd"' }
 
-      result = run_task(task_name: 'redis::redis_cli', params: 'command="ping && cat /etc/passwd"')
-      expect_multiple_regexes(result: result, regexes: [%r!{"status":"ERR unknown command ('|`)ping && cat /etc/passwd('|`)!, %r{Ran on 1 node in .+ seconds}])
+      it 'stops script injections and escapes' do
+        is_expected.to match(%r!{\s*"status":\s*"ERR unknown command ('|`)ping; cat /etc/passwd('|`)!)
+        is_expected.to match(%r{Ran on 1 target in .+ sec})
+      end
+    end
+
+    describe 'command with double ampersand' do
+      let(:params) { 'command="ping && cat /etc/passwd"' }
+
+      it 'stops script injections and escapes' do
+        is_expected.to match(%r!{\s*"status":\s*"ERR unknown command ('|`)ping && cat /etc/passwd('|`)!)
+        is_expected.to match(%r{Ran on 1 target in .+ sec})
+      end
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,34 +2,9 @@ require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
 
-DEFAULT_PASSWORD = 'root'.freeze
-
-def change_root_password(password = DEFAULT_PASSWORD)
-  on(hosts, "echo 'root:#{password}' | chpasswd")
-end
-
-def install_bolt_on(hosts)
-  on(hosts, "/opt/puppetlabs/puppet/bin/gem install winrm-fs -v '1.1.1' --no-ri --no-rdoc", acceptable_exit_codes: [0]).stdout
-  on(hosts, "/opt/puppetlabs/puppet/bin/gem install bolt -v '0.5.1' --no-ri --no-rdoc", acceptable_exit_codes: [0]).stdout
-end
-
 run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
-
-def run_task(task_name:, params: nil, password: DEFAULT_PASSWORD)
-  run_bolt_task(task_name: task_name, params: params, password: password)
-end
-
-def run_bolt_task(task_name:, params: nil, password: DEFAULT_PASSWORD)
-  on(master, "/opt/puppetlabs/puppet/bin/bolt task run #{task_name} --modules /etc/puppetlabs/code/modules/ --nodes localhost --user root --password #{password} #{params}", acceptable_exit_codes: [0, 1]).stdout
-end
-
-def expect_multiple_regexes(result:, regexes:)
-  regexes.each do |regex|
-    expect(result).to match(regex)
-  end
-end
 
 RSpec.configure do |c|
   # Readable test descriptions
@@ -37,18 +12,10 @@ RSpec.configure do |c|
 
   c.before :suite do
     hosts.each do |host|
-      case fact_on(host, 'operatingsystem')
-      when 'Debian'
-        host.install_package('build-essential')
-      when 'Ubuntu'
-        host.install_package('build-essential')
+      if fact_on(host, 'operatingsystem') == 'Ubuntu'
         host.install_package('software-properties-common')
-      else
-        # Bolt requires gcc and make
-        host.install_package('gcc')
-        host.install_package('make')
       end
+      host.install_package('puppet-bolt')
     end
-    install_bolt_on(hosts)
   end
 end


### PR DESCRIPTION
This changes the bolt testing to use bolt from packages. Because the output is different, the tests are modified. It removes all helpers from spec_helper_acceptance and uses more native rspec syntax to simplify the testing.