### PR TITLE
Specify environment module path for bolt

### DIFF
--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '5.5.0'
+modulesync_config_version: '6.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,10 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
-  gem 'voxpupuli-test', '~> 5.4',   :require => false
+  gem 'voxpupuli-test', '~> 6.0',   :require => false
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
-  gem 'puppet_metadata', '~> 2.0',  :require => false
+  gem 'puppet_metadata', '~> 3.0',  :require => false
   gem 'redis',                      :require => false
   gem 'mock_redis',                 :require => false
 end
@@ -18,18 +18,19 @@ group :development do
 end
 
 group :system_tests do
-  gem 'voxpupuli-acceptance', '~> 1.0',  :require => false
+  gem 'voxpupuli-acceptance', '~> 2.0',  :require => false
 end
 
 group :release do
-  gem 'github_changelog_generator', '>= 1.16.1',  :require => false if RUBY_VERSION >= '2.5'
-  gem 'voxpupuli-release', '~> 2.0',              :require => false
+  gem 'github_changelog_generator', '>= 1.16.1',  :require => false
+  gem 'voxpupuli-release', '~> 3.0',              :require => false
+  gem 'faraday-retry', '~> 2.1',                  :require => false
 end
 
 gem 'rake', :require => false
 gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-puppetversion = ENV['PUPPET_GEM_VERSION'] || '>= 6.0'
+puppetversion = ENV['PUPPET_GEM_VERSION'] || '~> 7.24'
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby

--- a/spec/acceptance/redis_cli_task_spec.rb
+++ b/spec/acceptance/redis_cli_task_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 
 describe 'redis-cli task' do
   subject do
-    on(default, "bolt task run --modulepath /etc/puppetlabs/code/modules --targets localhost #{task_name} #{params}", acceptable_exit_codes: [0, 1]).stdout
+    on(default, "bolt task run --modulepath /etc/puppetlabs/code/environments/production/modules --targets localhost #{task_name} #{params}", acceptable_exit_codes: [0, 1]).stdout
   end
 
   let(:task_name) { 'redis::redis_cli' }

--- a/spec/acceptance/suites/scl/redis5_spec.rb
+++ b/spec/acceptance/suites/scl/redis5_spec.rb
@@ -4,11 +4,11 @@ require 'spec_helper_acceptance'
 
 describe 'redis', if: %w[centos redhat].include?(os[:family]) && os[:release].to_i == 7 do
   before(:all) do
-    on hosts, puppet_resource('service', 'redis', 'ensure=stopped', 'enable=false')
+    apply_manifest_on(hosts, 'service{"redis" : ensure => stopped, enable => false}')
   end
 
   after(:all) do
-    on hosts, puppet_resource('service', 'rh-redis5-redis', 'ensure=stopped', 'enable=false')
+    apply_manifest('service{"rh-redis5-redis" : ensure => stopped, enable => false}')
   end
 
   it 'runs successfully' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,17 +4,17 @@ require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker do |host|
   # sysctl is untestable in docker
-  install_module_from_forge_on(host, 'puppet/augeasproviders_sysctl', '>= 3.0.0 < 4.0.0') unless host['hypervisor'] == 'docker'
+  install_puppet_module_via_pmt_on(host, 'puppet-augeasproviders_sysctl') unless host['hypervisor'] == 'docker'
+  install_puppet_module_via_pmt_on(host, 'puppet-epel') if fact_on(host, 'os.family') == 'RedHat' && fact_on(host, 'os.release.major').to_i == 7
 
-  install_module_from_forge_on(host, 'puppet/epel', '>= 3.0.0') if fact_on(host, 'osfamily') == 'RedHat' && fact_on(host, 'operatingsystemmajrelease').to_i == 7
-  unless fact_on(host, 'osfamily') == 'RedHat' && fact_on(host, 'operatingsystemmajrelease').to_i >= 9
+  unless fact_on(host, 'os.family') == 'RedHat' && fact_on(host, 'os.release.major').to_i >= 9
     # puppet-bolt rpm for CentOS 9 is not yet available
     # https://tickets.puppetlabs.com/browse/MODULES-11275
     host.install_package('puppet-bolt')
   end
 
-  if fact_on(host, 'osfamily') == 'Debian'
+  if fact_on(host, 'os.family') == 'Debian'
     # APT required for Debian based systems where `$redis::manage_repo` is `true`
-    install_module_from_forge_on(host, 'puppetlabs/apt', '>= 9.0.0')
+    install_puppet_module_via_pmt_on(host, 'puppetlabs-apt')
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Somewhere between voxpupuli-acceptance last v1 and v2 the modules are installed in a path where bolt can't find them.


#### This Pull Request (PR) fixes the following issues
Fixes #474 
Fixes #472

