### PR TITLE
Add some additional parameters for ownerships

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -200,6 +200,11 @@ The following parameters are available in the `redis` class:
 * [`unixsocketperm`](#-redis--unixsocketperm)
 * [`workdir`](#-redis--workdir)
 * [`workdir_mode`](#-redis--workdir_mode)
+* [`workdir_group`](#-redis--workdir_group)
+* [`workdir_owner`](#-redis--workdir_owner)
+* [`debdefault_group`](#-redis--debdefault_group)
+* [`debdefault_file_mode`](#-redis--debdefault_file_mode)
+* [`debdefault_owner`](#-redis--debdefault_owner)
 * [`zset_max_ziplist_entries`](#-redis--zset_max_ziplist_entries)
 * [`zset_max_ziplist_value`](#-redis--zset_max_ziplist_value)
 * [`cluster_enabled`](#-redis--cluster_enabled)
@@ -1160,6 +1165,49 @@ Data type: `Stdlib::Filemode`
 Adjust mode for data directory.
 
 Default value: `'0750'`
+
+##### <a name="-redis--workdir_group"></a>`workdir_group`
+
+Data type: `Optional[String[1]]`
+
+Adjust filesystem group for $workdir.
+
+Default value: `undef`
+
+##### <a name="-redis--workdir_owner"></a>`workdir_owner`
+
+Data type: `Optional[String[1]]`
+
+Adjust filesystem owner for $workdir.
+
+Default value: `undef`
+
+##### <a name="-redis--debdefault_group"></a>`debdefault_group`
+
+Data type: `Optional[String[1]]`
+
+group of /etc/defaults/redis on Debian systems
+if undef, $redis::config_group is taken
+
+Default value: `undef`
+
+##### <a name="-redis--debdefault_file_mode"></a>`debdefault_file_mode`
+
+Data type: `Optional[Stdlib::Filemode]`
+
+filemode of /etc/defaults/redis on Debian systems
+if undef, $redis::config_file_mode is taken
+
+Default value: `undef`
+
+##### <a name="-redis--debdefault_owner"></a>`debdefault_owner`
+
+Data type: `Optional[String[1]]`
+
+owner of /etc/defaults/redis on Debian systems
+if undef, $redis::config_owner is taken
+
+Default value: `undef`
 
 ##### <a name="-redis--zset_max_ziplist_entries"></a>`zset_max_ziplist_entries`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,9 +48,9 @@ class redis::config {
     'Debian': {
       file { '/etc/default/redis-server':
         ensure => file,
-        group  => $redis::config_group,
-        mode   => $redis::config_file_mode,
-        owner  => $redis::config_owner,
+        group  => pick($redis::debdefault_group, $redis::config_group),
+        mode   => pick($redis::debdefault_file_mode, $redis::config_file_mode),
+        owner  => pick($redis::debdefault_owner, $redis::config_owner),
       }
     }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,9 +21,9 @@ class redis::config {
 
   file { $redis::workdir:
     ensure => directory,
-    group  => $redis::service_group,
+    group  => pick($redis::workdir_group, $redis::service_group),
     mode   => $redis::workdir_mode,
-    owner  => $redis::service_user,
+    owner  => pick($redis::workdir_owner, $redis::service_user),
   }
 
   if $redis::default_install {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -267,6 +267,15 @@
 #   Adjust filesystem group for $workdir.
 # @param workdir_owner
 #   Adjust filesystem owner for $workdir.
+# @param debdefault_group
+#   group of /etc/defaults/redis on Debian systems
+#   if undef, $redis::config_group is taken
+# @param debdefault_file_mode
+#   filemode of /etc/defaults/redis on Debian systems
+#   if undef, $redis::config_file_mode is taken
+# @param debdefault_owner
+#   owner of /etc/defaults/redis on Debian systems
+#   if undef, $redis::config_owner is taken
 # @param zset_max_ziplist_entries
 #   Set max entries for sorted sets.
 # @param zset_max_ziplist_value
@@ -461,6 +470,9 @@ class redis (
   Stdlib::Filemode $workdir_mode                                 = '0750',
   Optional[String[1]] $workdir_group                             = undef,
   Optional[String[1]] $workdir_owner                             = undef,
+  Optional[String[1]] $debdefault_group                          = undef,
+  Optional[Stdlib::Filemode] $debdefault_file_mode               = undef,
+  Optional[String[1]] $debdefault_owner                          = undef,
   Integer[0] $zset_max_ziplist_entries                           = 128,
   Integer[0] $zset_max_ziplist_value                             = 64,
   Boolean $cluster_enabled                                       = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -263,6 +263,10 @@
 #   above using the 'dbfilename' configuration directive.
 # @param workdir_mode
 #   Adjust mode for data directory.
+# @param workdir_group
+#   Adjust filesystem group for $workdir.
+# @param workdir_owner
+#   Adjust filesystem owner for $workdir.
 # @param zset_max_ziplist_entries
 #   Set max entries for sorted sets.
 # @param zset_max_ziplist_value
@@ -455,6 +459,8 @@ class redis (
   Boolean $ulimit_managed                                        = true,
   Stdlib::Absolutepath $workdir                                  = $redis::params::workdir,
   Stdlib::Filemode $workdir_mode                                 = '0750',
+  Optional[String[1]] $workdir_group                             = undef,
+  Optional[String[1]] $workdir_owner                             = undef,
   Integer[0] $zset_max_ziplist_entries                           = 128,
   Integer[0] $zset_max_ziplist_value                             = 64,
   Boolean $cluster_enabled                                       = false,


### PR DESCRIPTION
#### Pull Request (PR) description
Add parameters to set owner/group/mode for workdir and /etc/default/redis file. They are needed set the ownership 
of files/directories the same way as the package maintainer in debian bullseye did.