### PR TITLE
Allow relative paths for $log_file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,7 +82,8 @@
 # @param log_dir_mode
 #   Adjust mode for directory containing log files.
 # @param log_file
-#   Specify file where to write log entries.
+#   Specify file where to write log entries. Relative paths will be prepended
+#   with log_dir but absolute paths are also accepted.
 # @param log_level
 #   Specify the server verbosity level.
 # @param manage_repo
@@ -260,7 +261,7 @@ class redis (
   Integer[0] $list_max_ziplist_value                             = 64,
   Stdlib::Absolutepath $log_dir                                  = $redis::params::log_dir,
   Stdlib::Filemode $log_dir_mode                                 = $redis::params::log_dir_mode,
-  Stdlib::Absolutepath $log_file                                 = '/var/log/redis/redis.log',
+  String $log_file                                               = 'redis.log',
   Redis::LogLevel $log_level                                     = 'notice',
   Boolean $manage_service_file                                   = false,
   Boolean $manage_package                                        = true,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -65,7 +65,8 @@
 # @param log_dir_mode
 #   Adjust mode for directory containing log files.
 # @param log_file
-#   Specify file where to write log entries.
+#   Specify file where to write log entries. Relative paths will be prepended
+#   with log_dir but absolute paths are also accepted.
 # @param log_level
 #   Specify the server verbosity level.
 # @param masterauth
@@ -276,7 +277,7 @@ define redis::instance (
   Boolean $service_enable                                        = $redis::service_enable,
   String[1] $service_group                                       = $redis::service_group,
   Boolean $manage_service_file                                   = true,
-  Optional[Stdlib::Absolutepath] $log_file                       = undef,
+  String $log_file                                               = "redis-server-${name}.log",
   Stdlib::Absolutepath $pid_file                                 = "/var/run/redis/redis-server-${name}.pid",
   Variant[Stdlib::Absolutepath, Enum['']] $unixsocket            = "/var/run/redis/redis-server-${name}.sock",
   Stdlib::Absolutepath $workdir                                  = "${redis::workdir}/redis-server-${name}",
@@ -335,7 +336,11 @@ define redis::instance (
     }
   }
 
-  $_real_log_file = pick($log_file, "${log_dir}/redis-server-${name}.log")
+  $_real_log_file = $log_file ? {
+    Stdlib::Absolutepath => $log_file,
+    default              => "${log_dir}/${log_file}",
+  }
+
   $bind_arr = [$bind].flatten
   $supports_protected_mode = $redis::supports_protected_mode
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -32,6 +32,7 @@ describe 'redis' do
         it do
           is_expected.to contain_file(config_file_orig).
             with_ensure('file').
+            with_content(%r{logfile /var/log/redis/redis\.log}).
             without_content(%r{undef})
 
           if facts[:osfamily] == 'FreeBSD'
@@ -424,17 +425,34 @@ describe 'redis' do
       end
 
       describe 'with parameter log_file' do
-        let(:params) do
-          {
-            log_file: '/var/log/redis/redis.log'
+        describe 'as absolute path' do
+          let(:params) do
+            {
+              log_file: '/var/log/my-redis/my-redis.log'
+            }
+          end
+
+          it {
+            is_expected.to contain_file(config_file_orig).with(
+              'content' => %r{^logfile /var/log/my-redis/my-redis\.log$}
+            )
           }
         end
 
-        it {
-          is_expected.to contain_file(config_file_orig).with(
-            'content' => %r{^logfile /var/log/redis/redis\.log$}
-          )
-        }
+        describe 'as relative path' do
+          let(:params) do
+            {
+              log_dir: '/var/log/my-redis',
+              log_file: 'my-redis.log'
+            }
+          end
+
+          it {
+            is_expected.to contain_file(config_file_orig).with(
+              'content' => %r{^logfile /var/log/my-redis/my-redis\.log$}
+            )
+          }
+        end
       end
 
       describe 'with parameter log_level' do


### PR DESCRIPTION
0c851ce3cd8d44256a3577dd81eaa88614095ac4 changed $log_dir for SCL deployments. However, $log_file was still absolute. That caused it to log to a non-existing directory.

This patch makes $log_file accept a relative path. If a relative path is specified, $log_dir will be prepended. Absolute paths are still used directly which keeps API compatibility.