### PR TITLE
Skip ensuring package if sentinel requires no additional package

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -56,7 +56,8 @@
 #   The name of the package that installs sentinel.
 #
 # @param package_ensure
-#   Do we ensure this package.
+#   Do we ensure this package. This parameter takes effect only if
+#   an independent package is required for sentinel.
 #
 # @param parallel_sync
 #   How many slaves can be reconfigured at the same time to use a
@@ -147,9 +148,11 @@ class redis::sentinel (
 
   require 'redis'
 
-  ensure_packages([$package_name], {
-    ensure => $package_ensure
-  })
+  if $package_name != $redis::package_name {
+    ensure_packages([$package_name], {
+      ensure => $package_ensure
+    })
+  }
   Package[$package_name] -> File[$config_file_orig]
 
   $sentinel_bind_arr = delete_undef_values([$sentinel_bind].flatten)

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -29,6 +29,10 @@ describe 'redis::sentinel' do
         end
       end
 
+      let(:redis_package_name) do
+        'redis'
+      end
+
       let(:sentinel_package_name) do
         if facts[:os]['family'] == 'Debian'
           'redis-sentinel'
@@ -169,6 +173,32 @@ CONFIG
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_class('redis::sentinel') }
         it { is_expected.to contain_file(config_file_orig).with_content(expected_content) }
+      end
+
+      describe 'with package_ensure different from redis::package_ensure' do
+        let(:pre_condition) do
+          <<-PUPPET
+          class { 'redis':
+            package_ensure => 'installed',
+          }
+          PUPPET
+        end
+
+        let(:params) do
+          {
+            package_ensure: 'latest'
+          }
+        end
+
+        let(:package_ensure) do
+          if facts[:os]['family'] == 'Debian'
+            'latest'
+          else
+            'installed'
+          end
+        end
+
+        it { is_expected.to contain_package(sentinel_package_name).with_ensure(package_ensure) }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
This change prevents duplicate package management by redis and redis::package in the distros which provide the common package for both Redis and Sentinel.

#### This Pull Request (PR) fixes the following issues
Currently both of the redis class and the redis::sentinel class have the package_ensure parameter which define status of the packages to install redis and redis sentinel.
However, in some distros like CentOS, the single redis package is enough to install both redis and sentinel, and we should set the same value to these two package_ensure parameters to avoid conflict between two package resources maintained by these two classes.
This change disables the package resource in the redis::sentinel class when the single package is used, to avoid such redundant requirements.

