### PR TITLE
Make it possible to install sentinel independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ class { '::redis::sentinel':
 }
 ```
 
+If installation without redis-server is desired, set `require_redis` parameter to false, i.e
+```puppet
+class { '::redis::sentinel':
+  ...
+  require_redis => false,
+  ...
+}
+```
+
 ### Soft dependency
 
 This module requires [camptocamp/systemd](https://forge.puppet.com/camptocamp/systemd) on Puppet versions older than 6.1.0.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -895,13 +895,13 @@ https://forge.puppet.com/modules/alexharvey/disable_transparent_hugepage
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 include redis::administration
 ```
 
-##### 
+#####
 
 ```puppet
 class {'redis::administration':
@@ -963,6 +963,15 @@ include redis::sentinel
 class {'redis::sentinel':
   down_after => 80000,
   log_file   => '/var/log/redis/sentinel.log',
+}
+```
+
+If installation without redis-server is desired, set `require_redis` parameter to false, i.e
+```puppet
+class { '::redis::sentinel':
+  ...
+  require_redis => false,
+  ...
 }
 ```
 
@@ -1213,6 +1222,14 @@ Data type: `Stdlib::Ensure::Service`
 
 Default value: `'running'`
 
+##### `require_redis`
+
+Data type: `Boolean`
+
+Require redis base class. If set to false, sentinel is installed without redis server.
+
+Default value: ``true``
+
 ## Defined types
 
 ### `redis::instance`
@@ -1222,7 +1239,7 @@ multiple redis instances on one machine without conflicts
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 redis::instance {'6380':

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -106,6 +106,7 @@
 #
 # @param require_redis
 #   Require redis base class. If set to false, sentinel is installed without redis server.
+#
 class redis::sentinel (
   Optional[String[1]] $auth_pass = undef,
   Stdlib::Absolutepath $config_file = $redis::params::sentinel_config_file,

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -104,6 +104,8 @@
 #     log_file   => '/var/log/redis/sentinel.log',
 #   }
 #
+# @param require_redis
+#   Require redis base class. If set to false, sentinel is installed without redis server.
 class redis::sentinel (
   Optional[String[1]] $auth_pass = undef,
   Stdlib::Absolutepath $config_file = $redis::params::sentinel_config_file,
@@ -134,8 +136,12 @@ class redis::sentinel (
   Stdlib::Absolutepath $working_dir = $redis::params::sentinel_working_dir,
   Optional[Stdlib::Absolutepath] $notification_script = undef,
   Optional[Stdlib::Absolutepath] $client_reconfig_script = undef,
+  Boolean $require_redis = true,
 ) inherits redis::params {
-  require 'redis'
+
+  if $require_redis {
+    require 'redis'
+  }
 
   ensure_packages([$package_name])
   Package[$package_name] -> File[$config_file_orig]


### PR DESCRIPTION

#### Pull Request (PR) description
This PR introduces the possibility to install `redis::sentinel` standalone, without `redis::server`. It comes in handy when you need your sentinels to be for example on a different node than your redis server.

The change itself is a pretty straightforward,  I am just adding a `require_redis` parameter, that makes the requirement of  `redis` class conditional. The default value is true, which includes the `redis` and it is therefore backward compatible with the current setup.

The only downside of this approach I see currently is that in case someone needs a standalone `redis-sentinel` from a managed repository, the repository must be added manually as the `redis::preinstall` is no longer included (as was previously with the `redis` class)

#### This Pull Request (PR) fixes the following issues
- installation of standalone sentinel (no open issue for this one, so far)


Thank you for any input :)