### PR TITLE
#372 Ensure THP is disabled after reboot

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,4 +13,3 @@ fixtures:
       puppet_version: ">= 6.0.0"
     systemd:
       repo: 'https://github.com/camptocamp/puppet-systemd.git'
-      puppet_version: "< 6.1.0"

--- a/files/service_files/disable_thp.service
+++ b/files/service_files/disable_thp.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Disables THP on boot
+
+[Service]
+Type=oneshot
+ExecStart=/bin/hugeadm --thp-never
+
+[Install]
+WantedBy=default.target

--- a/files/service_files/disable_thp.timer
+++ b/files/service_files/disable_thp.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Ensure that THP is disabled at boot
+
+[Timer]
+OnBootSec=0
+
+[Install]
+WantedBy=timers.target

--- a/manifests/administration.pp
+++ b/manifests/administration.pp
@@ -36,21 +36,16 @@ class redis::administration (
     package { $hugeadm_package:
       ensure => 'present',
     }
-
-    exec { 'systemd run_once disable_thp':
-      command     => '/usr/bin/systemctl start disable_thp.service',
-      refreshonly => true,
-      subscribe   => Systemd::Unit_file['disable_thp.service'],
-    }
   }
 
-  $ensure_thp_service = $disable_thp ? { true => 'present', false => 'absent' }
+  $ensure_thp = $disable_thp ? { true => 'present', false => 'absent' }
 
-  systemd::unit_file { 'disable_thp.service':
-    ensure  => $ensure_thp_service,
-    active  => false,
-    enable  => $disable_thp,
-    content => file("${module_name}/service_files/disable_thp.service"),
+  systemd::timer { 'disable_thp.timer':
+    ensure          => $ensure_thp,
+    timer_content   => file("${module_name}/service_files/disable_thp.timer"),
+    service_content => file("${module_name}/service_files/disable_thp.service"),
+    active          => false,
+    enable          => $disable_thp,
   }
 
   if $somaxconn > 0 {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,6 +38,8 @@ class redis::params inherits redis::globals {
             '16.04' => '/var/run/redis/redis-sentinel.pid',
             default => '/var/run/sentinel/redis-sentinel.pid',
           }
+
+          $hugeadm_package = 'hugepages'
         }
         default: {
           $config_group              = 'root'
@@ -47,6 +49,7 @@ class redis::params inherits redis::globals {
           } else {
             $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
           }
+          $hugeadm_package           = 'libhugetlbfs'
         }
       }
     }
@@ -62,6 +65,8 @@ class redis::params inherits redis::globals {
       $sentinel_daemonize   = false
       $sentinel_working_dir = '/tmp'
       $sentinel_protected_mode   = true
+
+      $hugeadm_package = 'libhugetlbfs-utils'
 
       $scl = $redis::globals::scl
       if $scl {
@@ -162,6 +167,8 @@ class redis::params inherits redis::globals {
 
       # suse package version
       $minimum_version           = '3.0.5'
+
+      $hugeadm_package           = 'libhugetlbfs-utils'
     }
 
     'Archlinux': {
@@ -192,6 +199,8 @@ class redis::params inherits redis::globals {
 
       # pkg version
       $minimum_version           = '3.2.4'
+
+      $hugeadm_package           = 'libhugetlbfs'
     }
     default: {
       fail "Operating system ${facts['os']['name']} is not supported yet."

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,10 @@
     {
       "name": "herculesteam/augeasproviders_core",
       "version_requirement": ">= 2.1.0 < 3.0.0"
+    },
+    {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 2.1.0 < 3.0.0"
     }
   ],
   "description": "Redis module with cluster support",

--- a/spec/classes/redis_administration_spec.rb
+++ b/spec/classes/redis_administration_spec.rb
@@ -1,28 +1,59 @@
 require 'spec_helper'
 
 describe 'redis::administration' do
-  context 'should set kernel and system values' do
-    it do
-      is_expected.to contain_sysctl('vm.overcommit_memory').with(
-        'ensure' => 'present',
-        'value' => '1'
-      )
-    end
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      let(:thp_control_package_name) do
+        case facts[:osfamily]
+        when 'Debian'
+          'libhugetlbfs'
+        when 'Ubuntu'
+          'hugepagesz'
+        when 'RedHat'
+          'libhugetlbfs-utils'
+        when 'Archlinux'
+          'libhugetlbfs'
+        end
+      end
+      it do
+        is_expected.to contain_sysctl('vm.overcommit_memory').with(
+          'ensure' => 'present',
+          'value' => '1'
+        )
+      end
 
-    it do
-      is_expected.to contain_exec('Disable Hugepages').with(
-        'command' => 'echo never > /sys/kernel/mm/transparent_hugepage/enabled',
-        'path' => ['/sbin', '/usr/sbin', '/bin', '/usr/bin'],
-        'onlyif' => 'test -f /sys/kernel/mm/transparent_hugepage/enabled',
-        'unless' => 'cat /sys/kernel/mm/transparent_hugepage/enabled | grep "\\[never\\]"'
-      )
-    end
+      it do
+        is_expected.to contain_sysctl('net.core.somaxconn').with(
+          'ensure' => 'present',
+          'value' => '65535'
+        )
+      end
 
-    it do
-      is_expected.to contain_sysctl('net.core.somaxconn').with(
-        'ensure' => 'present',
-        'value' => '65535'
-      )
+      it {
+        is_expected.to contain_file('/etc/systemd/system/disable_thp.service').
+          with_ensure('file').
+          with_mode('0644').
+          with_owner('root').
+          with_content(%r{ExecStart=/bin/hugeadm --thp-never})
+      }
+
+      it { is_expected.to contain_package(thp_control_package_name).with_ensure('present') }
+
+      it do
+        is_expected.to contain_service('disable_thp').with(
+          'ensure' => 'false',
+          'enable' => 'true',
+        )
+      end
+
+      it do
+        is_expected.to contain_exec('systemd run_once disable_thp').with(
+          'command' => '/usr/bin/systemctl start disable_thp.service',
+          'refreshonly' => 'true',
+        )
+      end
+
     end
   end
 end

--- a/spec/classes/redis_administration_spec.rb
+++ b/spec/classes/redis_administration_spec.rb
@@ -40,6 +40,7 @@ describe 'redis::administration' do
       it {
         is_expected.to contain_class('systemd')
       }
+      it { is_expected.to contain_systemd__unit_file('disable_thp.timer') }
 
       describe 'unit file' do
         let(:content) { catalogue.resource('systemd::unit_file', 'disable_thp.service').send(:parameters)[:content] }
@@ -51,13 +52,6 @@ describe 'redis::administration' do
         it 'ExecStart' do
           expect(content).to include('ExecStart=/bin/hugeadm --thp-never')
         end
-      end
-
-      it do
-        is_expected.to contain_exec('systemd run_once disable_thp').with(
-          'command' => '/usr/bin/systemctl start disable_thp.service',
-          'refreshonly' => 'true',
-        )
       end
 
     end


### PR DESCRIPTION
#### Pull Request (PR) description
Change the way THP is managed, by adding a way to disable it without running puppet in case of a reboot.

#### This Pull Request (PR) fixes the following issues
Fixes #372 
