### PR TITLE
Drop default PPA setting and only install EPEL on EL7

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ class { '::redis':
 }
 ```
 
-**Warning** note that PPA usage requires [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) on Ubuntu distros. On Red Hat [puppet/epel](https://forge.puppet.com/puppet/epel) is needed unless the installation is using Software Collections. In that case will install `centos-release-scl-rh` from CentOS extras. For RHEL or other RHEL-derivatives this isn't managed.
+**Warning** note that PPA usage requires [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) on Ubuntu distros. On EL7 [puppet/epel](https://forge.puppet.com/puppet/epel) is needed unless the installation is using Software Collections. In that case will install `centos-release-scl-rh` from CentOS extras. For RHEL or other RHEL-derivatives this isn't managed.
 
 ### Redis Sentinel
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ class { '::redis':
 }
 ```
 
-On Ubuntu, "chris-lea/redis-server" ppa repo will be added. You can change it by using ppa_repo parameter:
+On Ubuntu, you can use a PPA by using the `ppa_repo` parameter:
 
 ```puppet
 class { '::redis':
@@ -111,7 +111,7 @@ class { '::redis':
 }
 ```
 
-**Warning** note that it requires [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) on Ubuntu distros. On Red Hat [puppet/epel](https://forge.puppet.com/puppet/epel) is needed unless the installation is using Software Collections. In that case will install `centos-release-scl-rh` from CentOS extras. For RHEL or other RHEL-derivatives this isn't managed.
+**Warning** note that PPA usage requires [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) on Ubuntu distros. On Red Hat [puppet/epel](https://forge.puppet.com/puppet/epel) is needed unless the installation is using Software Collections. In that case will install `centos-release-scl-rh` from CentOS extras. For RHEL or other RHEL-derivatives this isn't managed.
 
 ### Redis Sentinel
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -315,7 +315,7 @@ class redis (
   Stdlib::Absolutepath $pid_file                                 = $redis::params::pid_file,
   Stdlib::Port $port                                             = 6379,
   Boolean $protected_mode                                        = true,
-  Optional[String] $ppa_repo                                     = $redis::params::ppa_repo,
+  Optional[String] $ppa_repo                                     = undef,
   Boolean $rdbcompression                                        = true,
   Hash[String,String] $rename_commands                           = {},
   String[1] $repl_backlog_size                                   = '1mb',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,8 +3,6 @@
 class redis::params inherits redis::globals {
   case $facts['os']['family'] {
     'Debian': {
-      $ppa_repo                  = 'ppa:chris-lea/redis-server'
-
       $config_dir                = '/etc/redis'
       $config_dir_mode           = '0755'
       $config_file               = '/etc/redis/redis.conf'
@@ -44,7 +42,6 @@ class redis::params inherits redis::globals {
     }
 
     'RedHat': {
-      $ppa_repo             = undef
       $daemonize            = false
       $config_owner         = 'redis'
       $config_group         = 'root'
@@ -93,8 +90,6 @@ class redis::params inherits redis::globals {
     }
 
     'FreeBSD': {
-      $ppa_repo                  = undef
-
       $config_dir                = '/usr/local/etc/redis'
       $config_dir_mode           = '0755'
       $config_file               = '/usr/local/etc/redis.conf'
@@ -121,8 +116,6 @@ class redis::params inherits redis::globals {
     }
 
     'Suse': {
-      $ppa_repo                  = undef
-
       $config_dir                = '/etc/redis'
       $config_dir_mode           = '0750'
       $config_file               = '/etc/redis/redis-server.conf'
@@ -148,8 +141,6 @@ class redis::params inherits redis::globals {
     }
 
     'Archlinux': {
-      $ppa_repo                  = undef
-
       $config_dir                = '/etc/redis'
       $config_dir_mode           = '0755'
       $config_file               = '/etc/redis/redis.conf'

--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -3,16 +3,14 @@
 # @api private
 class redis::preinstall {
   if $redis::manage_repo {
-    if $facts['os']['family'] == 'RedHat' {
-      if $facts['os']['name'] != 'Fedora' {
-        if $redis::scl {
-          if $facts['os']['name'] == 'CentOS' {
-            ensure_packages(['centos-release-scl-rh'])
-            Package['centos-release-scl-rh'] -> Package[$redis::package_name]
-          }
-        } else {
-          require 'epel'
+    if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '7') <= 0 {
+      if $redis::scl {
+        if $facts['os']['name'] == 'CentOS' {
+          ensure_packages(['centos-release-scl-rh'])
+          Package['centos-release-scl-rh'] -> Package[$redis::package_name]
         }
+      } else {
+        require 'epel'
       }
     } elsif $facts['os']['name'] == 'Ubuntu' and $redis::ppa_repo {
       contain 'apt'

--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -14,7 +14,7 @@ class redis::preinstall {
           require 'epel'
         }
       }
-    } elsif $facts['os']['name'] == 'Ubuntu' {
+    } elsif $facts['os']['name'] == 'Ubuntu' and $redis::ppa_repo {
       contain 'apt'
       apt::ppa { $redis::ppa_repo:
       }

--- a/spec/acceptance/hieradata/common.yaml
+++ b/spec/acceptance/hieradata/common.yaml
@@ -1,0 +1,2 @@
+---
+redis::manage_repo: true

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -466,11 +466,20 @@ describe 'redis' do
       describe 'with parameter: manage_repo' do
         let(:params) { { manage_repo: true } }
 
-        case facts[:operatingsystem]
-        when 'Ubuntu'
-          it { is_expected.to contain_apt__ppa('ppa:chris-lea/redis-server') }
-        when 'RedHat', 'CentOS', 'Scientific', 'OEL', 'Amazon'
+        if facts[:osfamily] == 'RedHat'
           it { is_expected.to contain_class('epel') }
+        else
+          it { is_expected.not_to contain_class('epel') }
+        end
+
+        describe 'with ppa' do
+          let(:params) { super().merge(ppa_repo: 'ppa:rwky/redis') }
+
+          if facts[:operatingsystem] == 'Ubuntu'
+            it { is_expected.to contain_apt__ppa('ppa:rwky/redis') }
+          else
+            it { is_expected.not_to contain_apt__ppa('ppa:rwky/redis') }
+          end
         end
       end
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -61,11 +61,15 @@ describe 'redis' do
               with_service_name('rh-redis5-redis')
           end
 
-          context 'manage_repo => true', if: facts[:operatingsystem] == 'CentOS' do
+          context 'manage_repo => true' do
             let(:params) { { manage_repo: true } }
 
             it { is_expected.to compile.with_all_deps }
-            it { is_expected.to contain_package('centos-release-scl-rh') }
+            if facts[:operatingsystem] == 'CentOS'
+              it { is_expected.to contain_package('centos-release-scl-rh') }
+            else
+              it { is_expected.not_to contain_package('centos-release-scl-rh') }
+            end
           end
         end
       end
@@ -466,7 +470,7 @@ describe 'redis' do
       describe 'with parameter: manage_repo' do
         let(:params) { { manage_repo: true } }
 
-        if facts[:osfamily] == 'RedHat'
+        if facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease].to_i <= 7
           it { is_expected.to contain_class('epel') }
         else
           it { is_expected.not_to contain_class('epel') }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,7 +1,7 @@
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker do |host|
-  if fact_on(host, 'osfamily') == 'RedHat'
+  if fact_on(host, 'osfamily') == 'RedHat' && fact_on(host, 'operatingsystemmajrelease') == '7'
     install_module_from_forge_on(host, 'puppet/epel', '>= 3.0.0')
   end
   host.install_package('puppet-bolt')

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,11 +1,8 @@
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker do |host|
-  case fact_on(host, 'operatingsystem')
-  when 'CentOS'
+  if fact_on(host, 'operatingsystem') == 'CentOS'
     host.install_package('epel-release')
-  when 'Ubuntu'
-    host.install_package('software-properties-common')
   end
   host.install_package('puppet-bolt')
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,8 +1,8 @@
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker do |host|
-  if fact_on(host, 'operatingsystem') == 'CentOS'
-    host.install_package('epel-release')
+  if fact_on(host, 'osfamily') == 'RedHat'
+    install_module_from_forge_on(host, 'puppet/epel', '>= 3.0.0')
   end
   host.install_package('puppet-bolt')
 end


### PR DESCRIPTION
In EL8 (and EL9) Redis is included in the OS itself. Only on EL7 it needs to be installed from EPEL. Even then, it can be installed via Software Collections which are included in the OS.