### PR TITLE
Move package parameters to init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -280,6 +280,7 @@ class redis (
   Optional[String[1]] $notify_keyspace_events                    = undef,
   Boolean $notify_service                                        = true,
   Boolean $managed_by_cluster_manager                            = false,
+  String[1] $minimum_version                                     = $redis::params::minimum_version,
   String[1] $package_ensure                                      = 'present',
   String[1] $package_name                                        = $redis::params::package_name,
   Stdlib::Absolutepath $pid_file                                 = $redis::params::pid_file,
@@ -332,6 +333,19 @@ class redis (
   Integer[0] $cluster_migration_barrier                          = 1,
   Hash[String[1], Hash] $instances                               = {},
 ) inherits redis::params {
+  if $package_ensure =~ /^([0-9]+:)?[0-9]+\.[0-9]/ {
+    if ':' in $package_ensure {
+      $_redis_version_real = split($package_ensure, ':')
+      $redis_version_real = $_redis_version_real[1]
+    } else {
+      $redis_version_real = $package_ensure
+    }
+  } else {
+    $redis_version_real = pick(getvar('redis_server_version'), $minimum_version)
+  }
+
+  $supports_protected_mode = !$redis_version_real or versioncmp($redis_version_real, '3.2.0') >= 0
+
   contain redis::preinstall
   contain redis::install
   contain redis::config

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -226,7 +226,6 @@ define redis::instance (
   Stdlib::Absolutepath $log_dir                                  = $redis::log_dir,
   Stdlib::Filemode $log_dir_mode                                 = $redis::log_dir_mode,
   Redis::LogLevel $log_level                                     = $redis::log_level,
-  String[1] $minimum_version                                     = $redis::minimum_version,
   Optional[String[1]] $masterauth                                = $redis::masterauth,
   Integer[1] $maxclients                                         = $redis::maxclients,
   $maxmemory                                                     = $redis::maxmemory,
@@ -237,7 +236,6 @@ define redis::instance (
   Boolean $no_appendfsync_on_rewrite                             = $redis::no_appendfsync_on_rewrite,
   Optional[String[1]] $notify_keyspace_events                    = $redis::notify_keyspace_events,
   Boolean $managed_by_cluster_manager                            = $redis::managed_by_cluster_manager,
-  String[1] $package_ensure                                      = $redis::package_ensure,
   Stdlib::Port $port                                             = $redis::port,
   Boolean $protected_mode                                        = $redis::protected_mode,
   Boolean $rdbcompression                                        = $redis::rdbcompression,
@@ -388,18 +386,7 @@ define redis::instance (
 
   $bind_arr = [$bind].flatten
 
-  if $package_ensure =~ /^([0-9]+:)?[0-9]+\.[0-9]/ {
-    if ':' in $package_ensure {
-      $_redis_version_real = split($package_ensure, ':')
-      $redis_version_real = $_redis_version_real[1]
-    } else {
-      $redis_version_real = $package_ensure
-    }
-  } else {
-    $redis_version_real = pick(getvar('redis_server_version'), $minimum_version)
-  }
-
-  $supports_protected_mode = !$redis_version_real or versioncmp($redis_version_real, '3.2.0') >= 0
+  $supports_protected_mode = $redis::supports_protected_mode
 
   File[$redis_file_name_orig] { content => template($conf_template) }
 }

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -154,6 +154,7 @@ class redis::sentinel (
   }
 
   $sentinel_bind_arr = delete_undef_values([$sentinel_bind].flatten)
+  $supports_protected_mode = $redis::supports_protected_mode
 
   file { $config_file_orig:
     ensure  => file,

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -29,6 +29,10 @@ describe 'redis::sentinel' do
         end
       end
 
+      let(:protected_mode) do
+        facts[:operatingsystem] != 'Ubuntu' || facts[:operatingsystemmajrelease] != '16.04'
+      end
+
       describe 'without parameters' do
         let(:expected_content) do
           <<CONFIG
@@ -36,8 +40,7 @@ port 26379
 dir #{facts[:osfamily] == 'Debian' ? '/var/lib/redis' : '/tmp'}
 daemonize #{facts[:osfamily] == 'RedHat' ? 'no' : 'yes'}
 pidfile #{pidfile}
-protected-mode yes
-
+#{protected_mode ? "protected-mode yes\n" : ''}
 sentinel monitor mymaster 127.0.0.1 6379 2
 sentinel down-after-milliseconds mymaster 30000
 sentinel parallel-syncs mymaster 1
@@ -94,8 +97,7 @@ port 26379
 dir /tmp/redis
 daemonize #{facts[:osfamily] == 'RedHat' ? 'no' : 'yes'}
 pidfile #{pidfile}
-protected-mode no
-
+#{protected_mode ? "protected-mode no\n" : ''}
 sentinel monitor cow 127.0.0.1 6379 2
 sentinel down-after-milliseconds cow 6000
 sentinel parallel-syncs cow 1
@@ -136,7 +138,7 @@ port 26379
 dir /tmp/redis
 daemonize #{facts[:osfamily] == 'RedHat' ? 'no' : 'yes'}
 pidfile #{pidfile}
-
+#{protected_mode ? "protected-mode yes\n" : ''}
 sentinel monitor cow 127.0.0.1 6379 2
 sentinel down-after-milliseconds cow 6000
 sentinel parallel-syncs cow 1

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -5,7 +5,9 @@ port <%= @sentinel_port %>
 dir <%= @working_dir %>
 daemonize <%= @daemonize ? 'yes' : 'no' %>
 pidfile <%= @pid_file %>
+<% if @supports_protected_mode -%>
 protected-mode <%= @protected_mode ? 'yes' : 'no' %>
+<% end -%>
 
 sentinel monitor <%= @master_name %> <%= @redis_host %> <%= @redis_port %> <%= @quorum %>
 sentinel down-after-milliseconds <%= @master_name %> <%= @down_after %>


### PR DESCRIPTION
This moves package_ensure and minimum_version parameters to init.pp.  They don't make sense on the instance because they're not actually honored. They are only used to determine whether protected mode is supported. Having that variable in the main redis class allows the sentinel to reuse the definition.