### PR TITLE
Drop Archlinux support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -61,9 +61,6 @@
         "8",
         "9"
       ]
-    },
-    {
-      "operatingsystem": "Archlinux"
     }
   ]
 }


### PR DESCRIPTION
Currently this is broken and the acceptance tests prove this. Once those are fixed it can be added again.