### PR TITLE
set correct redis bin path in systemd for instances when using SCL

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class redis::params inherits redis::globals {
       $package_name              = 'redis-server'
       $pid_file                  = '/var/run/redis/redis-server.pid'
       $workdir                   = '/var/lib/redis'
+      $bin_path                  = '/usr/bin'
       $daemonize                 = true
       $service_name              = 'redis-server'
 
@@ -74,6 +75,7 @@ class redis::params inherits redis::globals {
         $pid_file                  = "/var/opt/rh/${scl}/run/redis_6379.pid"
         $service_name              = "${scl}-redis"
         $workdir                   = "/var/opt/rh/${scl}/lib/redis"
+        $bin_path                  = "/opt/rh/${scl}/root/usr/bin"
 
         $sentinel_config_file      = "${config_dir}/redis-sentinel.conf"
         $sentinel_config_file_orig = "${config_dir}/redis-sentinel.conf.puppet"
@@ -95,6 +97,7 @@ class redis::params inherits redis::globals {
         $pid_file                  = '/var/run/redis_6379.pid'
         $service_name              = 'redis'
         $workdir                   = '/var/lib/redis'
+        $bin_path                  = '/usr/bin'
 
         $sentinel_config_file      = '/etc/redis-sentinel.conf'
         $sentinel_config_file_orig = '/etc/redis-sentinel.conf.puppet'
@@ -124,6 +127,7 @@ class redis::params inherits redis::globals {
       $daemonize                 = true
       $service_name              = 'redis'
       $workdir                   = '/var/db/redis'
+      $bin_path                  = '/usr/bin'
 
       $sentinel_config_file      = '/usr/local/etc/redis-sentinel.conf'
       $sentinel_config_file_orig = '/usr/local/etc/redis-sentinel.conf.puppet'
@@ -154,6 +158,7 @@ class redis::params inherits redis::globals {
       $daemonize                 = true
       $service_name              = 'redis'
       $workdir                   = '/var/lib/redis'
+      $bin_path                  = '/usr/bin'
 
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
@@ -185,6 +190,7 @@ class redis::params inherits redis::globals {
       $daemonize                 = true
       $service_name              = 'redis'
       $workdir                   = '/var/lib/redis'
+      $bin_path                  = '/usr/bin'
 
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'

--- a/templates/service_templates/redis.service.erb
+++ b/templates/service_templates/redis.service.erb
@@ -13,9 +13,9 @@ Type=forking
 ExecStart=/usr/bin/redis-server <%= @redis_file_name %>
 <% else -%>
 Type=notify
-ExecStart=/usr/bin/redis-server <%= @redis_file_name %> --supervised systemd
+ExecStart=<%= scope['redis::params::bin_path'] %>/redis-server <%= @redis_file_name %> --supervised systemd
 <% end -%>
-ExecStop=/usr/bin/redis-cli -p <%= @port %> shutdown
+ExecStop=<%= scope['redis::params::bin_path'] %>/redis-cli -p <%= @port %> shutdown
 Restart=always
 User=<%= @service_user %>
 Group=<%= @service_user %>


### PR DESCRIPTION
redis binary distributed via SCL is located in non-standard location -  /opt/rh/rh-redis5/root/bin/  
this PR updates systemd template to set correct path for redis-server binary when SCL
