### PR TITLE
enable sentinel bind usage with multi ip

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -149,7 +149,7 @@ class redis::sentinel (
     }
   }
 
-  $sentinel_bind_arr = [$sentinel_bind].flatten
+  $sentinel_bind_arr = delete_undef_values([$sentinel_bind]).flatten
 
   file { $config_file_orig:
     ensure  => file,

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -149,7 +149,7 @@ class redis::sentinel (
     }
   }
 
-  $sentinel_bind_arr = delete_undef_values([$sentinel_bind]).flatten
+  $sentinel_bind_arr = delete_undef_values([$sentinel_bind].flatten)
 
   file { $config_file_orig:
     ensure  => file,

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -149,6 +149,8 @@ class redis::sentinel (
     }
   }
 
+  $sentinel_bind_arr = [$sentinel_bind].flatten
+
   file { $config_file_orig:
     ensure  => file,
     owner   => $service_user,

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -110,6 +110,47 @@ CONFIG
         it { is_expected.to create_class('redis::sentinel') }
         it { is_expected.to contain_file(config_file_orig).with_content(expected_content) }
       end
+
+      describe 'with array sentinel bind' do
+        let(:params) do
+          {
+            auth_pass: 'password',
+            sentinel_bind: ['192.0.2.10', '192.168.1.1'],
+            master_name: 'cow',
+            down_after: 6000,
+            working_dir: '/tmp/redis',
+            log_file: '/tmp/barn-sentinel.log',
+            failover_timeout: 28_000,
+            notification_script: '/path/to/bar.sh',
+            client_reconfig_script: '/path/to/foo.sh'
+          }
+        end
+
+        let(:expected_content) do
+          <<CONFIG
+bind 192.0.2.10 192.168.1.1
+port 26379
+dir /tmp/redis
+daemonize #{facts[:osfamily] == 'RedHat' ? 'no' : 'yes'}
+pidfile #{pidfile}
+
+sentinel monitor cow 127.0.0.1 6379 2
+sentinel down-after-milliseconds cow 6000
+sentinel parallel-syncs cow 1
+sentinel failover-timeout cow 28000
+sentinel auth-pass cow password
+sentinel notification-script cow /path/to/bar.sh
+sentinel client-reconfig-script cow /path/to/foo.sh
+
+loglevel notice
+logfile /tmp/barn-sentinel.log
+CONFIG
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('redis::sentinel') }
+        it { is_expected.to contain_file(config_file_orig).with_content(expected_content) }
+      end
     end
   end
 end

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -1,5 +1,5 @@
-<% if @sentinel_bind -%>
-bind <%= @sentinel_bind %>
+<% unless @sentinel_bind_arr.empty? -%>
+bind <%= @sentinel_bind_arr.join(' ') %>
 <% end -%>
 port <%= @sentinel_port %>
 dir <%= @working_dir %>


### PR DESCRIPTION
#### Pull Request (PR) description
There is currently an issue where if you use the allowed array of IP for the sentinel bind, this fails and the template becomes something completely broken as the resulting template shows:
```
bind ["10.0.0.155", "127.0.0.1"]
```

This PR fixes that by using the same technique in the base redis usage to force it into an array and flatten it to generate a correct bind line.