### PR TITLE
Run acceptance tests with manage_repo => false

### DIFF
--- a/spec/acceptance/redis_cli_task_spec.rb
+++ b/spec/acceptance/redis_cli_task_spec.rb
@@ -3,22 +3,11 @@ require 'spec_helper_acceptance'
 describe 'redis-cli task' do
   it 'install redis-cli with the class' do
     pp = <<-EOS
-    Exec {
-      path => [ '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', ]
-    }
-
-    class { '::redis':
-      manage_repo => true,
-    }
+    include redis
     EOS
 
     apply_manifest(pp, catch_failures: true)
-
-    # Apply twice to ensure no errors the second time.
-    # TODO: not idempotent on Ubuntu 16.04
-    unless fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemmajrelease') == '16.04'
-      apply_manifest(pp, catch_changes: true)
-    end
+    apply_manifest(pp, catch_changes: true)
   end
 
   subject do

--- a/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
@@ -1,37 +1,28 @@
 require 'spec_helper_acceptance'
 
-# Cant get this to work on Debian, add exception for now
-describe 'redis::instance', unless: (fact('operatingsystem') == 'Debian') do
+describe 'redis::instance' do
   case fact('osfamily')
   when 'Debian'
-    config_path  = '/etc/redis'
-    manage_repo  = false
+    config_path = '/etc/redis'
     redis_name = 'redis-server'
   else
     redis_name = 'redis'
-    config_path  = '/etc'
-    manage_repo  = true
+    config_path = '/etc'
   end
 
   it 'runs successfully' do
     pp = <<-EOS
-    Exec {
-      path => [ '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', ]
-    }
-
-    class { '::redis':
-      manage_repo     => #{manage_repo},
+    class { 'redis':
       default_install => false,
     }
 
     redis::instance {'redis1':
-      port                => 7777,
+      port => 7777,
     }
 
     redis::instance {'redis2':
-      port                => 8888,
+      port => 8888,
     }
-
     EOS
 
     # Apply twice to ensure no errors the second time.

--- a/spec/acceptance/suites/default/redis_multi_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_node_spec.rb
@@ -19,7 +19,6 @@ if hosts.length >= 3
           }
 
           class { 'redis':
-            manage_repo => true,
             bind        => '#{master_ip_address}',
             requirepass => 'foobared',
           }
@@ -40,7 +39,6 @@ if hosts.length >= 3
         it 'works idempotently with no errors' do
           pp = <<-EOS
           class { 'redis':
-            manage_repo => true,
             bind        => '127.0.0.1',
             masterauth  => 'foobared',
             slaveof     => '#{master_ip_address} 6379'

--- a/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/suites/default/redis_sentinel_one_node_spec.rb
@@ -10,31 +10,15 @@ describe 'redis::sentinel' do
 
   it 'runs successfully' do
     pp = <<-EOS
-
-    $master_name      = 'mymaster'
-    $redis_master     = '127.0.0.1'
-    $failover_timeout = 10000
-
-    # We're testing with `manage_repo` true.  In redis-sentinel 5, the daemon has its own rundir
-    if $::operatingsystem == 'Ubuntu' {
-      $pidfile = '/var/run/sentinel/redis-sentinel.pid'
-    } else {
-      $pidfile = undef
-    }
-
-    class { 'redis':
-      manage_repo => true,
-    }
-    ->
     class { 'redis::sentinel':
-      master_name      => $master_name,
-      redis_host       => $redis_master,
-      failover_timeout => $failover_timeout,
-      pid_file         => $pidfile,
+      master_name      => 'mymaster',
+      redis_host       => '127.0.0.1',
+      failover_timeout => 10000,
     }
     EOS
 
     apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
   end
 
   describe package(redis_name) do

--- a/spec/acceptance/suites/default/redis_spec.rb
+++ b/spec/acceptance/suites/default/redis_spec.rb
@@ -1,24 +1,16 @@
 require 'spec_helper_acceptance'
 
 describe 'redis' do
-  case fact('osfamily')
-  when 'Debian'
-    redis_name  = 'redis-server'
-    manage_repo = false
-  else
-    redis_name  = 'redis'
-    manage_repo = true
-  end
+  redis_name = case fact('osfamily')
+               when 'Debian'
+                 'redis-server'
+               else
+                 'redis'
+               end
 
   it 'runs successfully' do
     pp = <<-EOS
-    Exec {
-      path => [ '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', ]
-    }
-
-    class { '::redis':
-      manage_repo => #{manage_repo},
-    }
+    include redis
     EOS
 
     # Apply twice to ensure no errors the second time.

--- a/spec/acceptance/suites/default/redisget_spec.rb
+++ b/spec/acceptance/suites/default/redisget_spec.rb
@@ -4,20 +4,13 @@ require 'spec_helper_acceptance'
 describe 'redis::get() function' do
   it 'runs successfully' do
     pp = <<-EOS
-    Exec {
-      path => [ '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', ]
-    }
-
-    class { 'redis':
-      manage_repo => true,
-    }
+    include redis
 
     package { 'redis-rubygem' :
       ensure   => '3.3.3',
       name     => 'redis',
       provider => 'puppet_gem',
     }
-
     EOS
 
     # Apply twice to ensure no errors the second time.

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -12,7 +12,10 @@ RSpec.configure do |c|
 
   c.before :suite do
     hosts.each do |host|
-      if fact_on(host, 'operatingsystem') == 'Ubuntu'
+      case fact_on(host, 'operatingsystem')
+      when 'CentOS'
+        host.install_package('epel-release')
+      when 'Ubuntu'
         host.install_package('software-properties-common')
       end
       host.install_package('puppet-bolt')


### PR DESCRIPTION
This makes sure we tests with the manifest defaults. It also allows testing on Debian 10 for which there is no dotdeb repository.