### PR TITLE
Make augeasproviders_sysctl a soft dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ class { '::redis::sentinel':
 
 When managing the repo, it either needs [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) or [puppet/epel](https://forge.puppet.com/puppet/epel).
 
+For administration of sysctl it depends on [herculesteam/augeasproviders_sysctl](https://forge.puppet.com/herculesteam/augeasproviders_sysctl).
+
 ## `redis::get()` function
 
 This function is used to get data from redis.

--- a/manifests/administration.pp
+++ b/manifests/administration.pp
@@ -3,6 +3,8 @@
 # For disabling Transparent Huge Pages (THP), use separate module such as:
 # https://forge.puppet.com/modules/alexharvey/disable_transparent_hugepage
 #
+# Note that this class requires the herculesteam/augeasproviders_sysctl module.
+#
 # @example
 #   include redis::administration
 #
@@ -18,6 +20,7 @@
 #
 # @author - Peter Souter
 # @see https://redis.io/topics/admin
+# @see https://forge.puppet.com/herculesteam/augeasproviders_sysctl
 #
 class redis::administration (
   Boolean $enable_overcommit_memory = true,

--- a/metadata.json
+++ b/metadata.json
@@ -13,14 +13,6 @@
       "version_requirement": ">= 4.25.0 < 8.0.0"
     },
     {
-      "name": "herculesteam/augeasproviders_sysctl",
-      "version_requirement": ">= 2.1.0 < 3.0.0"
-    },
-    {
-      "name": "herculesteam/augeasproviders_core",
-      "version_requirement": ">= 2.1.0 < 3.0.0"
-    },
-    {
       "name": "camptocamp/systemd",
       "version_requirement": ">= 2.0.0 < 4.0.0"
     }


### PR DESCRIPTION
augeasproviders_core was already redundant since augeasproviders_sysctl already depended on it and wasn't used directly.

Since augeasproviders_sysctl is only used on Red Hat and Debian to set ulimit when using non-systemd platforms (EL6, Debian with manual change from defaults). Those account for a very small number of the deployments so this makes it a soft dependency.