### PR TITLE
Fix for redis.conf.epp bug: save_db_to_disk = false does not work. 

### DIFF
--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -971,7 +971,7 @@ describe 'redis' do
 
           it {
             is_expected.to contain_file(config_file_orig).with(
-              'content' => %r{^(?!save)}
+              'content' => %r{^save ""$}
             )
           }
         end

--- a/templates/redis.conf.epp
+++ b/templates/redis.conf.epp
@@ -344,6 +344,8 @@ databases <%= $databases %>
 <%- $save_db_to_disk_interval.each |$seconds, $key_change| { -%>
 save <%= "${seconds} ${key_change}\n" -%>
 <%- } -%>
+<% } else { -%>
+save ""
 <% } %>
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.


### PR DESCRIPTION
#### Pull Request (PR) description
Adds `save ""` in `redis.conf` when `save_db_to_disk = false`. 
This is required in Redis 6.0+ when its used strictly as cache and requires disabling snapshotting to disk completely.

#### This Pull Request (PR) fixes the following issues
Fixes #477

