### PR TITLE
Honor redis::sentinel::package_ensure

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -124,7 +124,7 @@ class redis::sentinel (
   Stdlib::Port $redis_port = 6379,
   Optional[String[1]] $requirepass = undef,
   String[1] $package_name = $redis::params::sentinel_package_name,
-  String[1] $package_ensure = 'present',
+  String[1] $package_ensure = 'installed',
   Integer[0] $parallel_sync = 1,
   Stdlib::Absolutepath $pid_file = $redis::params::sentinel_pid_file,
   Integer[1] $quorum = 2,
@@ -147,7 +147,9 @@ class redis::sentinel (
 
   require 'redis'
 
-  ensure_packages([$package_name])
+  ensure_packages([$package_name], {
+    ensure => $package_ensure
+  })
   Package[$package_name] -> File[$config_file_orig]
 
   $sentinel_bind_arr = delete_undef_values([$sentinel_bind].flatten)


### PR DESCRIPTION
#### Pull Request (PR) description
This change ensures that the package_ensure parameter is properly used in the redis::sentinel class

#### This Pull Request (PR) fixes the following issues
The package_ensure parameter of the redis_sentinel class is supposed to define status of the redis-sentinel package but in fact it is not used. This fixes the ignored parameter.

Also, default of the parameter is updated following the recent change of redis::package_ensure. This is required to avoid conflicting declaration of redis package caused by a different status; 'installed' vs 'present'.
