### PR TITLE
Manage ulimit with systemd::dropin_file and allow it to be unmanaged

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,6 +11,4 @@ fixtures:
     yumrepo_core:
       repo: "https://github.com/puppetlabs/puppetlabs-yumrepo_core"
       puppet_version: ">= 6.0.0"
-    systemd:
-      repo: 'https://github.com/camptocamp/puppet-systemd.git'
-      puppet_version: "< 6.1.0"
+    systemd: 'https://github.com/camptocamp/puppet-systemd.git'

--- a/README.md
+++ b/README.md
@@ -135,8 +135,6 @@ class { '::redis::sentinel':
 
 ### Soft dependency
 
-This module requires [camptocamp/systemd](https://forge.puppet.com/camptocamp/systemd) on Puppet versions older than 6.1.0.
-
 When managing the repo, it either needs [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) or [puppet/epel](https://forge.puppet.com/puppet/epel).
 
 ## `redis::get()` function

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,7 +38,7 @@ class redis::config {
     }
   }
 
-  if $redis::ulimit {
+  if $redis::ulimit_managed {
     contain redis::ulimit
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -195,6 +195,8 @@
 #   Close the connection after a client is idle for N seconds (0 to disable).
 # @param ulimit
 #   Limit the use of system-wide resources.
+# @param ulimit_managed
+#   Defines wheter the Limit is managed by this module or not.
 # @param unixsocket
 #   Define unix socket path
 # @param unixsocketperm

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -316,6 +316,7 @@ class redis (
   Variant[Stdlib::Absolutepath, Enum['']] $unixsocket            = '/var/run/redis/redis.sock',
   Variant[Stdlib::Filemode, Enum['']] $unixsocketperm            = '0755',
   Integer[0] $ulimit                                             = 65536,
+  Boolean $ulimit_managed                                        = true,
   Stdlib::Absolutepath $workdir                                  = $redis::params::workdir,
   Stdlib::Filemode $workdir_mode                                 = '0750',
   Integer[0] $zset_max_ziplist_entries                           = 128,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -196,7 +196,8 @@
 # @param ulimit
 #   Limit the use of system-wide resources.
 # @param ulimit_managed
-#   Defines wheter the Limit is managed by this module or not.
+#   Defines wheter the max number of open files for the
+#   systemd service unit is explicitly managed.
 # @param unixsocket
 #   Define unix socket path
 # @param unixsocketperm

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -164,7 +164,7 @@
 # @param ulimit
 #   Limit the use of system-wide resources.
 # @param ulimit_managed
-#   Defines wheter the max number of open files for the
+#   Defines whether the max number of open files for the
 #   systemd service unit is explicitly managed.
 # @param unixsocket
 #   Define unix socket path

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -163,6 +163,9 @@
 #   Close the connection after a client is idle for N seconds (0 to disable).
 # @param ulimit
 #   Limit the use of system-wide resources.
+# @param ulimit_managed
+#   Defines wheter the max number of open files for the
+#   systemd service unit is explicitly managed.
 # @param unixsocket
 #   Define unix socket path
 # @param unixsocketperm
@@ -310,8 +313,8 @@ define redis::instance (
   }
 
   if $manage_service_file {
-    file { "/etc/systemd/system/${service_name}.service":
-      ensure  => file,
+    systemd::unit_file { "${service_name}.service":
+      ensure  => 'present',
       owner   => 'root',
       group   => 'root',
       mode    => '0644',

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -263,6 +263,7 @@ define redis::instance (
   Integer[0] $timeout                                            = $redis::timeout,
   Variant[Stdlib::Filemode , Enum['']] $unixsocketperm           = $redis::unixsocketperm,
   Integer[0] $ulimit                                             = $redis::ulimit,
+  Boolean $ulimit_managed                                        = $redis::ulimit_managed,
   Stdlib::Filemode $workdir_mode                                 = $redis::workdir_mode,
   Integer[0] $zset_max_ziplist_entries                           = $redis::zset_max_ziplist_entries,
   Integer[0] $zset_max_ziplist_value                             = $redis::zset_max_ziplist_value,

--- a/manifests/ulimit.pp
+++ b/manifests/ulimit.pp
@@ -31,7 +31,7 @@ class redis::ulimit {
     limits          => {
       'LimitNOFILE' => $redis::ulimit,
     },
-    restart_service =>  false,
+    restart_service => false,
   }
 
   file { "/etc/systemd/system/${redis::service_name}.service.d/limit.conf":

--- a/manifests/ulimit.pp
+++ b/manifests/ulimit.pp
@@ -27,31 +27,14 @@ class redis::ulimit {
     }
   }
 
-  file { "/etc/systemd/system/${redis::service_name}.service.d/":
-    ensure                  => 'directory',
-    owner                   => 'root',
-    group                   => 'root',
-    selinux_ignore_defaults => true,
+  systemd::service_limits { "${redis::service_name}.service":
+    limits          => {
+      'LimitNOFILE' => $redis::ulimit,
+    },
+    restart_service =>  false,
   }
 
   file { "/etc/systemd/system/${redis::service_name}.service.d/limit.conf":
-    ensure => file,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0444',
-  }
-  augeas { 'Systemd redis ulimit' :
-    incl    => "/etc/systemd/system/${redis::service_name}.service.d/limit.conf",
-    lens    => 'Systemd.lns',
-    changes => [
-      "defnode nofile Service/LimitNOFILE \"\"",
-      "set \$nofile/value \"${redis::ulimit}\"",
-    ],
-  }
-  # Only necessary for Puppet < 6.1.0,
-  # See https://github.com/puppetlabs/puppet/commit/f8d5c60ddb130c6429ff12736bfdb4ae669a9fd4
-  if versioncmp($facts['puppetversion'],'6.1.0') < 0 {
-    include systemd::systemctl::daemon_reload
-    Augeas['Systemd redis ulimit'] ~> Class['systemd::systemctl::daemon_reload']
+    ensure => absent,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,10 @@
     {
       "name": "herculesteam/augeasproviders_core",
       "version_requirement": ">= 2.1.0 < 3.0.0"
+    },
+    {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "description": "Redis module with cluster support",

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'redis' do
-  let(:service_file) { "/etc/systemd/system/#{service_name}.service" }
   let(:package_name) { manifest_vars[:package_name] }
   let(:service_name) { manifest_vars[:service_name] }
   let(:config_file) { manifest_vars[:config_file] }
@@ -1354,7 +1353,7 @@ describe 'redis' do
           }
         end
 
-        it { is_expected.to contain_file(service_file) }
+        it { is_expected.to contain_systemd__unit_file("#{service_name}.service") }
 
         it do
           content = <<-END.gsub(%r{^\s+\|}, '')
@@ -1379,18 +1378,18 @@ describe 'redis' do
             |WantedBy=multi-user.target
           END
 
-          is_expected.to contain_file(service_file).with_content(content)
+          is_expected.to contain_systemd__unit_file("#{service_name}.service").with_content(content)
         end
       end
 
-      describe 'with parameter manage_service_file' do
+      describe 'with parameter manage_service_file set to false' do
         let(:params) do
           {
             manage_service_file: false
           }
         end
 
-        it { is_expected.not_to contain_file(service_file) }
+        it { is_expected.not_to contain_systemd__unit_file("#{service_name}.service") }
       end
 
       context 'when $::redis_server_version fact is not present' do

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -111,25 +111,13 @@ describe 'redis' do
 
           it { is_expected.to compile.with_all_deps }
           it do
-            is_expected.to contain_file("/etc/systemd/system/#{service_name}.service.d/limit.conf").
-              with_ensure('file').
-              with_owner('root').
-              with_group('root').
-              with_mode('0444')
-            # Only necessary for Puppet < 6.1.0,
-            # See https://github.com/puppetlabs/puppet/commit/f8d5c60ddb130c6429ff12736bfdb4ae669a9fd4
-            if Puppet.version < '6.1'
-              is_expected.to contain_augeas('Systemd redis ulimit').
-                with_incl("/etc/systemd/system/#{service_name}.service.d/limit.conf").
-                with_lens('Systemd.lns').
-                with_changes(['defnode nofile Service/LimitNOFILE ""', 'set $nofile/value "7777"']).
-                that_notifies('Class[systemd::systemctl::daemon_reload]')
-            else
-              is_expected.to contain_augeas('Systemd redis ulimit').
-                with_incl("/etc/systemd/system/#{service_name}.service.d/limit.conf").
-                with_lens('Systemd.lns').
-                with_changes(['defnode nofile Service/LimitNOFILE ""', 'set $nofile/value "7777"'])
-            end
+            is_expected.to contain_file("/etc/systemd/system/#{service_name}.service.d/limit.conf")
+              .with_ensure('absent')
+
+            is_expected.to contain_systemd__service_limits("#{service_name}.service").
+              with_limits({ "LimitNOFILE" => 7777 }).
+              with_restart_service(false).
+              with_ensure('present')
           end
         end
 
@@ -138,8 +126,7 @@ describe 'redis' do
 
           it { is_expected.to compile.with_all_deps }
           it do
-            is_expected.to_not contain_file("/etc/systemd/system/#{service_name}.service.d/limit.conf")
-            is_expected.to_not contain_augeas('Systemd redis ulimit')
+            is_expected.not_to contain_systemd__service_limits("#{service_name}.service")
           end
         end
       end

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -105,29 +105,41 @@ describe 'redis' do
         end
       end
 
-      context 'with ulimit' do
-        let(:params) { { ulimit: 7777 } }
+      describe 'with parameter ulimit_managed' do
+        context 'true' do
+          let(:params) { { ulimit: 7777, ulimit_managed: true } }
 
-        it { is_expected.to compile.with_all_deps }
-        it do
-          is_expected.to contain_file("/etc/systemd/system/#{service_name}.service.d/limit.conf").
-            with_ensure('file').
-            with_owner('root').
-            with_group('root').
-            with_mode('0444')
-          # Only necessary for Puppet < 6.1.0,
-          # See https://github.com/puppetlabs/puppet/commit/f8d5c60ddb130c6429ff12736bfdb4ae669a9fd4
-          if Puppet.version < '6.1'
-            is_expected.to contain_augeas('Systemd redis ulimit').
-              with_incl("/etc/systemd/system/#{service_name}.service.d/limit.conf").
-              with_lens('Systemd.lns').
-              with_changes(['defnode nofile Service/LimitNOFILE ""', 'set $nofile/value "7777"']).
-              that_notifies('Class[systemd::systemctl::daemon_reload]')
-          else
-            is_expected.to contain_augeas('Systemd redis ulimit').
-              with_incl("/etc/systemd/system/#{service_name}.service.d/limit.conf").
-              with_lens('Systemd.lns').
-              with_changes(['defnode nofile Service/LimitNOFILE ""', 'set $nofile/value "7777"'])
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to contain_file("/etc/systemd/system/#{service_name}.service.d/limit.conf").
+              with_ensure('file').
+              with_owner('root').
+              with_group('root').
+              with_mode('0444')
+            # Only necessary for Puppet < 6.1.0,
+            # See https://github.com/puppetlabs/puppet/commit/f8d5c60ddb130c6429ff12736bfdb4ae669a9fd4
+            if Puppet.version < '6.1'
+              is_expected.to contain_augeas('Systemd redis ulimit').
+                with_incl("/etc/systemd/system/#{service_name}.service.d/limit.conf").
+                with_lens('Systemd.lns').
+                with_changes(['defnode nofile Service/LimitNOFILE ""', 'set $nofile/value "7777"']).
+                that_notifies('Class[systemd::systemctl::daemon_reload]')
+            else
+              is_expected.to contain_augeas('Systemd redis ulimit').
+                with_incl("/etc/systemd/system/#{service_name}.service.d/limit.conf").
+                with_lens('Systemd.lns').
+                with_changes(['defnode nofile Service/LimitNOFILE ""', 'set $nofile/value "7777"'])
+            end
+          end
+        end
+
+        context 'false' do
+          let(:params) { { ulimit_managed: false } }
+
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to_not contain_file("/etc/systemd/system/#{service_name}.service.d/limit.conf")
+            is_expected.to_not contain_augeas('Systemd redis ulimit')
           end
         end
       end

--- a/templates/service_templates/redis.service.erb
+++ b/templates/service_templates/redis.service.erb
@@ -19,7 +19,9 @@ ExecStop=/usr/bin/redis-cli -p <%= @port %> shutdown
 Restart=always
 User=<%= @service_user %>
 Group=<%= @service_user %>
+<%if @ulimit_managed -%>
 LimitNOFILE=<%= @ulimit %>
+<% end -%>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR changes two things:
- Adds the new parameter `ulimit_managed` to explicitly enable/disable ulimit
  - in systemd unit für instances and
  - systemd dropin for default setup
- Use [systemd:: service_limits](https://github.com/camptocamp/puppet-systemd/blob/master/manifests/service_limits.pp) to manage the ulimits for the default setup.
  Note: This adds a new dependency to [camptocamp/puppet-systemd](https://github.com/camptocamp/puppet-systemd).
- Use [systemd::unit_file](https://github.com/camptocamp/puppet-systemd/blob/master/manifests/unit_file.pp) for each instance service

Fixes #390

Note: I can split this PR into two/three PRs if desired (or squash the commits together).