### PR TITLE
CentOS9/RHEL9: Migrate configuration files to /etc/redis

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,22 +70,31 @@ class redis::params inherits redis::globals {
         $sentinel_pid_file         = "/var/opt/rh/${scl}/run/redis-sentinel.pid"
         $sentinel_log_file         = "/var/opt/rh/${scl}/log/redis/sentinel.log"
       } else {
-        $config_dir                = '/etc/redis'
-        $config_file               = '/etc/redis.conf'
-        $config_file_orig          = '/etc/redis.conf.puppet'
-        $log_dir                   = '/var/log/redis'
-        $package_name              = 'redis'
-        $pid_file                  = '/var/run/redis_6379.pid'
-        $service_name              = 'redis'
-        $workdir                   = '/var/lib/redis'
-        $bin_path                  = '/usr/bin'
-
-        $sentinel_config_file      = '/etc/redis-sentinel.conf'
-        $sentinel_config_file_orig = '/etc/redis-sentinel.conf.puppet'
-        $sentinel_service_name     = 'redis-sentinel'
-        $sentinel_package_name     = 'redis'
-        $sentinel_pid_file         = '/var/run/redis/redis-sentinel.pid'
-        $sentinel_log_file         = '/var/log/redis/sentinel.log'
+        $config_dir                  = '/etc/redis'
+        if (versioncmp($facts['os']['release']['major'], '9') >= 0) {
+          $config_file               = '/etc/redis/redis.conf'
+          $config_file_orig          = '/etc/redis/redis.conf.puppet'
+        } else {
+          $config_file               = '/etc/redis.conf'
+          $config_file_orig          = '/etc/redis.conf.puppet'
+        }
+        $log_dir                     = '/var/log/redis'
+        $package_name                = 'redis'
+        $pid_file                    = '/var/run/redis_6379.pid'
+        $service_name                = 'redis'
+        $workdir                     = '/var/lib/redis'
+        $bin_path                    = '/usr/bin'
+        if (versioncmp($facts['os']['release']['major'], '9') >= 0) {
+          $sentinel_config_file      = '/etc/redis/sentinel.conf'
+          $sentinel_config_file_orig = '/etc/redis/sentinel.conf.puppet'
+        } else {
+          $sentinel_config_file      = '/etc/redis-sentinel.conf'
+          $sentinel_config_file_orig = '/etc/redis-sentinel.conf.puppet'
+        }
+        $sentinel_service_name       = 'redis-sentinel'
+        $sentinel_package_name       = 'redis'
+        $sentinel_pid_file           = '/var/run/redis/redis-sentinel.pid'
+        $sentinel_log_file           = '/var/log/redis/sentinel.log'
       }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -50,14 +50,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/acceptance/redis_cli_task_spec.rb
+++ b/spec/acceptance/redis_cli_task_spec.rb
@@ -16,31 +16,33 @@ describe 'redis-cli task' do
     apply_manifest(pp, catch_changes: true)
   end
 
-  describe 'ping' do
-    let(:params) { 'command="ping"' }
+  unless fact('os.family') == 'RedHat' && fact('os.release.major').to_i >= 9
+    describe 'ping' do
+      let(:params) { 'command="ping"' }
 
