### PR TITLE
allow bin_path overrides for custom redis installs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,8 @@
 #   Adjust percentatge for auto-aof-rewrite.
 # @param bind
 #   Configure which IP address(es) to listen on. To bind on all interfaces, use an empty array.
+# @param bin_path
+#   Directory containing redis binary executables.
 # @param config_dir
 #   Directory containing the configuration files.
 # @param config_dir_mode
@@ -266,6 +268,7 @@ class redis (
   Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]] $bind = ['127.0.0.1'],
   String[1] $output_buffer_limit_slave                           = '256mb 64mb 60',
   String[1] $output_buffer_limit_pubsub                          = '32mb 8mb 60',
+  Stdlib::Absolutepath $bin_path                                 = $redis::params::bin_path,
   String[1] $conf_template                                       = 'redis/redis.conf.epp',
   Stdlib::Absolutepath $config_dir                               = $redis::params::config_dir,
   Stdlib::Filemode $config_dir_mode                              = $redis::params::config_dir_mode,

--- a/templates/service_templates/redis.service.erb
+++ b/templates/service_templates/redis.service.erb
@@ -8,8 +8,8 @@ Wants=network-online.target
 RuntimeDirectory=redis
 RuntimeDirectoryMode=2755
 Type=notify
-ExecStart=<%= scope['redis::params::bin_path'] %>/redis-server <%= @redis_file_name %> --supervised systemd
-ExecStop=<%= scope['redis::params::bin_path'] %>/redis-cli -p <%= @port %> shutdown
+ExecStart=<%= scope['redis::bin_path'] %>/redis-server <%= @redis_file_name %> --supervised systemd
+ExecStop=<%= scope['redis::bin_path'] %>/redis-cli -p <%= @port %> shutdown
 Restart=always
 User=<%= @service_user %>
 Group=<%= @service_user %>


### PR DESCRIPTION
Allow overrides for binary path parameter, bin_path, to support custom redis builds and install paths.
