### PR TITLE
Add support for systemd service timeouts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -160,6 +160,10 @@
 #   Specify the service name for Init or Systemd.
 # @param service_user
 #   Specify which user to run as.
+# @param service_timeout_start
+#   Specify the time after which a service startup should be considered as failed.
+# @param service_timeout_stop
+#   Specify the time after which a service stop should be considered as failed.
 # @param set_max_intset_entries
 #   The following configuration setting sets the limit in the size of the set
 #   in order to use this special memory saving encoding.
@@ -373,6 +377,8 @@ class redis (
   Boolean $service_manage                                        = true,
   String[1] $service_name                                        = $redis::params::service_name,
   String[1] $service_user                                        = 'redis',
+  Optional[Integer[0]] $service_timeout_start                    = undef,
+  Optional[Integer[0]] $service_timeout_stop                     = undef,
   Integer[0] $set_max_intset_entries                             = 512,
   Integer[0] $slave_priority                                     = 100,
   Boolean $slave_read_only                                       = true,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -128,6 +128,10 @@
 #   Specify which group to run as.
 # @param service_user
 #   Specify which user to run as.
+# @param service_timeout_start
+#   Specify the time after which a service startup should be considered as failed.
+# @param service_timeout_stop
+#   Specify the time after which a service stop should be considered as failed.
 # @param set_max_intset_entries
 #   The following configuration setting sets the limit in the size of the set
 #   in order to use this special memory saving encoding.
@@ -362,6 +366,8 @@ define redis::instance (
   Stdlib::Ensure::Service $service_ensure                        = $redis::service_ensure,
   Boolean $service_enable                                        = $redis::service_enable,
   String[1] $service_group                                       = $redis::service_group,
+  Optional[Integer[0]] $service_timeout_start                    = $redis::service_timeout_start,
+  Optional[Integer[0]] $service_timeout_stop                     = $redis::service_timeout_stop,
   Boolean $manage_service_file                                   = true,
   String $log_file                                               = "redis-server-${name}.log",
   Stdlib::Absolutepath $pid_file                                 = "/var/run/${service_name}/redis.pid",
@@ -433,14 +439,16 @@ define redis::instance (
       content => epp(
         'redis/service_templates/redis.service.epp',
         {
-          bin_path        => $redis::bin_path,
-          instance_title  => $name,
-          port            => $port,
-          redis_file_name => $redis_file_name,
-          service_name    => $service_name,
-          service_user    => $service_user,
-          ulimit          => $ulimit,
-          ulimit_managed  => $ulimit_managed,
+          bin_path              => $redis::bin_path,
+          instance_title        => $name,
+          port                  => $port,
+          redis_file_name       => $redis_file_name,
+          service_name          => $service_name,
+          service_user          => $service_user,
+          service_timeout_start => $service_timeout_start,
+          service_timeout_stop  => $service_timeout_stop,
+          ulimit                => $ulimit,
+          ulimit_managed        => $ulimit_managed,
         }
       ),
     }

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -1614,6 +1614,19 @@ describe 'redis' do
 
         it { is_expected.to contain_file(config_file_orig).with('content' => %r{^rdb-save-incremental-fsync yes$}) }
       end
+
+      describe 'test systemd service timeouts' do
+        let(:params) do
+          {
+            manage_service_file: true,
+            service_timeout_start: 600,
+            service_timeout_stop: 300,
+          }
+        end
+
+        it { is_expected.to contain_systemd__unit_file("#{service_name}.service").with('content' => %r{^TimeoutStartSec=600$}) }
+        it { is_expected.to contain_systemd__unit_file("#{service_name}.service").with('content' => %r{^TimeoutStopSec=300$}) }
+      end
     end
   end
 end

--- a/templates/service_templates/redis.service.epp
+++ b/templates/service_templates/redis.service.epp
@@ -7,6 +7,8 @@
   String[1]                                          $instance_title,
   String[1]                                          $service_name,
   String[1]                                          $service_user,
+  Optional[Integer[0]]                               $service_timeout_start,
+  Optional[Integer[0]]                               $service_timeout_stop,
 | -%>
 [Unit]
 Description=Redis Advanced key-value store for instance <%= $instance_title %>
@@ -24,6 +26,12 @@ Restart=always
 User=<%= $service_user %>
 Group=<%= $service_user %>
 <%if $ulimit_managed { %>LimitNOFILE=<%= $ulimit %><% } %>
+<% if $service_timeout_start { -%>
+TimeoutStartSec=<%= $service_timeout_start %>
+<% } -%>
+<% if $service_timeout_stop { -%>
+TimeoutStopSec=<%= $service_timeout_stop %>
+<% } -%>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
When using a Redis 6 cluster with systemd, the following issue may appear (most likely only when using large Redis databases):

```
$ sudo systemctl start redis-server-1234.service
Job for redis-server-1234.service failed because a timeout was exceeded. See "systemctl status redis-server-1234.service" and "journalctl -xe" for details.
```

The Redis log contains the following entry:

```
23391:signal-handler (1651434624) Received shutdown signal during loading, exiting now.
24844:C 01 May 2022 21:50:26.038 * Supervised by systemd. Please make sure you set appropriate values for  and TimeoutStopSec in your service unit.
```

Adding a proper TimeoutStartSec fixes this issue.

It is implemented with backwards-compatibility in mind, existing setups will not experience any change. 

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Fixes #402