-    it 'execute ping' do
-      is_expected.to match(%r{{\s*"status":\s*"PONG"\s*}})
-      is_expected.to match(%r{Ran on 1 target in .+ sec})
-    end
-  end
-
-  describe 'security' do
-    describe 'command with semi colon' do
-      let(:params) { 'command="ping; cat /etc/passwd"' }
-
-      it 'stops script injections and escapes' do
-        is_expected.to match(%r!{\s*"status":\s*"ERR unknown command ('|`)ping; cat /etc/passwd('|`)!)
+      it 'execute ping' do
+        is_expected.to match(%r{{\s*"status":\s*"PONG"\s*}})
         is_expected.to match(%r{Ran on 1 target in .+ sec})
       end
     end
 
-    describe 'command with double ampersand' do
-      let(:params) { 'command="ping && cat /etc/passwd"' }
+    describe 'security' do
+      describe 'command with semi colon' do
+        let(:params) { 'command="ping; cat /etc/passwd"' }
 
-      it 'stops script injections and escapes' do
-        is_expected.to match(%r!{\s*"status":\s*"ERR unknown command ('|`)ping && cat /etc/passwd('|`)!)
-        is_expected.to match(%r{Ran on 1 target in .+ sec})
+        it 'stops script injections and escapes' do
+          is_expected.to match(%r!{\s*"status":\s*"ERR unknown command ('|`)ping; cat /etc/passwd('|`)!)
+          is_expected.to match(%r{Ran on 1 target in .+ sec})
+        end
+      end
+
+      describe 'command with double ampersand' do
+        let(:params) { 'command="ping && cat /etc/passwd"' }
+
+        it 'stops script injections and escapes' do
+          is_expected.to match(%r!{\s*"status":\s*"ERR unknown command ('|`)ping && cat /etc/passwd('|`)!)
+          is_expected.to match(%r{Ran on 1 target in .+ sec})
+        end
       end
     end
   end

--- a/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
@@ -2,14 +2,26 @@ require 'spec_helper_acceptance'
 
 describe 'redis::instance example' do
   instances = [6379, 6380, 6381, 6382]
-  case fact('osfamily')
-  when 'Debian'
-    config_path = '/etc/redis'
-    redis_name = 'redis-server'
-  else
-    config_path = '/etc'
-    redis_name = 'redis'
-  end
+
+  config_path = case fact('os.family')
+                when 'Debian'
+                  '/etc/redis'
+                when 'RedHat'
+                  if fact('os.release.major').to_i >= 9
+                    '/etc/redis'
+                  else
+                    '/etc'
+                  end
+                else
+                  '/etc'
+                end
+
+  redis_name = case fact('os.family')
+               when 'Debian'
+                 'redis-server'
+               else
+                 'redis'
+               end
 
   it 'runs successfully' do
     pp = <<-EOS

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -15,7 +15,11 @@ describe 'redis::sentinel' do
         when 'FreeBSD'
           '/usr/local/etc/redis-sentinel.conf.puppet'
         when 'RedHat'
-          '/etc/redis-sentinel.conf.puppet'
+          if facts[:operatingsystemmajrelease].to_i > 8
+            '/etc/redis/sentinel.conf.puppet'
+          else
+            '/etc/redis-sentinel.conf.puppet'
+          end
         end
       end
 

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -5,7 +5,7 @@ describe 'redis::sentinel' do
     context "on #{os}" do
       let(:facts) { facts }
       let(:config_file_orig) do
-        case facts[:osfamily]
+        case facts[:os]['family']
         when 'Archlinux'
           '/etc/redis/redis-sentinel.conf.puppet'
         when 'Debian'
@@ -15,7 +15,7 @@ describe 'redis::sentinel' do
         when 'FreeBSD'
           '/usr/local/etc/redis-sentinel.conf.puppet'
         when 'RedHat'
-          if facts[:operatingsystemmajrelease].to_i > 8
+          if facts[:os]['release']['major'].to_i > 8
             '/etc/redis/sentinel.conf.puppet'
           else
             '/etc/redis-sentinel.conf.puppet'
@@ -24,10 +24,10 @@ describe 'redis::sentinel' do
       end
 
       let(:pidfile) do
-        if facts[:operatingsystem] == 'Ubuntu'
+        if facts[:os]['name'] == 'Ubuntu'
           '/var/run/sentinel/redis-sentinel.pid'
-        elsif facts[:operatingsystem] == 'Debian'
-          facts[:operatingsystemmajrelease] == '9' ? '/var/run/redis/redis-sentinel.pid' : '/run/sentinel/redis-sentinel.pid'
+        elsif facts[:os]['name'] == 'Debian'
+          facts[:os]['release']['major'].to_i == 9 ? '/var/run/redis/redis-sentinel.pid' : '/run/sentinel/redis-sentinel.pid'
         else
           '/var/run/redis/redis-sentinel.pid'
         end
@@ -49,8 +49,8 @@ describe 'redis::sentinel' do
         let(:expected_content) do
           <<CONFIG
 port 26379
-dir #{facts[:osfamily] == 'Debian' ? '/var/lib/redis' : '/tmp'}
-daemonize #{facts[:osfamily] == 'RedHat' ? 'no' : 'yes'}
+dir #{facts[:os]['family'] == 'Debian' ? '/var/lib/redis' : '/tmp'}
+daemonize #{facts[:os]['family'] == 'RedHat' ? 'no' : 'yes'}
 pidfile #{pidfile}
 protected-mode yes
 
@@ -60,7 +60,7 @@ sentinel parallel-syncs mymaster 1
 sentinel failover-timeout mymaster 180000
 
 loglevel notice
-logfile #{facts[:osfamily] == 'Debian' ? '/var/log/redis/redis-sentinel.log' : '/var/log/redis/sentinel.log'}
+logfile #{facts[:os]['family'] == 'Debian' ? '/var/log/redis/redis-sentinel.log' : '/var/log/redis/sentinel.log'}
 CONFIG
         end
 
@@ -113,7 +113,7 @@ CONFIG
 bind 192.0.2.10
 port 26379
 dir /tmp/redis
-daemonize #{facts[:osfamily] == 'RedHat' ? 'no' : 'yes'}
+daemonize #{facts[:os]['family'] == 'RedHat' ? 'no' : 'yes'}
 pidfile #{pidfile}
 protected-mode no
 
@@ -157,7 +157,7 @@ CONFIG
 bind 192.0.2.10 192.168.1.1
 port 26379
 dir /tmp/redis
-daemonize #{facts[:osfamily] == 'RedHat' ? 'no' : 'yes'}
+daemonize #{facts[:os]['family'] == 'RedHat' ? 'no' : 'yes'}
 pidfile #{pidfile}
 protected-mode yes
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -10,7 +10,11 @@ describe 'redis' do
     when 'FreeBSD'
       '/usr/local/etc/redis.conf'
     when 'RedHat'
-      '/etc/redis.conf'
+      if facts[:operatingsystemmajrelease].to_i > 8
+        '/etc/redis/redis.conf'
+      else
+        '/etc/redis.conf'
+      end
     end
   end
   let(:config_file_orig) { "#{config_file}.puppet" }
@@ -44,7 +48,7 @@ describe 'redis' do
 
         it { is_expected.to contain_service(service_name).with_ensure('running').with_enable('true') }
 
-        context 'with SCL', if: facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease] < '8' do
+        context 'with SCL', if: facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease].to_i < 8 do
           let(:pre_condition) do
             <<-PUPPET
             class { 'redis::globals':

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 describe 'redis' do
-  let(:package_name) { facts[:osfamily] == 'Debian' ? 'redis-server' : 'redis' }
+  let(:package_name) { facts[:os]['family'] == 'Debian' ? 'redis-server' : 'redis' }
   let(:service_name) { package_name }
   let(:config_file) do
-    case facts[:osfamily]
+    case facts[:os]['family']
     when 'Archlinux', 'Debian'
       '/etc/redis/redis.conf'
     when 'FreeBSD'
       '/usr/local/etc/redis.conf'
     when 'RedHat'
-      if facts[:operatingsystemmajrelease].to_i > 8
+      if facts[:os]['release']['major'].to_i > 8
         '/etc/redis/redis.conf'
       else
         '/etc/redis.conf'
@@ -39,7 +39,7 @@ describe 'redis' do
             with_content(%r{logfile /var/log/redis/redis\.log}).
             without_content(%r{undef})
 
-          if facts[:osfamily] == 'FreeBSD'
+          if facts[:os]['family'] == 'FreeBSD'
             is_expected.to contain_file(config_file_orig).
               with_content(%r{dir /var/db/redis}).
               with_content(%r{pidfile /var/run/redis/redis\.pid})
@@ -48,7 +48,7 @@ describe 'redis' do
 
         it { is_expected.to contain_service(service_name).with_ensure('running').with_enable('true') }
 
-        context 'with SCL', if: facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease].to_i < 8 do
+        context 'with SCL', if: facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'].to_i < 8 do
           let(:pre_condition) do
             <<-PUPPET
             class { 'redis::globals':
@@ -474,7 +474,7 @@ describe 'redis' do
       describe 'with parameter: manage_repo' do
         let(:params) { { manage_repo: true } }
 
-        if facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease].to_i <= 7
+        if facts[:osfamily] == 'RedHat' && facts[:os]['release']['major'].to_i <= 7
           it { is_expected.to contain_class('epel') }
         else
           it { is_expected.not_to contain_class('epel') }

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -18,7 +18,11 @@ describe 'redis::instance' do
         let(:config_file) do
           case facts[:osfamily]
           when 'RedHat'
-            '/etc/redis-server-app2.conf'
+            if facts[:operatingsystemmajrelease].to_i > 8
+              '/etc/redis/redis-server-app2.conf'
+            else
+              '/etc/redis-server-app2.conf'
+            end
           when 'FreeBSD'
             '/usr/local/etc/redis/redis-server-app2.conf'
           when 'Debian'

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -16,9 +16,9 @@ describe 'redis::instance' do
       context 'with app2 title' do
         let(:title) { 'app2' }
         let(:config_file) do
-          case facts[:osfamily]
+          case facts[:os]['family']
           when 'RedHat'
-            if facts[:operatingsystemmajrelease].to_i > 8
+            if facts[:os]['release']['major'].to_i > 8
               '/etc/redis/redis-server-app2.conf'
             else
               '/etc/redis-server-app2.conf'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,8 +1,12 @@
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker do |host|
-  if fact_on(host, 'osfamily') == 'RedHat' && fact_on(host, 'operatingsystemmajrelease') == '7'
+  if fact_on(host, 'osfamily') == 'RedHat' && fact_on(host, 'operatingsystemmajrelease').to_i == 7
     install_module_from_forge_on(host, 'puppet/epel', '>= 3.0.0')
   end
-  host.install_package('puppet-bolt')
+  unless fact_on(host, 'osfamily') == 'RedHat' && fact_on(host, 'operatingsystemmajrelease').to_i >= 9
+    # puppet-bolt rpm for CentOS 9 is not yet available
+    # https://tickets.puppetlabs.com/browse/MODULES-11275
+    host.install_package('puppet-bolt')
+  end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Recent update in CentOS 9 Stream changed paths where configuration
files are installed and now these files are placed under /etc/redis
(since redis 6.0.9-2)[1].

This change updates the paths according to that migration[2].

[1] https://gitlab.com/redhat/centos-stream/rpms/redis/-/blob/8d691e9f5a8e9e01a060b624c40ff19680b6472e/redis.spec#L346
[2] https://gitlab.com/redhat/centos-stream/rpms/redis/-/commit/617715f9dabf108b475902585b9fc5283c0670da


#### This Pull Request (PR) fixes the following issues

n/a