### PR TITLE
Make `sentinel::protected_mode` `Optional`

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,6 @@ class redis::params inherits redis::globals {
       $sentinel_package_name     = 'redis-sentinel'
       $sentinel_log_file         = '/var/log/redis/redis-sentinel.log'
       $sentinel_working_dir      = '/var/lib/redis'
-      $sentinel_protected_mode   = true
 
       case $facts['os']['name'] {
         'Ubuntu': {
@@ -63,7 +62,6 @@ class redis::params inherits redis::globals {
       $sentinel_daemonize   = false
       $sentinel_init_script = undef
       $sentinel_working_dir = '/tmp'
-      $sentinel_protected_mode   = true
 
       $scl = $redis::globals::scl
       if $scl {
@@ -135,7 +133,6 @@ class redis::params inherits redis::globals {
       $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
       $sentinel_log_file         = '/var/log/redis/sentinel.log'
       $sentinel_working_dir      = '/tmp'
-      $sentinel_protected_mode   = true
 
       # pkg version
       $minimum_version           = '3.2.4'
@@ -165,7 +162,6 @@ class redis::params inherits redis::globals {
       $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
       $sentinel_log_file         = '/var/log/redis/sentinel.log'
       $sentinel_working_dir      = '/tmp'
-      $sentinel_protected_mode   = true
 
       # suse package version
       $minimum_version           = '3.0.5'
@@ -196,7 +192,6 @@ class redis::params inherits redis::globals {
       $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
       $sentinel_log_file         = '/var/log/redis/sentinel.log'
       $sentinel_working_dir      = '/tmp'
-      $sentinel_protected_mode   = true
 
       # pkg version
       $minimum_version           = '3.2.4'

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -114,7 +114,7 @@ class redis::sentinel (
   Stdlib::Filemode $config_file_mode = '0644',
   String[1] $conf_template = 'redis/redis-sentinel.conf.erb',
   Boolean $daemonize = $redis::params::sentinel_daemonize,
-  Boolean $protected_mode = $redis::params::sentinel_protected_mode,
+  Optional[Boolean] $protected_mode = undef,
   Integer[1] $down_after = 30000,
   Integer[1] $failover_timeout = 180000,
   Optional[Stdlib::Absolutepath] $init_script = $redis::params::sentinel_init_script,
@@ -129,7 +129,7 @@ class redis::sentinel (
   Integer[0] $parallel_sync = 1,
   Stdlib::Absolutepath $pid_file = $redis::params::sentinel_pid_file,
   Integer[1] $quorum = 2,
-  Variant[Undef, Stdlib::IP::Address, Array[Stdlib::IP::Address]] $sentinel_bind = undef,
+  Optional[Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]]] $sentinel_bind = undef,
   Stdlib::Port $sentinel_port = 26379,
   String[1] $service_group = 'redis',
   String[1] $service_name = $redis::params::sentinel_service_name,
@@ -141,6 +141,10 @@ class redis::sentinel (
   Optional[Stdlib::Absolutepath] $client_reconfig_script = undef,
 ) inherits redis::params {
   require 'redis'
+
+  if $sentinel_bind and $protected_mode != undef {
+    fail('`protected_mode` should not be set at the same time as `sentinel_bind`')
+  }
 
   if $facts['os']['family'] == 'Debian' {
     package { $package_name:

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -5,7 +5,9 @@ port <%= @sentinel_port %>
 dir <%= @working_dir %>
 daemonize <%= @daemonize ? 'yes' : 'no' %>
 pidfile <%= @pid_file %>
+<% unless @protected_mode.nil? -%>
 protected-mode <%= @protected_mode ? 'yes' : 'no' %>
+<% end -%>
 
 sentinel monitor <%= @master_name %> <%= @redis_host %> <%= @redis_port %> <%= @quorum %>
 sentinel down-after-milliseconds <%= @master_name %> <%= @down_after %>


### PR DESCRIPTION
This might be a bit less disruptive than defaulting it to `true`, (and
means it won't break any sentinel 3.0 users if we've got any).