### PR TITLE
Add support for rename-command in redis.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,6 +125,8 @@
 #   Specify upstream (Ubuntu) PPA entry.
 # @param rdbcompression
 #   Enable/disable compression of string objects using LZF when dumping.
+# @param rename_commands
+#   A list of Redis commands to rename or disable for security reasons
 # @param repl_backlog_size
 #   The replication backlog size
 # @param repl_backlog_ttl
@@ -282,6 +284,7 @@ class redis (
   Boolean $protected_mode                                        = true,
   Optional[String] $ppa_repo                                     = $redis::params::ppa_repo,
   Boolean $rdbcompression                                        = true,
+  Hash[String,String] $rename_commands                           = {},
   String[1] $repl_backlog_size                                   = '1mb',
   Integer[0] $repl_backlog_ttl                                   = 3600,
   Boolean $repl_disable_tcp_nodelay                              = false,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -94,6 +94,8 @@
 #   Whether protected mode is enabled or not.  Only applicable when no bind is set.
 # @param rdbcompression
 #   Enable/disable compression of string objects using LZF when dumping.
+# @param rename_commands
+#   A list of Redis commands to rename or disable for security reasons
 # @param repl_backlog_size
 #   The replication backlog size
 # @param repl_backlog_ttl
@@ -235,6 +237,7 @@ define redis::instance (
   Stdlib::Port $port                                             = $redis::port,
   Boolean $protected_mode                                        = $redis::protected_mode,
   Boolean $rdbcompression                                        = $redis::rdbcompression,
+  Hash[String,String] $rename_commands                           = $redis::rename_commands,
   String[1] $repl_backlog_size                                   = $redis::repl_backlog_size,
   Integer[0] $repl_backlog_ttl                                   = $redis::repl_backlog_ttl,
   Boolean $repl_disable_tcp_nodelay                              = $redis::repl_disable_tcp_nodelay,

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -742,6 +742,44 @@ describe 'redis' do
         }
       end
 
+      describe 'with parameter rename_commands' do
+        context 'with a single rename' do
+          let(:params) do
+            {
+              rename_commands: { CONFIG: "\"\"" }
+            }
+          end
+          it {
+            is_expected.to contain_file(config_file_orig).with(
+              'content' => %r{^rename-command CONFIG ""$}
+            )
+          }
+        end
+        context 'with multiple renames' do
+          let(:params) do
+            {
+              rename_commands: { CONFIG: "\"\"", RENAME: "\"\"" }
+            }
+          end
+          it {
+            is_expected.to contain_file(config_file_orig).with(
+              'content' => %r{^rename-command CONFIG ""$}
+            )
+            is_expected.to contain_file(config_file_orig).with(
+              'content' => %r{^rename-command RENAME ""$}
+            )
+          }
+        end
+        context 'with empty hash' do
+          let(:params) do
+            {
+              "rename_commands" => {}
+            }
+          end
+          it { is_expected.not_to contain_file(config_file_orig).with_content(%r{^rename-command}) }
+        end
+      end
+
       describe 'with parameter repl_backlog_size' do
         let(:params) do
           {

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -355,6 +355,9 @@ min-slaves-max-lag <%= @min_slaves_max_lag %>
 # an empty string:
 #
 # rename-command CONFIG ""
+<% @rename_commands.each do |from,to| -%>
+rename-command <%= from %> <%= to %>
+<% end -%>
 
 ################################### LIMITS ####################################
 


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request adds support for renaming or disabling commands in redis.conf.
This is [best practice](https://redis.io/topics/security) when running production instances.

Hiera example:
```
redis::rename_commands:
  FLUSHDB: "\"\""
  FLUSHALL: "\"\""
  CONFIG: "\"\""
  SHUTDOWN: "\"\""
  DEBUG: "\"\""
```

#### This Pull Request (PR) fixes the following issues
Fixes #242 