### PR TITLE
Drop Ubuntu 16.04 support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -29,7 +29,7 @@ repositories.
 
 ### Functions
 
-* [`redis::get`](#redisget): Returns the value of the key being looked up or `undef` if the key does not exist.
+* [`redis::get`](#redisget): ```
 
 ### Data types
 
@@ -42,7 +42,7 @@ repositories.
 
 ## Classes
 
-### `redis`
+### <a name="redis"></a>`redis`
 
 This class installs redis
 
@@ -81,9 +81,109 @@ class { 'redis':
 
 #### Parameters
 
-The following parameters are available in the `redis` class.
+The following parameters are available in the `redis` class:
 
-##### `activerehashing`
+* [`activerehashing`](#activerehashing)
+* [`aof_load_truncated`](#aof_load_truncated)
+* [`aof_rewrite_incremental_fsync`](#aof_rewrite_incremental_fsync)
+* [`appendfilename`](#appendfilename)
+* [`appendfsync`](#appendfsync)
+* [`appendonly`](#appendonly)
+* [`auto_aof_rewrite_min_size`](#auto_aof_rewrite_min_size)
+* [`auto_aof_rewrite_percentage`](#auto_aof_rewrite_percentage)
+* [`bind`](#bind)
+* [`config_dir`](#config_dir)
+* [`config_dir_mode`](#config_dir_mode)
+* [`config_file_orig`](#config_file_orig)
+* [`config_file`](#config_file)
+* [`config_file_mode`](#config_file_mode)
+* [`config_group`](#config_group)
+* [`config_owner`](#config_owner)
+* [`conf_template`](#conf_template)
+* [`daemonize`](#daemonize)
+* [`default_install`](#default_install)
+* [`databases`](#databases)
+* [`dbfilename`](#dbfilename)
+* [`extra_config_file`](#extra_config_file)
+* [`hash_max_ziplist_entries`](#hash_max_ziplist_entries)
+* [`hash_max_ziplist_value`](#hash_max_ziplist_value)
+* [`hll_sparse_max_bytes`](#hll_sparse_max_bytes)
+* [`hz`](#hz)
+* [`latency_monitor_threshold`](#latency_monitor_threshold)
+* [`list_max_ziplist_entries`](#list_max_ziplist_entries)
+* [`list_max_ziplist_value`](#list_max_ziplist_value)
+* [`log_dir`](#log_dir)
+* [`log_dir_mode`](#log_dir_mode)
+* [`log_file`](#log_file)
+* [`log_level`](#log_level)
+* [`manage_repo`](#manage_repo)
+* [`manage_package`](#manage_package)
+* [`managed_by_cluster_manager`](#managed_by_cluster_manager)
+* [`masterauth`](#masterauth)
+* [`maxclients`](#maxclients)
+* [`maxmemory`](#maxmemory)
+* [`maxmemory_policy`](#maxmemory_policy)
+* [`maxmemory_samples`](#maxmemory_samples)
+* [`min_slaves_max_lag`](#min_slaves_max_lag)
+* [`min_slaves_to_write`](#min_slaves_to_write)
+* [`no_appendfsync_on_rewrite`](#no_appendfsync_on_rewrite)
+* [`notify_keyspace_events`](#notify_keyspace_events)
+* [`notify_service`](#notify_service)
+* [`package_ensure`](#package_ensure)
+* [`package_name`](#package_name)
+* [`pid_file`](#pid_file)
+* [`port`](#port)
+* [`protected_mode`](#protected_mode)
+* [`ppa_repo`](#ppa_repo)
+* [`rdbcompression`](#rdbcompression)
+* [`rename_commands`](#rename_commands)
+* [`repl_backlog_size`](#repl_backlog_size)
+* [`repl_backlog_ttl`](#repl_backlog_ttl)
+* [`repl_disable_tcp_nodelay`](#repl_disable_tcp_nodelay)
+* [`repl_ping_slave_period`](#repl_ping_slave_period)
+* [`repl_timeout`](#repl_timeout)
+* [`requirepass`](#requirepass)
+* [`save_db_to_disk`](#save_db_to_disk)
+* [`save_db_to_disk_interval`](#save_db_to_disk_interval)
+* [`service_manage`](#service_manage)
+* [`service_enable`](#service_enable)
+* [`service_ensure`](#service_ensure)
+* [`service_group`](#service_group)
+* [`service_name`](#service_name)
+* [`service_user`](#service_user)
+* [`set_max_intset_entries`](#set_max_intset_entries)
+* [`slave_priority`](#slave_priority)
+* [`slave_read_only`](#slave_read_only)
+* [`slave_serve_stale_data`](#slave_serve_stale_data)
+* [`slaveof`](#slaveof)
+* [`slowlog_log_slower_than`](#slowlog_log_slower_than)
+* [`slowlog_max_len`](#slowlog_max_len)
+* [`stop_writes_on_bgsave_error`](#stop_writes_on_bgsave_error)
+* [`syslog_enabled`](#syslog_enabled)
+* [`syslog_facility`](#syslog_facility)
+* [`tcp_backlog`](#tcp_backlog)
+* [`tcp_keepalive`](#tcp_keepalive)
+* [`timeout`](#timeout)
+* [`ulimit`](#ulimit)
+* [`ulimit_managed`](#ulimit_managed)
+* [`unixsocket`](#unixsocket)
+* [`unixsocketperm`](#unixsocketperm)
+* [`workdir`](#workdir)
+* [`workdir_mode`](#workdir_mode)
+* [`zset_max_ziplist_entries`](#zset_max_ziplist_entries)
+* [`zset_max_ziplist_value`](#zset_max_ziplist_value)
+* [`cluster_enabled`](#cluster_enabled)
+* [`cluster_config_file`](#cluster_config_file)
+* [`cluster_node_timeout`](#cluster_node_timeout)
+* [`cluster_slave_validity_factor`](#cluster_slave_validity_factor)
+* [`cluster_require_full_coverage`](#cluster_require_full_coverage)
+* [`cluster_migration_barrier`](#cluster_migration_barrier)
+* [`instances`](#instances)
+* [`output_buffer_limit_slave`](#output_buffer_limit_slave)
+* [`output_buffer_limit_pubsub`](#output_buffer_limit_pubsub)
+* [`manage_service_file`](#manage_service_file)
+
+##### <a name="activerehashing"></a>`activerehashing`
 
 Data type: `Boolean`
 
@@ -91,7 +191,7 @@ Enable/disable active rehashing.
 
 Default value: ``true``
 
-##### `aof_load_truncated`
+##### <a name="aof_load_truncated"></a>`aof_load_truncated`
 
 Data type: `Boolean`
 
@@ -99,7 +199,7 @@ Enable/disable loading truncated AOF file
 
 Default value: ``true``
 
-##### `aof_rewrite_incremental_fsync`
+##### <a name="aof_rewrite_incremental_fsync"></a>`aof_rewrite_incremental_fsync`
 
 Data type: `Boolean`
 
@@ -107,7 +207,7 @@ Enable/disable fsync for AOF file
 
 Default value: ``true``
 
-##### `appendfilename`
+##### <a name="appendfilename"></a>`appendfilename`
 
 Data type: `String[1]`
 
@@ -115,7 +215,7 @@ The name of the append only file
 
 Default value: `'appendonly.aof'`
 
-##### `appendfsync`
+##### <a name="appendfsync"></a>`appendfsync`
 
 Data type: `Enum['no', 'always', 'everysec']`
 
@@ -123,7 +223,7 @@ Adjust fsync mode
 
 Default value: `'everysec'`
 
-##### `appendonly`
+##### <a name="appendonly"></a>`appendonly`
 
 Data type: `Boolean`
 
@@ -131,7 +231,7 @@ Enable/disable appendonly mode.
 
 Default value: ``false``
 
-##### `auto_aof_rewrite_min_size`
+##### <a name="auto_aof_rewrite_min_size"></a>`auto_aof_rewrite_min_size`
 
 Data type: `String[1]`
 
@@ -139,7 +239,7 @@ Adjust minimum size for auto-aof-rewrite.
 
 Default value: `'64mb'`
 
-##### `auto_aof_rewrite_percentage`
+##### <a name="auto_aof_rewrite_percentage"></a>`auto_aof_rewrite_percentage`
 
 Data type: `Integer[0]`
 
@@ -147,7 +247,7 @@ Adjust percentatge for auto-aof-rewrite.
 
 Default value: `100`
 
-##### `bind`
+##### <a name="bind"></a>`bind`
 
 Data type: `Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]]`
 
@@ -155,7 +255,7 @@ Configure which IP address(es) to listen on. To bind on all interfaces, use an e
 
 Default value: `['127.0.0.1']`
 
-##### `config_dir`
+##### <a name="config_dir"></a>`config_dir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -163,7 +263,7 @@ Directory containing the configuration files.
 
 Default value: `$redis::params::config_dir`
 
-##### `config_dir_mode`
+##### <a name="config_dir_mode"></a>`config_dir_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -171,7 +271,7 @@ Adjust mode for directory containing configuration files.
 
 Default value: `$redis::params::config_dir_mode`
 
-##### `config_file_orig`
+##### <a name="config_file_orig"></a>`config_file_orig`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -179,7 +279,7 @@ The location and name of a config file that provides the source
 
 Default value: `$redis::params::config_file_orig`
 
-##### `config_file`
+##### <a name="config_file"></a>`config_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -187,7 +287,7 @@ Adjust main configuration file.
 
 Default value: `$redis::params::config_file`
 
-##### `config_file_mode`
+##### <a name="config_file_mode"></a>`config_file_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -195,7 +295,7 @@ Adjust permissions for configuration files.
 
 Default value: `'0644'`
 
-##### `config_group`
+##### <a name="config_group"></a>`config_group`
 
 Data type: `String[1]`
 
@@ -203,7 +303,7 @@ Adjust filesystem group for config files.
 
 Default value: `$redis::params::config_group`
 
-##### `config_owner`
+##### <a name="config_owner"></a>`config_owner`
 
 Data type: `String[1]`
 
@@ -211,7 +311,7 @@ Adjust filesystem owner for config files.
 
 Default value: `$redis::params::config_owner`
 
-##### `conf_template`
+##### <a name="conf_template"></a>`conf_template`
 
 Data type: `String[1]`
 
@@ -219,7 +319,7 @@ Define which template to use.
 
 Default value: `'redis/redis.conf.erb'`
 
-##### `daemonize`
+##### <a name="daemonize"></a>`daemonize`
 
 Data type: `Boolean`
 
@@ -227,7 +327,7 @@ Have Redis run as a daemon.
 
 Default value: `$redis::params::daemonize`
 
-##### `default_install`
+##### <a name="default_install"></a>`default_install`
 
 Data type: `Boolean`
 
@@ -235,7 +335,7 @@ Configure a default install of redis.
 
 Default value: ``true``
 
-##### `databases`
+##### <a name="databases"></a>`databases`
 
 Data type: `Integer[1]`
 
@@ -243,7 +343,7 @@ Set the number of databases.
 
 Default value: `16`
 
-##### `dbfilename`
+##### <a name="dbfilename"></a>`dbfilename`
 
 Data type: `Variant[String[1], Boolean]`
 
@@ -251,7 +351,7 @@ The filename where to dump the DB
 
 Default value: `'dump.rdb'`
 
-##### `extra_config_file`
+##### <a name="extra_config_file"></a>`extra_config_file`
 
 Data type: `Optional[String]`
 
@@ -259,7 +359,7 @@ Optional extra config file to include
 
 Default value: ``undef``
 
-##### `hash_max_ziplist_entries`
+##### <a name="hash_max_ziplist_entries"></a>`hash_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -267,7 +367,7 @@ Set max ziplist entries for hashes.
 
 Default value: `512`
 
-##### `hash_max_ziplist_value`
+##### <a name="hash_max_ziplist_value"></a>`hash_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -275,7 +375,7 @@ Set max ziplist values for hashes.
 
 Default value: `64`
 
-##### `hll_sparse_max_bytes`
+##### <a name="hll_sparse_max_bytes"></a>`hll_sparse_max_bytes`
 
 Data type: `Integer[0]`
 
@@ -283,7 +383,7 @@ HyperLogLog sparse representation bytes limit
 
 Default value: `3000`
 
-##### `hz`
+##### <a name="hz"></a>`hz`
 
 Data type: `Integer[1, 500]`
 
@@ -291,7 +391,7 @@ Set redis background tasks frequency
 
 Default value: `10`
 
-##### `latency_monitor_threshold`
+##### <a name="latency_monitor_threshold"></a>`latency_monitor_threshold`
 
 Data type: `Integer[0]`
 
@@ -299,7 +399,7 @@ Latency monitoring threshold in milliseconds
 
 Default value: `0`
 
-##### `list_max_ziplist_entries`
+##### <a name="list_max_ziplist_entries"></a>`list_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -307,7 +407,7 @@ Set max ziplist entries for lists.
 
 Default value: `512`
 
-##### `list_max_ziplist_value`
+##### <a name="list_max_ziplist_value"></a>`list_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -315,15 +415,15 @@ Set max ziplist values for lists.
 
 Default value: `64`
 
-##### `log_dir`
+##### <a name="log_dir"></a>`log_dir`
 
 Data type: `Stdlib::Absolutepath`
 
 Specify directory where to write log entries.
 
-Default value: `'/var/log/redis'`
+Default value: `$redis::params::log_dir`
 
-##### `log_dir_mode`
+##### <a name="log_dir_mode"></a>`log_dir_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -331,15 +431,16 @@ Adjust mode for directory containing log files.
 
 Default value: `$redis::params::log_dir_mode`
 
-##### `log_file`
+##### <a name="log_file"></a>`log_file`
 
-Data type: `Stdlib::Absolutepath`
+Data type: `String`
 
-Specify file where to write log entries.
+Specify file where to write log entries. Relative paths will be prepended
+with log_dir but absolute paths are also accepted.
 
-Default value: `'/var/log/redis/redis.log'`
+Default value: `'redis.log'`
 
-##### `log_level`
+##### <a name="log_level"></a>`log_level`
 
 Data type: `Redis::LogLevel`
 
@@ -347,7 +448,7 @@ Specify the server verbosity level.
 
 Default value: `'notice'`
 
-##### `manage_repo`
+##### <a name="manage_repo"></a>`manage_repo`
 
 Data type: `Boolean`
 
@@ -355,7 +456,7 @@ Enable/disable upstream repository configuration.
 
 Default value: ``false``
 
-##### `manage_package`
+##### <a name="manage_package"></a>`manage_package`
 
 Data type: `Boolean`
 
@@ -363,7 +464,7 @@ Enable/disable management of package
 
 Default value: ``true``
 
-##### `managed_by_cluster_manager`
+##### <a name="managed_by_cluster_manager"></a>`managed_by_cluster_manager`
 
 Data type: `Boolean`
 
@@ -371,7 +472,7 @@ Choose if redis will be managed by a cluster manager such as pacemaker or rgmana
 
 Default value: ``false``
 
-##### `masterauth`
+##### <a name="masterauth"></a>`masterauth`
 
 Data type: `Optional[String[1]]`
 
@@ -379,7 +480,7 @@ If the master is password protected (using the "requirepass" configuration
 
 Default value: ``undef``
 
-##### `maxclients`
+##### <a name="maxclients"></a>`maxclients`
 
 Data type: `Integer[1]`
 
@@ -387,7 +488,7 @@ Set the max number of connected clients at the same time.
 
 Default value: `10000`
 
-##### `maxmemory`
+##### <a name="maxmemory"></a>`maxmemory`
 
 Data type: `Any`
 
@@ -395,7 +496,7 @@ Don't use more memory than the specified amount of bytes.
 
 Default value: ``undef``
 
-##### `maxmemory_policy`
+##### <a name="maxmemory_policy"></a>`maxmemory_policy`
 
 Data type: `Any`
 
@@ -403,7 +504,7 @@ How Redis will select what to remove when maxmemory is reached.
 
 Default value: ``undef``
 
-##### `maxmemory_samples`
+##### <a name="maxmemory_samples"></a>`maxmemory_samples`
 
 Data type: `Any`
 
@@ -411,7 +512,7 @@ Select as well the sample size to check.
 
 Default value: ``undef``
 
-##### `min_slaves_max_lag`
+##### <a name="min_slaves_max_lag"></a>`min_slaves_max_lag`
 
 Data type: `Integer[0]`
 
@@ -419,7 +520,7 @@ The lag in seconds
 
 Default value: `10`
 
-##### `min_slaves_to_write`
+##### <a name="min_slaves_to_write"></a>`min_slaves_to_write`
 
 Data type: `Integer[0]`
 
@@ -427,7 +528,7 @@ Minimum number of slaves to be in "online" state
 
 Default value: `0`
 
-##### `no_appendfsync_on_rewrite`
+##### <a name="no_appendfsync_on_rewrite"></a>`no_appendfsync_on_rewrite`
 
 Data type: `Boolean`
 
@@ -435,7 +536,7 @@ If you have latency problems turn this to 'true'. Otherwise leave it as
 
 Default value: ``false``
 
-##### `notify_keyspace_events`
+##### <a name="notify_keyspace_events"></a>`notify_keyspace_events`
 
 Data type: `Optional[String[1]]`
 
@@ -443,7 +544,7 @@ Which events to notify Pub/Sub clients about events happening
 
 Default value: ``undef``
 
-##### `notify_service`
+##### <a name="notify_service"></a>`notify_service`
 
 Data type: `Boolean`
 
@@ -451,7 +552,7 @@ You may disable service reloads when config files change if you
 
 Default value: ``true``
 
-##### `package_ensure`
+##### <a name="package_ensure"></a>`package_ensure`
 
 Data type: `String[1]`
 
@@ -459,7 +560,7 @@ Default action for package.
 
 Default value: `'present'`
 
-##### `package_name`
+##### <a name="package_name"></a>`package_name`
 
 Data type: `String[1]`
 
@@ -467,7 +568,7 @@ Upstream package name.
 
 Default value: `$redis::params::package_name`
 
-##### `pid_file`
+##### <a name="pid_file"></a>`pid_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -475,7 +576,7 @@ Where to store the pid.
 
 Default value: `$redis::params::pid_file`
 
-##### `port`
+##### <a name="port"></a>`port`
 
 Data type: `Stdlib::Port`
 
@@ -483,7 +584,7 @@ Configure which port to listen on.
 
 Default value: `6379`
 
-##### `protected_mode`
+##### <a name="protected_mode"></a>`protected_mode`
 
 Data type: `Boolean`
 
@@ -491,7 +592,7 @@ Whether protected mode is enabled or not.  Only applicable when no bind is set.
 
 Default value: ``true``
 
-##### `ppa_repo`
+##### <a name="ppa_repo"></a>`ppa_repo`
 
 Data type: `Optional[String]`
 
@@ -499,7 +600,7 @@ Specify upstream (Ubuntu) PPA entry.
 
 Default value: `$redis::params::ppa_repo`
 
-##### `rdbcompression`
+##### <a name="rdbcompression"></a>`rdbcompression`
 
 Data type: `Boolean`
 
@@ -507,7 +608,15 @@ Enable/disable compression of string objects using LZF when dumping.
 
 Default value: ``true``
 
-##### `repl_backlog_size`
+##### <a name="rename_commands"></a>`rename_commands`
+
+Data type: `Hash[String,String]`
+
+A list of Redis commands to rename or disable for security reasons
+
+Default value: `{}`
+
+##### <a name="repl_backlog_size"></a>`repl_backlog_size`
 
 Data type: `String[1]`
 
@@ -515,7 +624,7 @@ The replication backlog size
 
 Default value: `'1mb'`
 
-##### `repl_backlog_ttl`
+##### <a name="repl_backlog_ttl"></a>`repl_backlog_ttl`
 
 Data type: `Integer[0]`
 
@@ -523,7 +632,7 @@ The number of seconds to elapse before freeing backlog buffer
 
 Default value: `3600`
 
-##### `repl_disable_tcp_nodelay`
+##### <a name="repl_disable_tcp_nodelay"></a>`repl_disable_tcp_nodelay`
 
 Data type: `Boolean`
 
@@ -531,7 +640,7 @@ Enable/disable TCP_NODELAY on the slave socket after SYNC
 
 Default value: ``false``
 
-##### `repl_ping_slave_period`
+##### <a name="repl_ping_slave_period"></a>`repl_ping_slave_period`
 
 Data type: `Integer[1]`
 
@@ -539,7 +648,7 @@ Slaves send PINGs to server in a predefined interval. It's possible
 
 Default value: `10`
 
-##### `repl_timeout`
+##### <a name="repl_timeout"></a>`repl_timeout`
 
 Data type: `Integer[1]`
 
@@ -547,7 +656,7 @@ Set the replication timeout for:
 
 Default value: `60`
 
-##### `requirepass`
+##### <a name="requirepass"></a>`requirepass`
 
 Data type: `Optional[String]`
 
@@ -555,7 +664,7 @@ Require clients to issue AUTH <PASSWORD> before processing any other commands.
 
 Default value: ``undef``
 
-##### `save_db_to_disk`
+##### <a name="save_db_to_disk"></a>`save_db_to_disk`
 
 Data type: `Boolean`
 
@@ -563,7 +672,7 @@ Set if save db to disk.
 
 Default value: ``true``
 
-##### `save_db_to_disk_interval`
+##### <a name="save_db_to_disk_interval"></a>`save_db_to_disk_interval`
 
 Data type: `Hash`
 
@@ -571,7 +680,7 @@ save the dataset every N seconds if there are at least M changes in the dataset
 
 Default value: `{ '900' => '1', '300' => '10', '60' => '10000' }`
 
-##### `service_manage`
+##### <a name="service_manage"></a>`service_manage`
 
 Data type: `Boolean`
 
@@ -579,7 +688,7 @@ Specify if the service should be part of the catalog.
 
 Default value: ``true``
 
-##### `service_enable`
+##### <a name="service_enable"></a>`service_enable`
 
 Data type: `Boolean`
 
@@ -587,7 +696,7 @@ Enable/disable daemon at boot.
 
 Default value: ``true``
 
-##### `service_ensure`
+##### <a name="service_ensure"></a>`service_ensure`
 
 Data type: `Stdlib::Ensure::Service`
 
@@ -595,7 +704,7 @@ Specify if the server should be running.
 
 Default value: `'running'`
 
-##### `service_group`
+##### <a name="service_group"></a>`service_group`
 
 Data type: `String[1]`
 
@@ -603,7 +712,7 @@ Specify which group to run as.
 
 Default value: `'redis'`
 
-##### `service_name`
+##### <a name="service_name"></a>`service_name`
 
 Data type: `String[1]`
 
@@ -611,7 +720,7 @@ Specify the service name for Init or Systemd.
 
 Default value: `$redis::params::service_name`
 
-##### `service_user`
+##### <a name="service_user"></a>`service_user`
 
 Data type: `String[1]`
 
@@ -619,7 +728,7 @@ Specify which user to run as.
 
 Default value: `'redis'`
 
-##### `set_max_intset_entries`
+##### <a name="set_max_intset_entries"></a>`set_max_intset_entries`
 
 Data type: `Integer[0]`
 
@@ -628,7 +737,7 @@ in order to use this special memory saving encoding.
 
 Default value: `512`
 
-##### `slave_priority`
+##### <a name="slave_priority"></a>`slave_priority`
 
 Data type: `Integer[0]`
 
@@ -636,7 +745,7 @@ The priority number for slave promotion by Sentinel
 
 Default value: `100`
 
-##### `slave_read_only`
+##### <a name="slave_read_only"></a>`slave_read_only`
 
 Data type: `Boolean`
 
@@ -644,7 +753,7 @@ You can configure a slave instance to accept writes or not.
 
 Default value: ``true``
 
-##### `slave_serve_stale_data`
+##### <a name="slave_serve_stale_data"></a>`slave_serve_stale_data`
 
 Data type: `Boolean`
 
@@ -659,7 +768,7 @@ is still in progress, the slave can act in two different ways:
 
 Default value: ``true``
 
-##### `slaveof`
+##### <a name="slaveof"></a>`slaveof`
 
 Data type: `Optional[String[1]]`
 
@@ -667,7 +776,7 @@ Use slaveof to make a Redis instance a copy of another Redis server.
 
 Default value: ``undef``
 
-##### `slowlog_log_slower_than`
+##### <a name="slowlog_log_slower_than"></a>`slowlog_log_slower_than`
 
 Data type: `Integer[0]`
 
@@ -676,7 +785,7 @@ for the command to get logged.
 
 Default value: `10000`
 
-##### `slowlog_max_len`
+##### <a name="slowlog_max_len"></a>`slowlog_max_len`
 
 Data type: `Integer[0]`
 
@@ -685,7 +794,7 @@ logged.
 
 Default value: `1024`
 
-##### `stop_writes_on_bgsave_error`
+##### <a name="stop_writes_on_bgsave_error"></a>`stop_writes_on_bgsave_error`
 
 Data type: `Boolean`
 
@@ -694,7 +803,7 @@ problems with disk, permissions, and so forth.
 
 Default value: ``true``
 
-##### `syslog_enabled`
+##### <a name="syslog_enabled"></a>`syslog_enabled`
 
 Data type: `Boolean`
 
@@ -702,7 +811,7 @@ Enable/disable logging to the system logger.
 
 Default value: ``false``
 
-##### `syslog_facility`
+##### <a name="syslog_facility"></a>`syslog_facility`
 
 Data type: `Optional[String[1]]`
 
@@ -710,7 +819,7 @@ Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
 
 Default value: ``undef``
 
-##### `tcp_backlog`
+##### <a name="tcp_backlog"></a>`tcp_backlog`
 
 Data type: `Integer[0]`
 
@@ -718,7 +827,7 @@ Sets the TCP backlog
 
 Default value: `511`
 
-##### `tcp_keepalive`
+##### <a name="tcp_keepalive"></a>`tcp_keepalive`
 
 Data type: `Integer[0]`
 
@@ -726,7 +835,7 @@ TCP keepalive.
 
 Default value: `0`
 
-##### `timeout`
+##### <a name="timeout"></a>`timeout`
 
 Data type: `Integer[0]`
 
@@ -734,7 +843,7 @@ Close the connection after a client is idle for N seconds (0 to disable).
 
 Default value: `0`
 
-##### `ulimit`
+##### <a name="ulimit"></a>`ulimit`
 
 Data type: `Integer[0]`
 
@@ -742,7 +851,16 @@ Limit the use of system-wide resources.
 
 Default value: `65536`
 
-##### `unixsocket`
+##### <a name="ulimit_managed"></a>`ulimit_managed`
+
+Data type: `Boolean`
+
+Defines wheter the max number of open files for the
+systemd service unit is explicitly managed.
+
+Default value: ``true``
+
+##### <a name="unixsocket"></a>`unixsocket`
 
 Data type: `Variant[Stdlib::Absolutepath, Enum['']]`
 
@@ -750,7 +868,7 @@ Define unix socket path
 
 Default value: `'/var/run/redis/redis.sock'`
 
-##### `unixsocketperm`
+##### <a name="unixsocketperm"></a>`unixsocketperm`
 
 Data type: `Variant[Stdlib::Filemode, Enum['']]`
 
@@ -758,7 +876,7 @@ Define unix socket file permissions
 
 Default value: `'0755'`
 
-##### `workdir`
+##### <a name="workdir"></a>`workdir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -767,7 +885,7 @@ above using the 'dbfilename' configuration directive.
 
 Default value: `$redis::params::workdir`
 
-##### `workdir_mode`
+##### <a name="workdir_mode"></a>`workdir_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -775,7 +893,7 @@ Adjust mode for data directory.
 
 Default value: `'0750'`
 
-##### `zset_max_ziplist_entries`
+##### <a name="zset_max_ziplist_entries"></a>`zset_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -783,7 +901,7 @@ Set max entries for sorted sets.
 
 Default value: `128`
 
-##### `zset_max_ziplist_value`
+##### <a name="zset_max_ziplist_value"></a>`zset_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -791,7 +909,7 @@ Set max values for sorted sets.
 
 Default value: `64`
 
-##### `cluster_enabled`
+##### <a name="cluster_enabled"></a>`cluster_enabled`
 
 Data type: `Boolean`
 
@@ -799,7 +917,7 @@ Enables redis 3.0 cluster functionality
 
 Default value: ``false``
 
-##### `cluster_config_file`
+##### <a name="cluster_config_file"></a>`cluster_config_file`
 
 Data type: `String[1]`
 
@@ -808,7 +926,7 @@ touched by humans. Only set if cluster_enabled is true
 
 Default value: `'nodes.conf'`
 
-##### `cluster_node_timeout`
+##### <a name="cluster_node_timeout"></a>`cluster_node_timeout`
 
 Data type: `Integer[1]`
 
@@ -816,7 +934,7 @@ Node timeout. Only set if cluster_enabled is true
 
 Default value: `5000`
 
-##### `cluster_slave_validity_factor`
+##### <a name="cluster_slave_validity_factor"></a>`cluster_slave_validity_factor`
 
 Data type: `Integer[0]`
 
@@ -825,7 +943,7 @@ Only set if cluster_enabled is true
 
 Default value: `0`
 
-##### `cluster_require_full_coverage`
+##### <a name="cluster_require_full_coverage"></a>`cluster_require_full_coverage`
 
 Data type: `Boolean`
 
@@ -834,7 +952,7 @@ Only set if cluster_enabled is true
 
 Default value: ``true``
 
-##### `cluster_migration_barrier`
+##### <a name="cluster_migration_barrier"></a>`cluster_migration_barrier`
 
 Data type: `Integer[0]`
 
@@ -844,7 +962,7 @@ Only set if cluster_enabled is true
 
 Default value: `1`
 
-##### `instances`
+##### <a name="instances"></a>`instances`
 
 Data type: `Hash[String[1], Hash]`
 
@@ -852,7 +970,7 @@ Iterate through multiple instance configurations
 
 Default value: `{}`
 
-##### `output_buffer_limit_slave`
+##### <a name="output_buffer_limit_slave"></a>`output_buffer_limit_slave`
 
 Data type: `String[1]`
 
@@ -860,7 +978,7 @@ Data type: `String[1]`
 
 Default value: `'256mb 64mb 60'`
 
-##### `output_buffer_limit_pubsub`
+##### <a name="output_buffer_limit_pubsub"></a>`output_buffer_limit_pubsub`
 
 Data type: `String[1]`
 
@@ -868,7 +986,7 @@ Data type: `String[1]`
 
 Default value: `'32mb 8mb 60'`
 
-##### `manage_service_file`
+##### <a name="manage_service_file"></a>`manage_service_file`
 
 Data type: `Boolean`
 
@@ -876,22 +994,17 @@ Data type: `Boolean`
 
 Default value: ``false``
 
-##### `minimum_version`
-
-Data type: `String[1]`
-
-
-
-Default value: `$redis::params::minimum_version`
-
-### `redis::administration`
+### <a name="redisadministration"></a>`redis::administration`
 
 As documented in the FAQ and https://redis.io/topics/admin.
 For disabling Transparent Huge Pages (THP), use separate module such as:
 https://forge.puppet.com/modules/alexharvey/disable_transparent_hugepage
 
+Note that this class requires the herculesteam/augeasproviders_sysctl module.
+
 * **See also**
   * https://redis.io/topics/admin
+  * https://forge.puppet.com/herculesteam/augeasproviders_sysctl
 
 #### Examples
 
@@ -911,9 +1024,12 @@ class {'redis::administration':
 
 #### Parameters
 
-The following parameters are available in the `redis::administration` class.
+The following parameters are available in the `redis::administration` class:
 
-##### `enable_overcommit_memory`
+* [`enable_overcommit_memory`](#enable_overcommit_memory)
+* [`somaxconn`](#somaxconn)
+
+##### <a name="enable_overcommit_memory"></a>`enable_overcommit_memory`
 
 Data type: `Boolean`
 
@@ -921,7 +1037,7 @@ Enable the overcommit memory setting
 
 Default value: ``true``
 
-##### `somaxconn`
+##### <a name="somaxconn"></a>`somaxconn`
 
 Data type: `Integer[0]`
 
@@ -929,15 +1045,17 @@ Set somaxconn value
 
 Default value: `65535`
 
-### `redis::globals`
+### <a name="redisglobals"></a>`redis::globals`
 
 Set a global config for Redis
 
 #### Parameters
 
-The following parameters are available in the `redis::globals` class.
+The following parameters are available in the `redis::globals` class:
 
-##### `scl`
+* [`scl`](#scl)
+
+##### <a name="scl"></a>`scl`
 
 Data type: `Optional[String]`
 
@@ -945,7 +1063,7 @@ Use a specific Software CoLlection on Red Hat based systems
 
 Default value: ``undef``
 
-### `redis::sentinel`
+### <a name="redissentinel"></a>`redis::sentinel`
 
 Install redis-sentinel
 
@@ -968,9 +1086,40 @@ class {'redis::sentinel':
 
 #### Parameters
 
-The following parameters are available in the `redis::sentinel` class.
+The following parameters are available in the `redis::sentinel` class:
 
-##### `auth_pass`
+* [`auth_pass`](#auth_pass)
+* [`config_file`](#config_file)
+* [`config_file_orig`](#config_file_orig)
+* [`config_file_mode`](#config_file_mode)
+* [`conf_template`](#conf_template)
+* [`daemonize`](#daemonize)
+* [`down_after`](#down_after)
+* [`failover_timeout`](#failover_timeout)
+* [`log_file`](#log_file)
+* [`log_level`](#log_level)
+* [`master_name`](#master_name)
+* [`redis_host`](#redis_host)
+* [`redis_port`](#redis_port)
+* [`requirepass`](#requirepass)
+* [`protected_mode`](#protected_mode)
+* [`package_name`](#package_name)
+* [`package_ensure`](#package_ensure)
+* [`parallel_sync`](#parallel_sync)
+* [`pid_file`](#pid_file)
+* [`quorum`](#quorum)
+* [`sentinel_bind`](#sentinel_bind)
+* [`sentinel_port`](#sentinel_port)
+* [`service_group`](#service_group)
+* [`service_name`](#service_name)
+* [`service_user`](#service_user)
+* [`service_enable`](#service_enable)
+* [`working_dir`](#working_dir)
+* [`notification_script`](#notification_script)
+* [`client_reconfig_script`](#client_reconfig_script)
+* [`service_ensure`](#service_ensure)
+
+##### <a name="auth_pass"></a>`auth_pass`
 
 Data type: `Optional[String[1]]`
 
@@ -978,7 +1127,7 @@ The password to use to authenticate with the master and slaves.
 
 Default value: ``undef``
 
-##### `config_file`
+##### <a name="config_file"></a>`config_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -986,7 +1135,7 @@ The location and name of the sentinel config file.
 
 Default value: `$redis::params::sentinel_config_file`
 
-##### `config_file_orig`
+##### <a name="config_file_orig"></a>`config_file_orig`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -998,7 +1147,7 @@ changes from the manifests.
 
 Default value: `$redis::params::sentinel_config_file_orig`
 
-##### `config_file_mode`
+##### <a name="config_file_mode"></a>`config_file_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -1006,7 +1155,7 @@ Permissions of config file.
 
 Default value: `'0644'`
 
-##### `conf_template`
+##### <a name="conf_template"></a>`conf_template`
 
 Data type: `String[1]`
 
@@ -1014,7 +1163,7 @@ Define which template to use.
 
 Default value: `'redis/redis-sentinel.conf.erb'`
 
-##### `daemonize`
+##### <a name="daemonize"></a>`daemonize`
 
 Data type: `Boolean`
 
@@ -1022,7 +1171,7 @@ Have Redis sentinel run as a daemon.
 
 Default value: `$redis::params::sentinel_daemonize`
 
-##### `down_after`
+##### <a name="down_after"></a>`down_after`
 
 Data type: `Integer[1]`
 
@@ -1032,7 +1181,7 @@ for the specified period) in order to consider it in S_DOWN state.
 
 Default value: `30000`
 
-##### `failover_timeout`
+##### <a name="failover_timeout"></a>`failover_timeout`
 
 Data type: `Integer[1]`
 
@@ -1040,7 +1189,7 @@ Specify the failover timeout in milliseconds.
 
 Default value: `180000`
 
-##### `log_file`
+##### <a name="log_file"></a>`log_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1048,7 +1197,7 @@ Specify where to write log entries.
 
 Default value: `$redis::params::sentinel_log_file`
 
-##### `log_level`
+##### <a name="log_level"></a>`log_level`
 
 Data type: `Redis::LogLevel`
 
@@ -1056,7 +1205,7 @@ Specify how much we should log.
 
 Default value: `'notice'`
 
-##### `master_name`
+##### <a name="master_name"></a>`master_name`
 
 Data type: `String[1]`
 
@@ -1065,7 +1214,7 @@ The valid charset is A-z 0-9 and the three characters ".-_".
 
 Default value: `'mymaster'`
 
-##### `redis_host`
+##### <a name="redis_host"></a>`redis_host`
 
 Data type: `Stdlib::Host`
 
@@ -1073,7 +1222,7 @@ Specify the bound host of the master redis server.
 
 Default value: `'127.0.0.1'`
 
-##### `redis_port`
+##### <a name="redis_port"></a>`redis_port`
 
 Data type: `Stdlib::Port`
 
@@ -1081,15 +1230,23 @@ Specify the port of the master redis server.
 
 Default value: `6379`
 
-##### `protected_mode`
+##### <a name="requirepass"></a>`requirepass`
+
+Data type: `Optional[String[1]]`
+
+Specify the password to require client authentication via the AUTH command, however this feature is only available starting with Redis 5.0.1.
+
+Default value: ``undef``
+
+##### <a name="protected_mode"></a>`protected_mode`
 
 Data type: `Boolean`
 
 Whether protected mode is enabled or not. Only applicable when no bind is set.
 
-Default value: `$redis::params::sentinel_protected_mode`
+Default value: ``true``
 
-##### `package_name`
+##### <a name="package_name"></a>`package_name`
 
 Data type: `String[1]`
 
@@ -1097,7 +1254,7 @@ The name of the package that installs sentinel.
 
 Default value: `$redis::params::sentinel_package_name`
 
-##### `package_ensure`
+##### <a name="package_ensure"></a>`package_ensure`
 
 Data type: `String[1]`
 
@@ -1105,7 +1262,7 @@ Do we ensure this package.
 
 Default value: `'present'`
 
-##### `parallel_sync`
+##### <a name="parallel_sync"></a>`parallel_sync`
 
 Data type: `Integer[0]`
 
@@ -1114,7 +1271,7 @@ new master after a failover.
 
 Default value: `1`
 
-##### `pid_file`
+##### <a name="pid_file"></a>`pid_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1122,7 +1279,7 @@ If sentinel is daemonized it will write its pid at this location.
 
 Default value: `$redis::params::sentinel_pid_file`
 
-##### `quorum`
+##### <a name="quorum"></a>`quorum`
 
 Data type: `Integer[1]`
 
@@ -1131,7 +1288,7 @@ signal sdown state.
 
 Default value: `2`
 
-##### `sentinel_bind`
+##### <a name="sentinel_bind"></a>`sentinel_bind`
 
 Data type: `Variant[Undef, Stdlib::IP::Address, Array[Stdlib::IP::Address]]`
 
@@ -1140,7 +1297,7 @@ issues arising from protect-mode added Redis 3.2
 
 Default value: ``undef``
 
-##### `sentinel_port`
+##### <a name="sentinel_port"></a>`sentinel_port`
 
 Data type: `Stdlib::Port`
 
@@ -1148,7 +1305,7 @@ The port of sentinel server.
 
 Default value: `26379`
 
-##### `service_group`
+##### <a name="service_group"></a>`service_group`
 
 Data type: `String[1]`
 
@@ -1156,7 +1313,7 @@ The group of the config file.
 
 Default value: `'redis'`
 
-##### `service_name`
+##### <a name="service_name"></a>`service_name`
 
 Data type: `String[1]`
 
@@ -1164,7 +1321,7 @@ The name of the service (for puppet to manage).
 
 Default value: `$redis::params::sentinel_service_name`
 
-##### `service_user`
+##### <a name="service_user"></a>`service_user`
 
 Data type: `String[1]`
 
@@ -1172,7 +1329,7 @@ The owner of the config file.
 
 Default value: `'redis'`
 
-##### `service_enable`
+##### <a name="service_enable"></a>`service_enable`
 
 Data type: `Boolean`
 
@@ -1180,7 +1337,7 @@ Enable the service at boot time.
 
 Default value: ``true``
 
-##### `working_dir`
+##### <a name="working_dir"></a>`working_dir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1189,7 +1346,7 @@ conflicts.
 
 Default value: `$redis::params::sentinel_working_dir`
 
-##### `notification_script`
+##### <a name="notification_script"></a>`notification_script`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
@@ -1197,7 +1354,7 @@ Path to the notification script
 
 Default value: ``undef``
 
-##### `client_reconfig_script`
+##### <a name="client_reconfig_script"></a>`client_reconfig_script`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
@@ -1205,7 +1362,7 @@ Path to the client-reconfig script
 
 Default value: ``undef``
 
-##### `service_ensure`
+##### <a name="service_ensure"></a>`service_ensure`
 
 Data type: `Stdlib::Ensure::Service`
 
@@ -1215,7 +1372,7 @@ Default value: `'running'`
 
 ## Defined types
 
-### `redis::instance`
+### <a name="redisinstance"></a>`redis::instance`
 
 This is an defined type to allow the configuration of
 multiple redis instances on one machine without conflicts
@@ -1232,9 +1389,98 @@ redis::instance {'6380':
 
 #### Parameters
 
-The following parameters are available in the `redis::instance` defined type.
+The following parameters are available in the `redis::instance` defined type:
 
-##### `activerehashing`
+* [`activerehashing`](#activerehashing)
+* [`aof_load_truncated`](#aof_load_truncated)
+* [`aof_rewrite_incremental_fsync`](#aof_rewrite_incremental_fsync)
+* [`appendfilename`](#appendfilename)
+* [`appendfsync`](#appendfsync)
+* [`appendonly`](#appendonly)
+* [`auto_aof_rewrite_min_size`](#auto_aof_rewrite_min_size)
+* [`auto_aof_rewrite_percentage`](#auto_aof_rewrite_percentage)
+* [`bind`](#bind)
+* [`config_file_orig`](#config_file_orig)
+* [`config_file`](#config_file)
+* [`config_file_mode`](#config_file_mode)
+* [`config_group`](#config_group)
+* [`config_owner`](#config_owner)
+* [`conf_template`](#conf_template)
+* [`daemonize`](#daemonize)
+* [`databases`](#databases)
+* [`dbfilename`](#dbfilename)
+* [`extra_config_file`](#extra_config_file)
+* [`hash_max_ziplist_entries`](#hash_max_ziplist_entries)
+* [`hash_max_ziplist_value`](#hash_max_ziplist_value)
+* [`hll_sparse_max_bytes`](#hll_sparse_max_bytes)
+* [`hz`](#hz)
+* [`latency_monitor_threshold`](#latency_monitor_threshold)
+* [`list_max_ziplist_entries`](#list_max_ziplist_entries)
+* [`list_max_ziplist_value`](#list_max_ziplist_value)
+* [`log_dir`](#log_dir)
+* [`log_dir_mode`](#log_dir_mode)
+* [`log_file`](#log_file)
+* [`log_level`](#log_level)
+* [`masterauth`](#masterauth)
+* [`maxclients`](#maxclients)
+* [`maxmemory`](#maxmemory)
+* [`maxmemory_policy`](#maxmemory_policy)
+* [`maxmemory_samples`](#maxmemory_samples)
+* [`min_slaves_max_lag`](#min_slaves_max_lag)
+* [`min_slaves_to_write`](#min_slaves_to_write)
+* [`no_appendfsync_on_rewrite`](#no_appendfsync_on_rewrite)
+* [`notify_keyspace_events`](#notify_keyspace_events)
+* [`pid_file`](#pid_file)
+* [`port`](#port)
+* [`protected_mode`](#protected_mode)
+* [`rdbcompression`](#rdbcompression)
+* [`rename_commands`](#rename_commands)
+* [`repl_backlog_size`](#repl_backlog_size)
+* [`repl_backlog_ttl`](#repl_backlog_ttl)
+* [`repl_disable_tcp_nodelay`](#repl_disable_tcp_nodelay)
+* [`repl_ping_slave_period`](#repl_ping_slave_period)
+* [`repl_timeout`](#repl_timeout)
+* [`requirepass`](#requirepass)
+* [`save_db_to_disk`](#save_db_to_disk)
+* [`save_db_to_disk_interval`](#save_db_to_disk_interval)
+* [`service_name`](#service_name)
+* [`service_enable`](#service_enable)
+* [`service_ensure`](#service_ensure)
+* [`service_group`](#service_group)
+* [`service_user`](#service_user)
+* [`set_max_intset_entries`](#set_max_intset_entries)
+* [`slave_priority`](#slave_priority)
+* [`slave_read_only`](#slave_read_only)
+* [`slave_serve_stale_data`](#slave_serve_stale_data)
+* [`slaveof`](#slaveof)
+* [`slowlog_log_slower_than`](#slowlog_log_slower_than)
+* [`slowlog_max_len`](#slowlog_max_len)
+* [`stop_writes_on_bgsave_error`](#stop_writes_on_bgsave_error)
+* [`syslog_enabled`](#syslog_enabled)
+* [`syslog_facility`](#syslog_facility)
+* [`tcp_backlog`](#tcp_backlog)
+* [`tcp_keepalive`](#tcp_keepalive)
+* [`timeout`](#timeout)
+* [`ulimit`](#ulimit)
+* [`ulimit_managed`](#ulimit_managed)
+* [`unixsocket`](#unixsocket)
+* [`unixsocketperm`](#unixsocketperm)
+* [`workdir`](#workdir)
+* [`workdir_mode`](#workdir_mode)
+* [`zset_max_ziplist_entries`](#zset_max_ziplist_entries)
+* [`zset_max_ziplist_value`](#zset_max_ziplist_value)
+* [`cluster_enabled`](#cluster_enabled)
+* [`cluster_config_file`](#cluster_config_file)
+* [`cluster_node_timeout`](#cluster_node_timeout)
+* [`cluster_slave_validity_factor`](#cluster_slave_validity_factor)
+* [`cluster_require_full_coverage`](#cluster_require_full_coverage)
+* [`cluster_migration_barrier`](#cluster_migration_barrier)
+* [`output_buffer_limit_slave`](#output_buffer_limit_slave)
+* [`output_buffer_limit_pubsub`](#output_buffer_limit_pubsub)
+* [`managed_by_cluster_manager`](#managed_by_cluster_manager)
+* [`manage_service_file`](#manage_service_file)
+
+##### <a name="activerehashing"></a>`activerehashing`
 
 Data type: `Boolean`
 
@@ -1242,7 +1488,7 @@ Enable/disable active rehashing.
 
 Default value: `$redis::activerehashing`
 
-##### `aof_load_truncated`
+##### <a name="aof_load_truncated"></a>`aof_load_truncated`
 
 Data type: `Boolean`
 
@@ -1250,7 +1496,7 @@ Enable/disable loading truncated AOF file
 
 Default value: `$redis::aof_load_truncated`
 
-##### `aof_rewrite_incremental_fsync`
+##### <a name="aof_rewrite_incremental_fsync"></a>`aof_rewrite_incremental_fsync`
 
 Data type: `Boolean`
 
@@ -1258,7 +1504,7 @@ Enable/disable fsync for AOF file
 
 Default value: `$redis::aof_rewrite_incremental_fsync`
 
-##### `appendfilename`
+##### <a name="appendfilename"></a>`appendfilename`
 
 Data type: `String[1]`
 
@@ -1266,7 +1512,7 @@ The name of the append only file
 
 Default value: `$redis::appendfilename`
 
-##### `appendfsync`
+##### <a name="appendfsync"></a>`appendfsync`
 
 Data type: `Enum['no', 'always', 'everysec']`
 
@@ -1274,7 +1520,7 @@ Adjust fsync mode. Valid options: always, everysec, no.
 
 Default value: `$redis::appendfsync`
 
-##### `appendonly`
+##### <a name="appendonly"></a>`appendonly`
 
 Data type: `Boolean`
 
@@ -1282,7 +1528,7 @@ Enable/disable appendonly mode.
 
 Default value: `$redis::appendonly`
 
-##### `auto_aof_rewrite_min_size`
+##### <a name="auto_aof_rewrite_min_size"></a>`auto_aof_rewrite_min_size`
 
 Data type: `String[1]`
 
@@ -1290,7 +1536,7 @@ Adjust minimum size for auto-aof-rewrite.
 
 Default value: `$redis::auto_aof_rewrite_min_size`
 
-##### `auto_aof_rewrite_percentage`
+##### <a name="auto_aof_rewrite_percentage"></a>`auto_aof_rewrite_percentage`
 
 Data type: `Integer[0]`
 
@@ -1298,7 +1544,7 @@ Adjust percentatge for auto-aof-rewrite.
 
 Default value: `$redis::auto_aof_rewrite_percentage`
 
-##### `bind`
+##### <a name="bind"></a>`bind`
 
 Data type: `Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]]`
 
@@ -1306,7 +1552,7 @@ Configure which IP address(es) to listen on. To bind on all interfaces, use an e
 
 Default value: `$redis::bind`
 
-##### `config_file_orig`
+##### <a name="config_file_orig"></a>`config_file_orig`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1314,7 +1560,7 @@ The location and name of a config file that provides the source
 
 Default value: `$redis::config_file_orig`
 
-##### `config_file`
+##### <a name="config_file"></a>`config_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1322,7 +1568,7 @@ Adjust main configuration file.
 
 Default value: `$redis::config_file`
 
-##### `config_file_mode`
+##### <a name="config_file_mode"></a>`config_file_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -1330,7 +1576,7 @@ Adjust permissions for configuration files.
 
 Default value: `$redis::config_file_mode`
 
-##### `config_group`
+##### <a name="config_group"></a>`config_group`
 
 Data type: `String[1]`
 
@@ -1338,7 +1584,7 @@ Adjust filesystem group for config files.
 
 Default value: `$redis::config_group`
 
-##### `config_owner`
+##### <a name="config_owner"></a>`config_owner`
 
 Data type: `String[1]`
 
@@ -1346,7 +1592,7 @@ Adjust filesystem owner for config files.
 
 Default value: `$redis::config_owner`
 
-##### `conf_template`
+##### <a name="conf_template"></a>`conf_template`
 
 Data type: `String[1]`
 
@@ -1354,7 +1600,7 @@ Define which template to use.
 
 Default value: `$redis::conf_template`
 
-##### `daemonize`
+##### <a name="daemonize"></a>`daemonize`
 
 Data type: `Boolean`
 
@@ -1362,7 +1608,7 @@ Have Redis run as a daemon.
 
 Default value: ``true``
 
-##### `databases`
+##### <a name="databases"></a>`databases`
 
 Data type: `Integer[1]`
 
@@ -1370,7 +1616,7 @@ Set the number of databases.
 
 Default value: `$redis::databases`
 
-##### `dbfilename`
+##### <a name="dbfilename"></a>`dbfilename`
 
 Data type: `Variant[String[1], Boolean]`
 
@@ -1378,7 +1624,7 @@ The filename where to dump the DB
 
 Default value: `$redis::dbfilename`
 
-##### `extra_config_file`
+##### <a name="extra_config_file"></a>`extra_config_file`
 
 Data type: `Optional[String]`
 
@@ -1386,7 +1632,7 @@ Optional extra config file to include
 
 Default value: `$redis::extra_config_file`
 
-##### `hash_max_ziplist_entries`
+##### <a name="hash_max_ziplist_entries"></a>`hash_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -1394,7 +1640,7 @@ Set max ziplist entries for hashes.
 
 Default value: `$redis::hash_max_ziplist_entries`
 
-##### `hash_max_ziplist_value`
+##### <a name="hash_max_ziplist_value"></a>`hash_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -1402,7 +1648,7 @@ Set max ziplist values for hashes.
 
 Default value: `$redis::hash_max_ziplist_value`
 
-##### `hll_sparse_max_bytes`
+##### <a name="hll_sparse_max_bytes"></a>`hll_sparse_max_bytes`
 
 Data type: `Integer[0]`
 
@@ -1410,7 +1656,7 @@ HyperLogLog sparse representation bytes limit
 
 Default value: `$redis::hll_sparse_max_bytes`
 
-##### `hz`
+##### <a name="hz"></a>`hz`
 
 Data type: `Integer[1, 500]`
 
@@ -1418,7 +1664,7 @@ Set redis background tasks frequency
 
 Default value: `$redis::hz`
 
-##### `latency_monitor_threshold`
+##### <a name="latency_monitor_threshold"></a>`latency_monitor_threshold`
 
 Data type: `Integer[0]`
 
@@ -1426,7 +1672,7 @@ Latency monitoring threshold in milliseconds
 
 Default value: `$redis::latency_monitor_threshold`
 
-##### `list_max_ziplist_entries`
+##### <a name="list_max_ziplist_entries"></a>`list_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -1434,7 +1680,7 @@ Set max ziplist entries for lists.
 
 Default value: `$redis::list_max_ziplist_entries`
 
-##### `list_max_ziplist_value`
+##### <a name="list_max_ziplist_value"></a>`list_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -1442,7 +1688,7 @@ Set max ziplist values for lists.
 
 Default value: `$redis::list_max_ziplist_value`
 
-##### `log_dir`
+##### <a name="log_dir"></a>`log_dir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1450,7 +1696,7 @@ Specify directory where to write log entries.
 
 Default value: `$redis::log_dir`
 
-##### `log_dir_mode`
+##### <a name="log_dir_mode"></a>`log_dir_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -1458,15 +1704,16 @@ Adjust mode for directory containing log files.
 
 Default value: `$redis::log_dir_mode`
 
-##### `log_file`
+##### <a name="log_file"></a>`log_file`
 
-Data type: `Optional[Stdlib::Absolutepath]`
+Data type: `String`
 
-Specify file where to write log entries.
+Specify file where to write log entries. Relative paths will be prepended
+with log_dir but absolute paths are also accepted.
 
-Default value: ``undef``
+Default value: `"redis-server-${name}.log"`
 
-##### `log_level`
+##### <a name="log_level"></a>`log_level`
 
 Data type: `Redis::LogLevel`
 
@@ -1474,7 +1721,7 @@ Specify the server verbosity level.
 
 Default value: `$redis::log_level`
 
-##### `masterauth`
+##### <a name="masterauth"></a>`masterauth`
 
 Data type: `Optional[String[1]]`
 
@@ -1482,7 +1729,7 @@ If the master is password protected (using the "requirepass" configuration
 
 Default value: `$redis::masterauth`
 
-##### `maxclients`
+##### <a name="maxclients"></a>`maxclients`
 
 Data type: `Integer[1]`
 
@@ -1490,7 +1737,7 @@ Set the max number of connected clients at the same time.
 
 Default value: `$redis::maxclients`
 
-##### `maxmemory`
+##### <a name="maxmemory"></a>`maxmemory`
 
 Data type: `Any`
 
@@ -1498,7 +1745,7 @@ Don't use more memory than the specified amount of bytes.
 
 Default value: `$redis::maxmemory`
 
-##### `maxmemory_policy`
+##### <a name="maxmemory_policy"></a>`maxmemory_policy`
 
 Data type: `Any`
 
@@ -1506,7 +1753,7 @@ How Redis will select what to remove when maxmemory is reached.
 
 Default value: `$redis::maxmemory_policy`
 
-##### `maxmemory_samples`
+##### <a name="maxmemory_samples"></a>`maxmemory_samples`
 
 Data type: `Any`
 
@@ -1514,7 +1761,7 @@ Select as well the sample size to check.
 
 Default value: `$redis::maxmemory_samples`
 
-##### `min_slaves_max_lag`
+##### <a name="min_slaves_max_lag"></a>`min_slaves_max_lag`
 
 Data type: `Integer[0]`
 
@@ -1522,7 +1769,7 @@ The lag in seconds
 
 Default value: `$redis::min_slaves_max_lag`
 
-##### `min_slaves_to_write`
+##### <a name="min_slaves_to_write"></a>`min_slaves_to_write`
 
 Data type: `Integer[0]`
 
@@ -1530,7 +1777,7 @@ Minimum number of slaves to be in "online" state
 
 Default value: `$redis::min_slaves_to_write`
 
-##### `no_appendfsync_on_rewrite`
+##### <a name="no_appendfsync_on_rewrite"></a>`no_appendfsync_on_rewrite`
 
 Data type: `Boolean`
 
@@ -1538,7 +1785,7 @@ If you have latency problems turn this to 'true'. Otherwise leave it as
 
 Default value: `$redis::no_appendfsync_on_rewrite`
 
-##### `notify_keyspace_events`
+##### <a name="notify_keyspace_events"></a>`notify_keyspace_events`
 
 Data type: `Optional[String[1]]`
 
@@ -1546,7 +1793,7 @@ Which events to notify Pub/Sub clients about events happening
 
 Default value: `$redis::notify_keyspace_events`
 
-##### `pid_file`
+##### <a name="pid_file"></a>`pid_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1554,7 +1801,7 @@ Where to store the pid.
 
 Default value: `"/var/run/redis/redis-server-${name}.pid"`
 
-##### `port`
+##### <a name="port"></a>`port`
 
 Data type: `Stdlib::Port`
 
@@ -1562,7 +1809,7 @@ Configure which port to listen on.
 
 Default value: `$redis::port`
 
-##### `protected_mode`
+##### <a name="protected_mode"></a>`protected_mode`
 
 Data type: `Boolean`
 
@@ -1570,7 +1817,7 @@ Whether protected mode is enabled or not.  Only applicable when no bind is set.
 
 Default value: `$redis::protected_mode`
 
-##### `rdbcompression`
+##### <a name="rdbcompression"></a>`rdbcompression`
 
 Data type: `Boolean`
 
@@ -1578,7 +1825,15 @@ Enable/disable compression of string objects using LZF when dumping.
 
 Default value: `$redis::rdbcompression`
 
-##### `repl_backlog_size`
+##### <a name="rename_commands"></a>`rename_commands`
+
+Data type: `Hash[String,String]`
+
+A list of Redis commands to rename or disable for security reasons
+
+Default value: `$redis::rename_commands`
+
+##### <a name="repl_backlog_size"></a>`repl_backlog_size`
 
 Data type: `String[1]`
 
@@ -1586,7 +1841,7 @@ The replication backlog size
 
 Default value: `$redis::repl_backlog_size`
 
-##### `repl_backlog_ttl`
+##### <a name="repl_backlog_ttl"></a>`repl_backlog_ttl`
 
 Data type: `Integer[0]`
 
@@ -1594,7 +1849,7 @@ The number of seconds to elapse before freeing backlog buffer
 
 Default value: `$redis::repl_backlog_ttl`
 
-##### `repl_disable_tcp_nodelay`
+##### <a name="repl_disable_tcp_nodelay"></a>`repl_disable_tcp_nodelay`
 
 Data type: `Boolean`
 
@@ -1602,7 +1857,7 @@ Enable/disable TCP_NODELAY on the slave socket after SYNC
 
 Default value: `$redis::repl_disable_tcp_nodelay`
 
-##### `repl_ping_slave_period`
+##### <a name="repl_ping_slave_period"></a>`repl_ping_slave_period`
 
 Data type: `Integer[1]`
 
@@ -1610,7 +1865,7 @@ Slaves send PINGs to server in a predefined interval. It's possible
 
 Default value: `$redis::repl_ping_slave_period`
 
-##### `repl_timeout`
+##### <a name="repl_timeout"></a>`repl_timeout`
 
 Data type: `Integer[1]`
 
@@ -1618,7 +1873,7 @@ Set the replication timeout for:
 
 Default value: `$redis::repl_timeout`
 
-##### `requirepass`
+##### <a name="requirepass"></a>`requirepass`
 
 Data type: `Optional[String]`
 
@@ -1627,7 +1882,7 @@ commands.
 
 Default value: `$redis::requirepass`
 
-##### `save_db_to_disk`
+##### <a name="save_db_to_disk"></a>`save_db_to_disk`
 
 Data type: `Boolean`
 
@@ -1635,7 +1890,7 @@ Set if save db to disk.
 
 Default value: `$redis::save_db_to_disk`
 
-##### `save_db_to_disk_interval`
+##### <a name="save_db_to_disk_interval"></a>`save_db_to_disk_interval`
 
 Data type: `Hash`
 
@@ -1643,7 +1898,7 @@ save the dataset every N seconds if there are at least M changes in the dataset
 
 Default value: `$redis::save_db_to_disk_interval`
 
-##### `service_name`
+##### <a name="service_name"></a>`service_name`
 
 Data type: `String[1]`
 
@@ -1651,7 +1906,7 @@ The service name for this instance
 
 Default value: `"redis-server-${name}"`
 
-##### `service_enable`
+##### <a name="service_enable"></a>`service_enable`
 
 Data type: `Boolean`
 
@@ -1659,7 +1914,7 @@ Enable/disable daemon at boot.
 
 Default value: `$redis::service_enable`
 
-##### `service_ensure`
+##### <a name="service_ensure"></a>`service_ensure`
 
 Data type: `Stdlib::Ensure::Service`
 
@@ -1667,7 +1922,7 @@ Specify if the server should be running.
 
 Default value: `$redis::service_ensure`
 
-##### `service_group`
+##### <a name="service_group"></a>`service_group`
 
 Data type: `String[1]`
 
@@ -1675,7 +1930,7 @@ Specify which group to run as.
 
 Default value: `$redis::service_group`
 
-##### `service_user`
+##### <a name="service_user"></a>`service_user`
 
 Data type: `String[1]`
 
@@ -1683,7 +1938,7 @@ Specify which user to run as.
 
 Default value: `$redis::service_user`
 
-##### `set_max_intset_entries`
+##### <a name="set_max_intset_entries"></a>`set_max_intset_entries`
 
 Data type: `Integer[0]`
 
@@ -1692,7 +1947,7 @@ in order to use this special memory saving encoding.
 
 Default value: `$redis::set_max_intset_entries`
 
-##### `slave_priority`
+##### <a name="slave_priority"></a>`slave_priority`
 
 Data type: `Integer[0]`
 
@@ -1700,7 +1955,7 @@ The priority number for slave promotion by Sentinel
 
 Default value: `$redis::slave_priority`
 
-##### `slave_read_only`
+##### <a name="slave_read_only"></a>`slave_read_only`
 
 Data type: `Boolean`
 
@@ -1708,7 +1963,7 @@ You can configure a slave instance to accept writes or not.
 
 Default value: `$redis::slave_read_only`
 
-##### `slave_serve_stale_data`
+##### <a name="slave_serve_stale_data"></a>`slave_serve_stale_data`
 
 Data type: `Boolean`
 
@@ -1723,7 +1978,7 @@ is still in progress, the slave can act in two different ways:
 
 Default value: `$redis::slave_serve_stale_data`
 
-##### `slaveof`
+##### <a name="slaveof"></a>`slaveof`
 
 Data type: `Optional[String[1]]`
 
@@ -1731,7 +1986,7 @@ Use slaveof to make a Redis instance a copy of another Redis server.
 
 Default value: `$redis::slaveof`
 
-##### `slowlog_log_slower_than`
+##### <a name="slowlog_log_slower_than"></a>`slowlog_log_slower_than`
 
 Data type: `Integer[0]`
 
@@ -1740,7 +1995,7 @@ for the command to get logged.
 
 Default value: `$redis::slowlog_log_slower_than`
 
-##### `slowlog_max_len`
+##### <a name="slowlog_max_len"></a>`slowlog_max_len`
 
 Data type: `Integer[0]`
 
@@ -1749,7 +2004,7 @@ to get logged.
 
 Default value: `$redis::slowlog_max_len`
 
-##### `stop_writes_on_bgsave_error`
+##### <a name="stop_writes_on_bgsave_error"></a>`stop_writes_on_bgsave_error`
 
 Data type: `Boolean`
 
@@ -1758,7 +2013,7 @@ are problems with disk, permissions, and so forth.
 
 Default value: `$redis::stop_writes_on_bgsave_error`
 
-##### `syslog_enabled`
+##### <a name="syslog_enabled"></a>`syslog_enabled`
 
 Data type: `Boolean`
 
@@ -1766,7 +2021,7 @@ Enable/disable logging to the system logger.
 
 Default value: `$redis::syslog_enabled`
 
-##### `syslog_facility`
+##### <a name="syslog_facility"></a>`syslog_facility`
 
 Data type: `Optional[String[1]]`
 
@@ -1774,7 +2029,7 @@ Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
 
 Default value: `$redis::syslog_facility`
 
-##### `tcp_backlog`
+##### <a name="tcp_backlog"></a>`tcp_backlog`
 
 Data type: `Integer[0]`
 
@@ -1782,7 +2037,7 @@ Sets the TCP backlog
 
 Default value: `$redis::tcp_backlog`
 
-##### `tcp_keepalive`
+##### <a name="tcp_keepalive"></a>`tcp_keepalive`
 
 Data type: `Integer[0]`
 
@@ -1790,7 +2045,7 @@ TCP keepalive.
 
 Default value: `$redis::tcp_keepalive`
 
-##### `timeout`
+##### <a name="timeout"></a>`timeout`
 
 Data type: `Integer[0]`
 
@@ -1798,7 +2053,7 @@ Close the connection after a client is idle for N seconds (0 to disable).
 
 Default value: `$redis::timeout`
 
-##### `ulimit`
+##### <a name="ulimit"></a>`ulimit`
 
 Data type: `Integer[0]`
 
@@ -1806,7 +2061,16 @@ Limit the use of system-wide resources.
 
 Default value: `$redis::ulimit`
 
-##### `unixsocket`
+##### <a name="ulimit_managed"></a>`ulimit_managed`
+
+Data type: `Boolean`
+
+Defines wheter the max number of open files for the
+systemd service unit is explicitly managed.
+
+Default value: `$redis::ulimit_managed`
+
+##### <a name="unixsocket"></a>`unixsocket`
 
 Data type: `Variant[Stdlib::Absolutepath, Enum['']]`
 
@@ -1814,7 +2078,7 @@ Define unix socket path
 
 Default value: `"/var/run/redis/redis-server-${name}.sock"`
 
-##### `unixsocketperm`
+##### <a name="unixsocketperm"></a>`unixsocketperm`
 
 Data type: `Variant[Stdlib::Filemode , Enum['']]`
 
@@ -1822,7 +2086,7 @@ Define unix socket file permissions
 
 Default value: `$redis::unixsocketperm`
 
-##### `workdir`
+##### <a name="workdir"></a>`workdir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1831,7 +2095,7 @@ above using the 'dbfilename' configuration directive.
 
 Default value: `"${redis::workdir}/redis-server-${name}"`
 
-##### `workdir_mode`
+##### <a name="workdir_mode"></a>`workdir_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -1839,7 +2103,7 @@ Adjust mode for data directory.
 
 Default value: `$redis::workdir_mode`
 
-##### `zset_max_ziplist_entries`
+##### <a name="zset_max_ziplist_entries"></a>`zset_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -1847,7 +2111,7 @@ Set max entries for sorted sets.
 
 Default value: `$redis::zset_max_ziplist_entries`
 
-##### `zset_max_ziplist_value`
+##### <a name="zset_max_ziplist_value"></a>`zset_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -1855,7 +2119,7 @@ Set max values for sorted sets.
 
 Default value: `$redis::zset_max_ziplist_value`
 
-##### `cluster_enabled`
+##### <a name="cluster_enabled"></a>`cluster_enabled`
 
 Data type: `Boolean`
 
@@ -1863,7 +2127,7 @@ Enables redis 3.0 cluster functionality
 
 Default value: `$redis::cluster_enabled`
 
-##### `cluster_config_file`
+##### <a name="cluster_config_file"></a>`cluster_config_file`
 
 Data type: `String[1]`
 
@@ -1872,7 +2136,7 @@ touched by humans.  Only set if cluster_enabled is true
 
 Default value: `$redis::cluster_config_file`
 
-##### `cluster_node_timeout`
+##### <a name="cluster_node_timeout"></a>`cluster_node_timeout`
 
 Data type: `Integer[1]`
 
@@ -1880,7 +2144,7 @@ Node timeout. Only set if cluster_enabled is true
 
 Default value: `$redis::cluster_node_timeout`
 
-##### `cluster_slave_validity_factor`
+##### <a name="cluster_slave_validity_factor"></a>`cluster_slave_validity_factor`
 
 Data type: `Integer[0]`
 
@@ -1889,7 +2153,7 @@ master Only set if cluster_enabled is true
 
 Default value: `$redis::cluster_slave_validity_factor`
 
-##### `cluster_require_full_coverage`
+##### <a name="cluster_require_full_coverage"></a>`cluster_require_full_coverage`
 
 Data type: `Boolean`
 
@@ -1898,7 +2162,7 @@ of keys can be processed Only set if cluster_enabled is true
 
 Default value: `$redis::cluster_require_full_coverage`
 
-##### `cluster_migration_barrier`
+##### <a name="cluster_migration_barrier"></a>`cluster_migration_barrier`
 
 Data type: `Integer[0]`
 
@@ -1908,7 +2172,7 @@ set if cluster_enabled is true
 
 Default value: `$redis::cluster_migration_barrier`
 
-##### `output_buffer_limit_slave`
+##### <a name="output_buffer_limit_slave"></a>`output_buffer_limit_slave`
 
 Data type: `String[1]`
 
@@ -1916,7 +2180,7 @@ Data type: `String[1]`
 
 Default value: `$redis::output_buffer_limit_slave`
 
-##### `output_buffer_limit_pubsub`
+##### <a name="output_buffer_limit_pubsub"></a>`output_buffer_limit_pubsub`
 
 Data type: `String[1]`
 
@@ -1924,7 +2188,7 @@ Data type: `String[1]`
 
 Default value: `$redis::output_buffer_limit_pubsub`
 
-##### `managed_by_cluster_manager`
+##### <a name="managed_by_cluster_manager"></a>`managed_by_cluster_manager`
 
 Data type: `Boolean`
 
@@ -1932,7 +2196,7 @@ Data type: `Boolean`
 
 Default value: `$redis::managed_by_cluster_manager`
 
-##### `manage_service_file`
+##### <a name="manage_service_file"></a>`manage_service_file`
 
 Data type: `Boolean`
 
@@ -1942,32 +2206,14 @@ Default value: ``true``
 
 ## Functions
 
-### `redis::get`
+### <a name="redisget"></a>`redis::get`
 
 Type: Ruby 4.x API
 
-Takes two arguments with an optional third. The first being a string
-value of the key to be looked up, the second is the URL to the Redis service
-and the third optional argument is a default value to be used if the lookup
-fails.
-
-example usage
-```
-$version = redis::get('version.myapp', 'redis://redis.example.com:6379')
-$version_with_default = redis::get('version.myapp', 'redis://redis.example.com:6379', $::myapp_version)
 ```
 
 #### `redis::get(String[1] $key, Redis::RedisUrl $url, Optional[String] $default)`
 
-Takes two arguments with an optional third. The first being a string
-value of the key to be looked up, the second is the URL to the Redis service
-and the third optional argument is a default value to be used if the lookup
-fails.
-
-example usage
-```
-$version = redis::get('version.myapp', 'redis://redis.example.com:6379')
-$version_with_default = redis::get('version.myapp', 'redis://redis.example.com:6379', $::myapp_version)
 ```
 
 Returns: `Optional[String]` Returns the value of the key from Redis
@@ -1992,7 +2238,7 @@ The value to return if the key is not found or the connection to Redis fails
 
 ## Data types
 
-### `Redis::LogLevel`
+### <a name="redisloglevel"></a>`Redis::LogLevel`
 
 This can be one of:
 * debug (a lot of information, useful for development/testing)
@@ -2000,17 +2246,25 @@ This can be one of:
 * notice (moderately verbose, what you want in production probably)
 * warning (only very important / critical messages are logged)
 
-Alias of `Enum['debug', 'verbose', 'notice', 'warning']`
+Alias of
 
-### `Redis::RedisUrl`
+```puppet
+Enum['debug', 'verbose', 'notice', 'warning']
+```
+
+### <a name="redisredisurl"></a>`Redis::RedisUrl`
 
 The Redis::RedisUrl data type.
 
-Alias of `Pattern[/(^redis:\/\/)/]`
+Alias of
+
+```puppet
+Pattern[/(^redis:\/\/)/]
+```
 
 ## Tasks
 
-### `redis_cli`
+### <a name="redis_cli"></a>`redis_cli`
 
 Executes a redis-cli command on the target system
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -280,7 +280,6 @@ class redis (
   Optional[String[1]] $notify_keyspace_events                    = undef,
   Boolean $notify_service                                        = true,
   Boolean $managed_by_cluster_manager                            = false,
-  String[1] $minimum_version                                     = $redis::params::minimum_version,
   String[1] $package_ensure                                      = 'present',
   String[1] $package_name                                        = $redis::params::package_name,
   Stdlib::Absolutepath $pid_file                                 = $redis::params::pid_file,
@@ -332,19 +331,6 @@ class redis (
   Integer[0] $cluster_migration_barrier                          = 1,
   Hash[String[1], Hash] $instances                               = {},
 ) inherits redis::params {
-  if $package_ensure =~ /^([0-9]+:)?[0-9]+\.[0-9]/ {
-    if ':' in $package_ensure {
-      $_redis_version_real = split($package_ensure, ':')
-      $redis_version_real = $_redis_version_real[1]
-    } else {
-      $redis_version_real = $package_ensure
-    }
-  } else {
-    $redis_version_real = pick(getvar('redis_server_version'), $minimum_version)
-  }
-
-  $supports_protected_mode = !$redis_version_real or versioncmp($redis_version_real, '3.2.0') >= 0
-
   contain redis::preinstall
   contain redis::install
   contain redis::config

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -349,7 +349,6 @@ define redis::instance (
   }
 
   $bind_arr = [$bind].flatten
-  $supports_protected_mode = $redis::supports_protected_mode
 
   file { $redis_file_name_orig:
     ensure  => file,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,24 +26,14 @@ class redis::params inherits redis::globals {
       $sentinel_package_name     = 'redis-sentinel'
       $sentinel_log_file         = '/var/log/redis/redis-sentinel.log'
       $sentinel_working_dir      = '/var/lib/redis'
-      $sentinel_protected_mode   = true
 
       case $facts['os']['name'] {
         'Ubuntu': {
           $config_group = 'redis'
-          $minimum_version = $facts['os']['release']['major'] ? {
-            '16.04' => '3.0.5',
-            '18.04' => '4.0.9',
-            default => '5.0.7',
-          }
-          $sentinel_pid_file = $facts['os']['release']['major'] ? {
-            '16.04' => '/var/run/redis/redis-sentinel.pid',
-            default => '/var/run/sentinel/redis-sentinel.pid',
-          }
+          $sentinel_pid_file =  '/var/run/sentinel/redis-sentinel.pid'
         }
         default: {
           $config_group              = 'root'
-          $minimum_version           = '3.2.5'
           if versioncmp($facts['os']['release']['major'], '10') >= 0 {
             $sentinel_pid_file         = '/run/sentinel/redis-sentinel.pid'
           } else {
@@ -63,7 +53,6 @@ class redis::params inherits redis::globals {
 
       $sentinel_daemonize   = false
       $sentinel_working_dir = '/tmp'
-      $sentinel_protected_mode   = true
 
       $scl = $redis::globals::scl
       if $scl {
@@ -83,11 +72,6 @@ class redis::params inherits redis::globals {
         $sentinel_package_name     = $package_name
         $sentinel_pid_file         = "/var/opt/rh/${scl}/run/redis-sentinel.pid"
         $sentinel_log_file         = "/var/opt/rh/${scl}/log/redis/sentinel.log"
-
-        $minimum_version = $scl ? {
-          'rh-redis32' => '3.2.13',
-          default      => '5.0.5',
-        }
       } else {
         $config_dir                = '/etc/redis'
         $config_file               = '/etc/redis.conf'
@@ -105,9 +89,6 @@ class redis::params inherits redis::globals {
         $sentinel_package_name     = 'redis'
         $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
         $sentinel_log_file         = '/var/log/redis/sentinel.log'
-
-        # EPEL 7 and newer have 3.2 so we can assume all EL is 3.2+
-        $minimum_version           = '3.2.12'
       }
     }
 
@@ -137,10 +118,6 @@ class redis::params inherits redis::globals {
       $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
       $sentinel_log_file         = '/var/log/redis/sentinel.log'
       $sentinel_working_dir      = '/tmp'
-      $sentinel_protected_mode   = true
-
-      # pkg version
-      $minimum_version           = '3.2.4'
     }
 
     'Suse': {
@@ -168,10 +145,6 @@ class redis::params inherits redis::globals {
       $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
       $sentinel_log_file         = '/var/log/redis/sentinel.log'
       $sentinel_working_dir      = '/tmp'
-      $sentinel_protected_mode   = true
-
-      # suse package version
-      $minimum_version           = '3.0.5'
     }
 
     'Archlinux': {
@@ -200,10 +173,6 @@ class redis::params inherits redis::globals {
       $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
       $sentinel_log_file         = '/var/log/redis/sentinel.log'
       $sentinel_working_dir      = '/tmp'
-      $sentinel_protected_mode   = true
-
-      # pkg version
-      $minimum_version           = '3.2.4'
     }
     default: {
       fail "Operating system ${facts['os']['name']} is not supported yet."

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -114,7 +114,7 @@ class redis::sentinel (
   Stdlib::Filemode $config_file_mode = '0644',
   String[1] $conf_template = 'redis/redis-sentinel.conf.erb',
   Boolean $daemonize = $redis::params::sentinel_daemonize,
-  Boolean $protected_mode = $redis::params::sentinel_protected_mode,
+  Boolean $protected_mode = true,
   Integer[1] $down_after = 30000,
   Integer[1] $failover_timeout = 180000,
   Redis::LogLevel $log_level = 'notice',
@@ -145,7 +145,6 @@ class redis::sentinel (
   Package[$package_name] -> File[$config_file_orig]
 
   $sentinel_bind_arr = delete_undef_values([$sentinel_bind].flatten)
-  $supports_protected_mode = $redis::supports_protected_mode
 
   file { $config_file_orig:
     ensure  => file,

--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04",
         "18.04",
         "20.04"
       ]

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -21,16 +21,12 @@ describe 'redis::sentinel' do
 
       let(:pidfile) do
         if facts[:operatingsystem] == 'Ubuntu'
-          facts[:operatingsystemmajrelease] == '16.04' ? '/var/run/redis/redis-sentinel.pid' : '/var/run/sentinel/redis-sentinel.pid'
+          '/var/run/sentinel/redis-sentinel.pid'
         elsif facts[:operatingsystem] == 'Debian'
           facts[:operatingsystemmajrelease] == '9' ? '/var/run/redis/redis-sentinel.pid' : '/run/sentinel/redis-sentinel.pid'
         else
           '/var/run/redis/redis-sentinel.pid'
         end
-      end
-
-      let(:protected_mode) do
-        facts[:operatingsystem] != 'Ubuntu' || facts[:operatingsystemmajrelease] != '16.04'
       end
 
       describe 'without parameters' do
@@ -40,7 +36,8 @@ port 26379
 dir #{facts[:osfamily] == 'Debian' ? '/var/lib/redis' : '/tmp'}
 daemonize #{facts[:osfamily] == 'RedHat' ? 'no' : 'yes'}
 pidfile #{pidfile}
-#{protected_mode ? "protected-mode yes\n" : ''}
+protected-mode yes
+
 sentinel monitor mymaster 127.0.0.1 6379 2
 sentinel down-after-milliseconds mymaster 30000
 sentinel parallel-syncs mymaster 1
@@ -97,7 +94,8 @@ port 26379
 dir /tmp/redis
 daemonize #{facts[:osfamily] == 'RedHat' ? 'no' : 'yes'}
 pidfile #{pidfile}
-#{protected_mode ? "protected-mode no\n" : ''}
+protected-mode no
+
 sentinel monitor cow 127.0.0.1 6379 2
 sentinel down-after-milliseconds cow 6000
 sentinel parallel-syncs cow 1
@@ -138,7 +136,8 @@ port 26379
 dir /tmp/redis
 daemonize #{facts[:osfamily] == 'RedHat' ? 'no' : 'yes'}
 pidfile #{pidfile}
-#{protected_mode ? "protected-mode yes\n" : ''}
+protected-mode yes
+
 sentinel monitor cow 127.0.0.1 6379 2
 sentinel down-after-milliseconds cow 6000
 sentinel parallel-syncs cow 1

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -5,9 +5,7 @@ port <%= @sentinel_port %>
 dir <%= @working_dir %>
 daemonize <%= @daemonize ? 'yes' : 'no' %>
 pidfile <%= @pid_file %>
-<% if @supports_protected_mode -%>
 protected-mode <%= @protected_mode ? 'yes' : 'no' %>
-<% end -%>
 
 sentinel monitor <%= @master_name %> <%= @redis_host %> <%= @redis_port %> <%= @quorum %>
 sentinel down-after-milliseconds <%= @master_name %> <%= @down_after %>

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -20,7 +20,6 @@ daemonize <% if @daemonize -%>yes<% else -%>no<% end -%>
 # default. You can specify a custom pid file location here.
 pidfile <%= @pid_file %>
 
-<% if @supports_protected_mode -%>
 # Protected mode is a layer of security protection, in order to avoid that
 # Redis instances left open on the internet are accessed and exploited.
 #
@@ -40,7 +39,6 @@ pidfile <%= @pid_file %>
 # are explicitly listed using the "bind" directive.
 protected-mode <%= @protected_mode ? 'yes' : 'no' %>
 
-<% end -%>
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.
 port <%= @port %>

--- a/templates/service_templates/redis.service.erb
+++ b/templates/service_templates/redis.service.erb
@@ -7,14 +7,8 @@ Wants=network-online.target
 [Service]
 RuntimeDirectory=redis
 RuntimeDirectoryMode=2755
-<%# Redis on Xenial is too old for systemd integration -%>
-<% if @facts['os']['name'] == 'Ubuntu' and @facts['os']['release']['major'] == '16.04' -%>
-Type=forking
-ExecStart=/usr/bin/redis-server <%= @redis_file_name %>
-<% else -%>
 Type=notify
 ExecStart=<%= scope['redis::params::bin_path'] %>/redis-server <%= @redis_file_name %> --supervised systemd
-<% end -%>
 ExecStop=<%= scope['redis::params::bin_path'] %>/redis-cli -p <%= @port %> shutdown
 Restart=always
 User=<%= @service_user %>


### PR DESCRIPTION
This also removes parameters for the minimum version since that's no longer used.

The `redis_server_version` fact is now unused. I'm not sure if it should also be removed or if people like that.