### PR TITLE
Make apt and epel soft dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ class { '::redis':
 }
 ```
 
+**Warning** note that it requires [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) on Debian or Ubuntu distros. On Red Hat [puppet/epel](https://forge.puppet.com/puppet/epel) is needed unless the installation is using Software Collections. In that case will install `centos-release-scl-rh` from CentOS extras. For RHEL or other RHEL-derivatives this isn't managed.
+
 ### Redis Sentinel
 
 Optionally install and configuration a redis-sentinel server.
@@ -133,7 +135,9 @@ class { '::redis::sentinel':
 
 ### Soft dependency
 
-This module requires `camptocamp/systemd` on Puppet versions older than 6.1.0.
+This module requires [camptocamp/systemd](https://forge.puppet.com/camptocamp/systemd) on Puppet versions older than 6.1.0.
+
+When managing the repo, it either needs [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) or [puppet/epel](https://forge.puppet.com/puppet/epel).
 
 ## `redis::get()` function
 

--- a/metadata.json
+++ b/metadata.json
@@ -9,16 +9,8 @@
   "issues_url": "https://github.com/voxpupuli/puppet-redis/issues",
   "dependencies": [
     {
-      "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.3.0 < 8.0.0"
-    },
-    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.25.0 < 7.0.0"
-    },
-    {
-      "name": "puppet/epel",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_sysctl",


### PR DESCRIPTION
The defaults are not to manage repositories. This means the modules are not needed in most cases.