### PR TITLE
Allow custom replica announce IP/port and Sentinel announce IP

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,6 +144,10 @@
 #   Enable/disable compression of string objects using LZF when dumping.
 # @param rename_commands
 #   A list of Redis commands to rename or disable for security reasons
+# @param repl_announce_ip
+#   The specific IP or hostname a replica will report to its master
+# @param repl_announce_port
+#   The specific port a replica will report to its master
 # @param repl_backlog_size
 #   The replication backlog size
 # @param repl_backlog_ttl
@@ -383,6 +387,8 @@ class redis (
   String[1] $apt_key_server                                      = 'hkp://keyserver.ubuntu.com/',
   Boolean $rdbcompression                                        = true,
   Hash[String,String] $rename_commands                           = {},
+  Optional[Stdlib::Host] $repl_announce_ip                       = undef,
+  Optional[Stdlib::Port] $repl_announce_port                     = undef,
   String[1] $repl_backlog_size                                   = '1mb',
   Integer[0] $repl_backlog_ttl                                   = 3600,
   Boolean $repl_disable_tcp_nodelay                              = false,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -101,6 +101,10 @@
 #   Enable/disable compression of string objects using LZF when dumping.
 # @param rename_commands
 #   A list of Redis commands to rename or disable for security reasons
+# @param repl_announce_ip
+#   The specific IP or hostname a replica will report to its master
+# @param repl_announce_port
+#   The specific port a replica will report to its master
 # @param repl_backlog_size
 #   The replication backlog size
 # @param repl_backlog_ttl
@@ -316,6 +320,8 @@ define redis::instance (
   Boolean $protected_mode                                        = $redis::protected_mode,
   Boolean $rdbcompression                                        = $redis::rdbcompression,
   Hash[String,String] $rename_commands                           = $redis::rename_commands,
+  Optional[Stdlib::Host] $repl_announce_ip                       = $redis::repl_announce_ip,
+  Optional[Stdlib::Port] $repl_announce_port                     = $redis::repl_announce_port,
   String[1] $repl_backlog_size                                   = $redis::repl_backlog_size,
   Integer[0] $repl_backlog_ttl                                   = $redis::repl_backlog_ttl,
   Boolean $repl_disable_tcp_nodelay                              = $redis::repl_disable_tcp_nodelay,
@@ -503,6 +509,8 @@ define redis::instance (
         masterauth                    => $masterauth,
         slave_serve_stale_data        => $slave_serve_stale_data,
         slave_read_only               => $slave_read_only,
+        repl_announce_ip              => $repl_announce_ip,
+        repl_announce_port            => $repl_announce_port,
         repl_ping_slave_period        => $repl_ping_slave_period,
         repl_timeout                  => $repl_timeout,
         repl_disable_tcp_nodelay      => $repl_disable_tcp_nodelay,

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -74,6 +74,9 @@
 #   Whether or not sentinels will announce hostnames instead of ip addresses
 #   to clients.  This can be required for TLS.
 #
+# @param sentinel_announce_ip
+#   Specify the IP or hostname that Sentinel will announce
+#
 # @param sentinel_bind
 #   Allow optional sentinel server ip binding.  Can help overcome
 #   issues arising from protect-mode added Redis 3.2
@@ -158,6 +161,7 @@ class redis::sentinel (
   Stdlib::Absolutepath $pid_file = $redis::params::sentinel_pid_file,
   Integer[1] $quorum = 2,
   Optional[Enum['yes', 'no']] $sentinel_announce_hostnames = undef,
+  Optional[Stdlib::Host] $sentinel_announce_ip = undef,
   Variant[Undef, Stdlib::IP::Address, Array[Stdlib::IP::Address]] $sentinel_bind = undef,
   Stdlib::Port $sentinel_port = 26379,
   Optional[Enum['yes', 'no']] $sentinel_resolve_hostnames = undef,

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -109,6 +109,7 @@ describe 'redis::sentinel' do
             package_ensure: 'latest',
             sentinel_announce_hostnames: 'yes',
             sentinel_resolve_hostnames: 'yes',
+            sentinel_announce_ip: 'myhostnameOrIP',
             tls_cert_file: '/etc/pki/cert.pem',
             tls_key_file: '/etc/pki/privkey.pem',
             tls_ca_cert_file: '/etc/pki/cacert.pem',
@@ -130,6 +131,7 @@ describe 'redis::sentinel' do
             protected-mode no
 
             sentinel announce-hostnames yes
+            sentinel announce-ip myhostnameOrIP
             sentinel resolve-hostnames yes
             sentinel monitor cow 127.0.0.1 6379 2
             sentinel down-after-milliseconds cow 6000

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -905,6 +905,34 @@ describe 'redis' do
         }
       end
 
+      describe 'with parameter repl_announce_ip' do
+        let(:params) do
+          {
+            repl_announce_ip: 'my.hostname.name.or.ip'
+          }
+        end
+
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => %r{replica-announce-ip.*my\.hostname\.name\.or\.ip}
+          )
+        }
+      end
+
+      describe 'with parameter repl_announce_port' do
+        let(:params) do
+          {
+            repl_announce_port: 1234
+          }
+        end
+
+        it {
+          is_expected.to contain_file(config_file_orig).with(
+            'content' => %r{replica-announce-port.*1234}
+          )
+        }
+      end
+
       describe 'with parameter requirepass' do
         let(:params) do
           {

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -14,6 +14,9 @@ protected-mode <%= @protected_mode ? 'yes' : 'no' %>
 <% if @sentinel_announce_hostnames -%>
 sentinel announce-hostnames <%= @sentinel_announce_hostnames %>
 <% end -%>
+<% if @sentinel_announce_ip -%>
+sentinel announce-ip <%= @sentinel_announce_ip %>
+<% end -%>
 <% if @sentinel_resolve_hostnames -%>
 sentinel resolve-hostnames <%= @sentinel_resolve_hostnames %>
 <% end -%>

--- a/templates/redis.conf.epp
+++ b/templates/redis.conf.epp
@@ -24,6 +24,8 @@
   Optional[Variant[String[1], Sensitive[String[1]]]] $masterauth,
   Boolean                                            $slave_serve_stale_data,
   Boolean                                            $slave_read_only,
+  Optional[Stdlib::Host]                             $repl_announce_ip,
+  Optional[Stdlib::Port]                             $repl_announce_port,
   Integer[1]                                         $repl_ping_slave_period,
   Integer[1]                                         $repl_timeout,
   Boolean                                            $repl_disable_tcp_nodelay,
@@ -431,6 +433,37 @@ slave-serve-stale-data <%= bool2str($slave_serve_stale_data, 'yes', 'no') %>
 # security of read only slaves using 'rename-command' to shadow all the
 # administrative / dangerous commands.
 slave-read-only <%= bool2str($slave_read_only, 'yes', 'no') %>
+
+# A Redis master is able to list the address and port of the attached
+# replicas in different ways. For example the "INFO replication" section
+# offers this information, which is used, among other tools, by
+# Redis Sentinel in order to discover replica instances.
+# Another place where this info is available is in the output of the
+# "ROLE" command of a master.
+#
+# The listed IP address and port normally reported by a replica is
+# obtained in the following way:
+#
+#   IP: The address is auto detected by checking the peer address
+#   of the socket used by the replica to connect with the master.
+#
+#   Port: The port is communicated by the replica during the replication
+#   handshake, and is normally the port that the replica is using to
+#   listen for connections.
+#
+# However when port forwarding or Network Address Translation (NAT) is
+# used, the replica may actually be reachable via different IP and port
+# pairs. The following two options can be used by a replica in order to
+# report to its master a specific set of IP and port, so that both INFO
+# and ROLE will report those values.
+#
+# There is no need to use both the options if you need to override just
+# the port or the IP address.
+#
+# replica-announce-ip 5.5.5.5
+# replica-announce-port 1234
+<% if $repl_announce_ip { -%>replica-announce-ip <%= $repl_announce_ip %><% } %>
+<% if $repl_announce_port { -%>replica-announce-port <%= $repl_announce_port %><% } -%>
 
 # Slaves send PINGs to server in a predefined interval. It's possible to change
 # this interval with the repl_ping_slave_period option. The default value is 10


### PR DESCRIPTION
#### Pull Request (PR) description
Add parameters `replica-announce-ip` and `replica-announce-port` for Redis, and `sentinel announce-ip` for Redis-Sentinel

These parameters are usefull with NAT, and when TLS is enabled.
