### PR TITLE
Fix running acceptance tests in non-Docker environments

### DIFF
--- a/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper_acceptance'
 
 describe 'redis::instance example' do
+  # TODO: SELinux
+  # semanage port --add --type redis_port_t --proto tcp 6380-6382
+  # Label /run/redis-server-\d+(/.+)? as redis_var_run_t
+
   instances = [6379, 6380, 6381, 6382]
 
   config_path = case fact('os.family')

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,11 @@
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker do |host|
+  # sysctl is untestable in docker
+  unless host['hypervisor'] == 'docker'
+    install_module_from_forge_on(host, 'herculesteam/augeasproviders_sysctl', '>= 2.1.0 < 3.0.0')
+  end
+
   if fact_on(host, 'osfamily') == 'RedHat' && fact_on(host, 'operatingsystemmajrelease').to_i == 7
     install_module_from_forge_on(host, 'puppet/epel', '>= 3.0.0')
   end


### PR DESCRIPTION
This is incomplete, see individual commits for details.