### PR TITLE
Add tls settings to the redis::sentinel class and the redis-sentinel.conf template

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -70,12 +70,22 @@
 #   Number of sentinels that must agree that a master is down to
 #   signal sdown state.
 #
+# @param sentinel_announce_hostnames
+#   Whether or not sentinels will announce hostnames instead of ip addresses
+#   to clients.  This can be required for TLS.
+#
 # @param sentinel_bind
 #   Allow optional sentinel server ip binding.  Can help overcome
 #   issues arising from protect-mode added Redis 3.2
 #
 # @param sentinel_port
 #   The port of sentinel server.
+#
+# @param sentinel_resolve_hostnames
+#   Whether or not sentinels can resolve hostnames to ip addresses.
+#
+# @param sentinel_tls_port
+#   Configure which TLS port to listen on.
 #
 # @param service_group
 #   The group of the config file.
@@ -88,6 +98,24 @@
 #
 # @param service_enable
 #   Enable the service at boot time.
+#
+# @param tls_cert_file
+#   Specify which X.509 certificate file to use for TLS connections.
+#
+# @param tls_key_file
+#   Specify which privaye key file to use for TLS connections.
+#
+# @param tls_ca_cert_file
+#   Specify which X.509 CA certificate(s) bundle file to use.
+#
+# @param tls_ca_cert_dir
+#   Specify which X.509 CA certificate(s) bundle directory to use.
+#
+# @param tls_auth_clients
+#   Specify if clients and replicas are required to authenticate using valid client side certificates.
+#
+# @param tls_replication
+#   Specify if TLS should be enabled on replication links.
 #
 # @param working_dir
 #   The directory into which sentinel will change to avoid mount
@@ -129,13 +157,22 @@ class redis::sentinel (
   Integer[0] $parallel_sync = 1,
   Stdlib::Absolutepath $pid_file = $redis::params::sentinel_pid_file,
   Integer[1] $quorum = 2,
+  Optional[Enum['yes', 'no']] $sentinel_announce_hostnames = undef,
   Variant[Undef, Stdlib::IP::Address, Array[Stdlib::IP::Address]] $sentinel_bind = undef,
   Stdlib::Port $sentinel_port = 26379,
+  Optional[Enum['yes', 'no']] $sentinel_resolve_hostnames = undef,
+  Optional[Stdlib::Port::Unprivileged] $sentinel_tls_port = undef,
   String[1] $service_group = 'redis',
   String[1] $service_name = $redis::params::sentinel_service_name,
   Stdlib::Ensure::Service $service_ensure = 'running',
   Boolean $service_enable = true,
   String[1] $service_user = 'redis',
+  Optional[Stdlib::Absolutepath] $tls_cert_file = undef,
+  Optional[Stdlib::Absolutepath] $tls_key_file = undef,
+  Optional[Stdlib::Absolutepath] $tls_ca_cert_file = undef,
+  Optional[Stdlib::Absolutepath] $tls_ca_cert_dir = undef,
+  Enum['yes', 'no', 'optional'] $tls_auth_clients = 'no',
+  Boolean $tls_replication = false,
   Stdlib::Absolutepath $working_dir = $redis::params::sentinel_working_dir,
   Optional[Stdlib::Absolutepath] $notification_script = undef,
   Optional[Stdlib::Absolutepath] $client_reconfig_script = undef,

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -94,6 +94,7 @@ CONFIG
 
         let(:params) do
           {
+            sentinel_tls_port: 26_380,
             auth_pass: 'password',
             sentinel_bind: '192.0.2.10',
             protected_mode: false,
@@ -104,7 +105,15 @@ CONFIG
             failover_timeout: 28_000,
             notification_script: '/path/to/bar.sh',
             client_reconfig_script: '/path/to/foo.sh',
-            package_ensure: 'latest'
+            package_ensure: 'latest',
+            sentinel_announce_hostnames: 'yes',
+            sentinel_resolve_hostnames: 'yes',
+            tls_cert_file: '/etc/pki/cert.pem',
+            tls_key_file: '/etc/pki/privkey.pem',
+            tls_ca_cert_file: '/etc/pki/cacert.pem',
+            tls_ca_cert_dir: '/etc/pki/cacerts',
+            tls_auth_clients: 'yes',
+            tls_replication: true,
           }
         end
 
@@ -112,11 +121,14 @@ CONFIG
           <<CONFIG
 bind 192.0.2.10
 port 26379
+tls-port 26380
 dir /tmp/redis
 daemonize #{facts[:os]['family'] == 'RedHat' ? 'no' : 'yes'}
 pidfile #{pidfile}
 protected-mode no
 
+sentinel announce-hostnames yes
+sentinel resolve-hostnames yes
 sentinel monitor cow 127.0.0.1 6379 2
 sentinel down-after-milliseconds cow 6000
 sentinel parallel-syncs cow 1
@@ -124,6 +136,13 @@ sentinel failover-timeout cow 28000
 sentinel auth-pass cow password
 sentinel notification-script cow /path/to/bar.sh
 sentinel client-reconfig-script cow /path/to/foo.sh
+
+tls-cert-file /etc/pki/cert.pem
+tls-key-file /etc/pki/privkey.pem
+tls-ca-cert-file /etc/pki/cacert.pem
+tls-ca-cert-dir /etc/pki/cacerts
+tls-auth-clients yes
+tls-replication yes
 
 loglevel notice
 logfile /tmp/barn-sentinel.log

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -2,11 +2,20 @@
 bind <%= @sentinel_bind_arr.join(' ') %>
 <% end -%>
 port <%= @sentinel_port %>
+<% if @sentinel_tls_port -%>
+tls-port <%= @sentinel_tls_port %>
+<% end -%>
 dir <%= @working_dir %>
 daemonize <%= @daemonize ? 'yes' : 'no' %>
 pidfile <%= @pid_file %>
 protected-mode <%= @protected_mode ? 'yes' : 'no' %>
 
+<% if @sentinel_announce_hostnames -%>
+sentinel announce-hostnames <%= @sentinel_announce_hostnames %>
+<% end -%>
+<% if @sentinel_resolve_hostnames -%>
+sentinel resolve-hostnames <%= @sentinel_resolve_hostnames %>
+<% end -%>
 sentinel monitor <%= @master_name %> <%= @redis_host %> <%= @redis_port %> <%= @quorum %>
 sentinel down-after-milliseconds <%= @master_name %> <%= @down_after %>
 sentinel parallel-syncs <%= @master_name %> <%= @parallel_sync %>
@@ -22,6 +31,21 @@ sentinel client-reconfig-script <%= @master_name %> <%= @client_reconfig_script 
 <% end -%>
 <% if @requirepass -%>
 requirepass <%= @requirepass %>
+<% end -%>
+<% if @sentinel_tls_port -%>
+
+tls-cert-file <%= @tls_cert_file %>
+tls-key-file <%= @tls_key_file %>
+<% if @tls_ca_cert_file -%>
+tls-ca-cert-file <%= @tls_ca_cert_file %>
+<% end -%>
+<% if @tls_ca_cert_dir -%>
+tls-ca-cert-dir <%= @tls_ca_cert_dir %>
+<% end -%>
+tls-auth-clients <%= @tls_auth_clients %>
+<% if @tls_replication -%>
+tls-replication <%= @tls_replication ? 'yes' : 'no' %>
+<% end -%>
 <% end -%>
 
 loglevel <%= @log_level %>


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Added tls settings to the redis sentinel submodule.  If you have tls only enabled for redis not having tls on the sentinels makes them useless.


