### PR TITLE
Drop dotdeb repo management support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ class { '::redis':
 }
 ```
 
-**Warning** note that it requires [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) on Debian or Ubuntu distros. On Red Hat [puppet/epel](https://forge.puppet.com/puppet/epel) is needed unless the installation is using Software Collections. In that case will install `centos-release-scl-rh` from CentOS extras. For RHEL or other RHEL-derivatives this isn't managed.
+**Warning** note that it requires [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) on Ubuntu distros. On Red Hat [puppet/epel](https://forge.puppet.com/puppet/epel) is needed unless the installation is using Software Collections. In that case will install `centos-release-scl-rh` from CentOS extras. For RHEL or other RHEL-derivatives this isn't managed.
 
 ### Redis Sentinel
 

--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -14,17 +14,6 @@ class redis::preinstall {
           require 'epel'
         }
       }
-    } elsif $facts['os']['name'] == 'Debian' {
-      contain 'apt'
-      apt::source { 'dotdeb':
-        location => 'http://packages.dotdeb.org/',
-        repos    => 'all',
-        key      => {
-          id     => '6572BBEF1B5FF28B28B706837E3F070089DF5277',
-          source => 'http://www.dotdeb.org/dotdeb.gpg',
-        },
-        include  => { 'src' => true },
-      }
     } elsif $facts['os']['name'] == 'Ubuntu' {
       contain 'apt'
       apt::ppa { $redis::ppa_repo:

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -484,18 +484,6 @@ describe 'redis' do
         let(:params) { { manage_repo: true } }
 
         case facts[:operatingsystem]
-        when 'Debian'
-          context 'on Debian' do
-            it do
-              is_expected.to create_apt__source('dotdeb').with(location: 'http://packages.dotdeb.org/',
-                                                               repos: 'all',
-                                                               key: {
-                                                                 'id' => '6572BBEF1B5FF28B28B706837E3F070089DF5277',
-                                                                 'source' => 'http://www.dotdeb.org/dotdeb.gpg'
-                                                               },
-                                                               include: { 'src' => true })
-            end
-          end
         when 'Ubuntu'
           it { is_expected.to contain_apt__ppa('ppa:chris-lea/redis-server') }
         when 'RedHat', 'CentOS', 'Scientific', 'OEL', 'Amazon'


### PR DESCRIPTION
The dotdeb project has been discontinued and never published packages for Debian 9 or 10. 645229f8aa507eb3213de0c4daa4cb8966859287 dropped Debian 8 support so this is essentially dead code that can only lead to problems.