### PR TITLE
add missing default config_file_orig for SUSE

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -128,6 +128,7 @@ class redis::params inherits redis::globals {
       $config_dir                = '/etc/redis'
       $config_dir_mode           = '0750'
       $config_file               = '/etc/redis/redis-server.conf'
+      $config_file_orig          = '/etc/redis/redis-server.conf.puppet'
       $config_group              = 'redis'
       $config_owner              = 'redis'
       $log_dir                   = '/var/log/redis'


### PR DESCRIPTION
#### Pull Request (PR) description
Add the missing default config_file_orig for SUSE platforms.
