### PR TITLE
Multi instance fixes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,8 +8,10 @@ class redis::config {
   }
 
   file { $redis::config_dir:
-    ensure => directory,
-    mode   => $redis::config_dir_mode,
+    ensure  => directory,
+    mode    => $redis::config_dir_mode,
+    purge   => $redis::config_dir_purge,
+    recurse => $redis::config_dir_recurse,
   }
 
   file { $redis::log_dir:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,10 @@
 #   Directory containing the configuration files.
 # @param config_dir_mode
 #   Adjust mode for directory containing configuration files.
+# @param config_dir_purge
+#   Adjust purge option for directory containing configuration files.
+# @param config_dir_recurse
+#   Adjust recurse option for directory containing configuration files.
 # @param config_file_orig
 #   The location and name of a config file that provides the source
 # @param config_file
@@ -242,6 +246,8 @@ class redis (
   String[1] $conf_template                                       = 'redis/redis.conf.erb',
   Stdlib::Absolutepath $config_dir                               = $redis::params::config_dir,
   Stdlib::Filemode $config_dir_mode                              = $redis::params::config_dir_mode,
+  Boolean $config_dir_purge                                      = $redis::params::config_dir_purge,
+  Boolean $config_dir_recurse                                    = $redis::params::config_dir_recurse,
   Stdlib::Absolutepath $config_file                              = $redis::params::config_file,
   Stdlib::Filemode $config_file_mode                             = '0644',
   Stdlib::Absolutepath $config_file_orig                         = $redis::params::config_file_orig,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -286,8 +286,7 @@ define redis::instance (
     $redis_file_name_orig = $config_file_orig
     $redis_file_name      = $config_file
   } else {
-    $redis_file_name_orig = sprintf('%s/%s.%s', dirname($config_file_orig), $service_name, 'conf.puppet')
-    $redis_file_name      = sprintf('%s/%s.%s', dirname($config_file), $service_name, 'conf')
+    $redis_file_name_orig = $redis_file_name = sprintf('%s/%s.%s', dirname($config_file_orig), $service_name, 'conf')
   }
 
   if $log_dir != $redis::log_dir {
@@ -330,7 +329,6 @@ define redis::instance (
         enable    => $service_enable,
         subscribe => [
           File["/etc/systemd/system/${service_name}.service"],
-          Exec["cp -p ${redis_file_name_orig} ${redis_file_name}"],
         ],
       }
     }
@@ -352,9 +350,11 @@ define redis::instance (
     content => template($conf_template),
   }
 
-  exec { "cp -p ${redis_file_name_orig} ${redis_file_name}":
-    path        => '/usr/bin:/bin',
-    subscribe   => File[$redis_file_name_orig],
-    refreshonly => true,
+  if $title == 'default' {
+    exec { "cp -p ${redis_file_name_orig} ${redis_file_name}":
+      path        => '/usr/bin:/bin',
+      subscribe   => File[$redis_file_name_orig],
+      refreshonly => true,
+    }
   }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -278,8 +278,8 @@ define redis::instance (
   String[1] $service_group                                       = $redis::service_group,
   Boolean $manage_service_file                                   = true,
   String $log_file                                               = "redis-server-${name}.log",
-  Stdlib::Absolutepath $pid_file                                 = "/var/run/redis/redis-server-${name}.pid",
-  Variant[Stdlib::Absolutepath, Enum['']] $unixsocket            = "/var/run/redis/redis-server-${name}.sock",
+  Stdlib::Absolutepath $pid_file                                 = "/var/run/redis-${name}/redis.pid",
+  Variant[Stdlib::Absolutepath, Enum['']] $unixsocket            = "/var/run/redis-${name}/redis.sock",
   Stdlib::Absolutepath $workdir                                  = "${redis::workdir}/redis-server-${name}",
 ) {
   if $title == 'default' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,8 @@ class redis::params inherits redis::globals {
 
       $config_dir                = '/etc/redis'
       $config_dir_mode           = '0755'
+      $config_dir_purge          = false
+      $config_dir_recurse        = false
       $config_file               = '/etc/redis/redis.conf'
       $config_file_orig          = '/etc/redis/redis.conf.puppet'
       $config_owner              = 'redis'

--- a/templates/service_templates/redis.service.erb
+++ b/templates/service_templates/redis.service.erb
@@ -5,7 +5,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-RuntimeDirectory=redis
+RuntimeDirectory=redis-<%= @title %>
 RuntimeDirectoryMode=2755
 <%# Redis on Xenial is too old for systemd integration -%>
 <% if @facts['os']['name'] == 'Ubuntu' and @facts['os']['release']['major'] == '16.04' -%>

--- a/templates/service_templates/redis.service.erb
+++ b/templates/service_templates/redis.service.erb
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/redis-server <%= @redis_file_name %>
 Type=notify
 ExecStart=/usr/bin/redis-server <%= @redis_file_name %> --supervised systemd
 <% end -%>
-ExecStop=/usr/bin/redis-cli -p <%= @port %> shutdown
+ExecStop=/bin/kill -s TERM $MAINPID
 Restart=always
 User=<%= @service_user %>
 Group=<%= @service_user %>


### PR DESCRIPTION
This PR aims to fix remaining issues with multi instance handling :
- **Instance shutdown** : multiples issues with the existing command
It fails if we use 0 as a port (eg : to disable listening for an unix socket only usage).
It also fails if a password is defined.
I decided to use a SIGTERM like Debian for its default service. (It's still a graceful shutdown : https://redis.io/topics/signals)

- **Socket files removal and permission problems**
By using the same directory to store sockets and pids, it means stopping or restarting an instance will clear every other instances sockets !
If we use RuntimeDirectoryPreserve=yes, it's still not optimal if our instances are using different users. Each stop or restart will reset the socket owner of every instances.
So my solution was to use per instance directories for sockets and pids.