### PR TITLE
Make spec_helper.rb managed again

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -5,4 +5,4 @@ Gemfile:
       - gem: 'redis'
       - gem: 'mock_redis'
 spec/spec_helper.rb:
-  unmanaged: true
+  mock_with: ":mocha"

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -2,10 +2,19 @@ require 'spec_helper'
 
 describe 'redis' do
   let(:service_file) { "/etc/systemd/system/#{service_name}.service" }
-  let(:package_name) { manifest_vars[:package_name] }
-  let(:service_name) { manifest_vars[:service_name] }
-  let(:config_file) { manifest_vars[:config_file] }
-  let(:config_file_orig) { manifest_vars[:config_file_orig] }
+  let(:package_name) { facts[:osfamily] == 'Debian' ? 'redis-server' : 'redis' }
+  let(:service_name) { package_name }
+  let(:config_file) do
+    case facts[:osfamily]
+    when 'Archlinux', 'Debian'
+      '/etc/redis/redis.conf'
+    when 'FreeBSD',
+      '/usr/local/etc/redis.conf'
+    when 'RedHat'
+      '/etc/redis.conf'
+    end
+  end
+  let(:config_file_orig) { "#{config_file}.puppet" }
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,35 +6,6 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
-def manifest_vars
-  vars = {}
-
-  case facts[:osfamily].to_s
-  when 'RedHat'
-    vars[:package_name] = 'redis'
-    vars[:service_name] = 'redis'
-    vars[:config_file] = '/etc/redis.conf'
-    vars[:config_file_orig] = '/etc/redis.conf.puppet'
-  when 'FreeBSD',
-    vars[:package_name] = 'redis'
-    vars[:service_name] = 'redis'
-    vars[:config_file] = '/usr/local/etc/redis.conf'
-    vars[:config_file_orig] = '/usr/local/etc/redis.conf.puppet'
-  when 'Debian'
-    vars[:package_name] = 'redis-server'
-    vars[:service_name] = 'redis-server'
-    vars[:config_file] = '/etc/redis/redis.conf'
-    vars[:config_file_orig] = '/etc/redis/redis.conf.puppet'
-  when 'Archlinux'
-    vars[:package_name] = 'redis'
-    vars[:service_name] = 'redis'
-    vars[:config_file] = '/etc/redis/redis.conf'
-    vars[:config_file_orig] = '/etc/redis/redis.conf.puppet'
-  end
-
-  vars
-end
-
 if ENV['DEBUG']
   Puppet::Util::Log.level = :debug
   Puppet::Util::Log.newdestination(:console)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,31 +1,22 @@
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/voxpupuli/modulesync_config
+
 RSpec.configure do |c|
   c.mock_with :mocha
 end
 
-require 'puppetlabs_spec_helper/module_spec_helper'
-require 'rspec-puppet-facts'
-include RspecPuppetFacts
+# puppetlabs_spec_helper will set up coverage if the env variable is set.
+# We want to do this if lib exists and it hasn't been explicitly set.
+ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../../lib', __FILE__))
 
-if ENV['DEBUG']
-  Puppet::Util::Log.level = :debug
-  Puppet::Util::Log.newdestination(:console)
-end
+require 'voxpupuli/test/spec_helper'
 
-RSpec.configure do |c|
-  # getting the correct facter version is tricky. We use facterdb as a source to mock facts
-  # see https://github.com/camptocamp/facterdb
-  # people might provide a specific facter version. In that case we use it.
-  # Otherwise we need to match the correct facter version to the used puppet version.
-  # as of 2019-10-31, puppet 5 ships facter 3.11 and puppet 6 ships facter 3.14
-  # https://puppet.com/docs/puppet/5.5/about_agent.html
-  c.default_facter_version = if ENV['FACTERDB_FACTS_VERSION']
-                               ENV['FACTERDB_FACTS_VERSION']
-                             else
-                               Gem::Dependency.new('', ENV['PUPPET_VERSION']).match?('', '5') ? '3.11.0' : '3.14.0'
-                             end
-
-  # Coverage generation
-  c.after(:suite) do
-    RSpec::Puppet::Coverage.report!
+if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
+  facts = YAML.safe_load(File.read(File.join(__dir__, 'default_module_facts.yml')))
+  if facts
+    facts.each do |name, value|
+      add_custom_fact name.to_sym, value
+    end
   end
 end


### PR DESCRIPTION
This allows getting updates via modulesync again. It currently depends on https://github.com/voxpupuli/voxpupuli-test/pull/19 which is why it's a draft. This is also to see if that PR actually works.