### PR TITLE
Fix missing puppet strings

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,9 +9,9 @@
 #### Public Classes
 
 * [`redis`](#redis): This class installs redis
-* [`redis::administration`](#redis--administration): Allows various administrative settings for Redis
-* [`redis::globals`](#redis--globals): Set a global config for Redis
-* [`redis::sentinel`](#redis--sentinel): Install redis-sentinel
+* [`redis::administration`](#redisadministration): Allows various administrative settings for Redis
+* [`redis::globals`](#redisglobals): Set a global config for Redis
+* [`redis::sentinel`](#redissentinel): Install redis-sentinel
 
 #### Private Classes
 
@@ -26,17 +26,17 @@ repositories.
 
 ### Defined types
 
-* [`redis::instance`](#redis--instance): Allows the configuration of multiple redis configurations on one machine
+* [`redis::instance`](#redisinstance): Allows the configuration of multiple redis configurations on one machine
 
 ### Functions
 
-* [`redis::get`](#redis--get): Returns the value of the key being looked up or `undef` if the key does not exist.
+* [`redis::get`](#redisget): Returns the value of the key being looked up or `undef` if the key does not exist.
 
 ### Data types
 
-* [`Redis::LogLevel`](#Redis--LogLevel): Specify the server verbosity level.
-* [`Redis::MemoryPolicy`](#Redis--MemoryPolicy): Specify the server maxmemory_policy.
-* [`Redis::RedisUrl`](#Redis--RedisUrl)
+* [`Redis::LogLevel`](#redisloglevel): Specify the server verbosity level.
+* [`Redis::MemoryPolicy`](#redismemorypolicy): Specify the server maxmemory_policy.
+* [`Redis::RedisUrl`](#redisredisurl): validate URL matches redis protocol
 
 ### Tasks
 
@@ -85,172 +85,172 @@ class { 'redis':
 
 The following parameters are available in the `redis` class:
 
-* [`activerehashing`](#-redis--activerehashing)
-* [`aof_load_truncated`](#-redis--aof_load_truncated)
-* [`aof_rewrite_incremental_fsync`](#-redis--aof_rewrite_incremental_fsync)
-* [`appendfilename`](#-redis--appendfilename)
-* [`appendfsync`](#-redis--appendfsync)
-* [`appendonly`](#-redis--appendonly)
-* [`auto_aof_rewrite_min_size`](#-redis--auto_aof_rewrite_min_size)
-* [`auto_aof_rewrite_percentage`](#-redis--auto_aof_rewrite_percentage)
-* [`bind`](#-redis--bind)
-* [`bin_path`](#-redis--bin_path)
-* [`config_dir`](#-redis--config_dir)
-* [`config_dir_mode`](#-redis--config_dir_mode)
-* [`config_file_orig`](#-redis--config_file_orig)
-* [`config_file`](#-redis--config_file)
-* [`config_file_mode`](#-redis--config_file_mode)
-* [`config_group`](#-redis--config_group)
-* [`config_owner`](#-redis--config_owner)
-* [`conf_template`](#-redis--conf_template)
-* [`daemonize`](#-redis--daemonize)
-* [`default_install`](#-redis--default_install)
-* [`databases`](#-redis--databases)
-* [`dbfilename`](#-redis--dbfilename)
-* [`extra_config_file`](#-redis--extra_config_file)
-* [`hash_max_ziplist_entries`](#-redis--hash_max_ziplist_entries)
-* [`hash_max_ziplist_value`](#-redis--hash_max_ziplist_value)
-* [`hll_sparse_max_bytes`](#-redis--hll_sparse_max_bytes)
-* [`hz`](#-redis--hz)
-* [`latency_monitor_threshold`](#-redis--latency_monitor_threshold)
-* [`list_max_ziplist_entries`](#-redis--list_max_ziplist_entries)
-* [`list_max_ziplist_value`](#-redis--list_max_ziplist_value)
-* [`log_dir`](#-redis--log_dir)
-* [`log_dir_mode`](#-redis--log_dir_mode)
-* [`log_file`](#-redis--log_file)
-* [`log_level`](#-redis--log_level)
-* [`manage_repo`](#-redis--manage_repo)
-* [`manage_package`](#-redis--manage_package)
-* [`managed_by_cluster_manager`](#-redis--managed_by_cluster_manager)
-* [`masterauth`](#-redis--masterauth)
-* [`maxclients`](#-redis--maxclients)
-* [`maxmemory`](#-redis--maxmemory)
-* [`maxmemory_policy`](#-redis--maxmemory_policy)
-* [`maxmemory_samples`](#-redis--maxmemory_samples)
-* [`min_slaves_max_lag`](#-redis--min_slaves_max_lag)
-* [`min_slaves_to_write`](#-redis--min_slaves_to_write)
-* [`modules`](#-redis--modules)
-* [`no_appendfsync_on_rewrite`](#-redis--no_appendfsync_on_rewrite)
-* [`notify_keyspace_events`](#-redis--notify_keyspace_events)
-* [`notify_service`](#-redis--notify_service)
-* [`package_ensure`](#-redis--package_ensure)
-* [`package_name`](#-redis--package_name)
-* [`pid_file`](#-redis--pid_file)
-* [`port`](#-redis--port)
-* [`protected_mode`](#-redis--protected_mode)
-* [`ppa_repo`](#-redis--ppa_repo)
-* [`redis_apt_repo`](#-redis--redis_apt_repo)
-* [`apt_location`](#-redis--apt_location)
-* [`apt_repos`](#-redis--apt_repos)
-* [`apt_release`](#-redis--apt_release)
-* [`apt_key_id`](#-redis--apt_key_id)
-* [`apt_key_server`](#-redis--apt_key_server)
-* [`apt_key_options`](#-redis--apt_key_options)
-* [`rdbcompression`](#-redis--rdbcompression)
-* [`rename_commands`](#-redis--rename_commands)
-* [`repl_announce_ip`](#-redis--repl_announce_ip)
-* [`repl_announce_port`](#-redis--repl_announce_port)
-* [`repl_backlog_size`](#-redis--repl_backlog_size)
-* [`repl_backlog_ttl`](#-redis--repl_backlog_ttl)
-* [`repl_disable_tcp_nodelay`](#-redis--repl_disable_tcp_nodelay)
-* [`repl_ping_slave_period`](#-redis--repl_ping_slave_period)
-* [`repl_timeout`](#-redis--repl_timeout)
-* [`requirepass`](#-redis--requirepass)
-* [`save_db_to_disk`](#-redis--save_db_to_disk)
-* [`save_db_to_disk_interval`](#-redis--save_db_to_disk_interval)
-* [`service_manage`](#-redis--service_manage)
-* [`service_enable`](#-redis--service_enable)
-* [`service_ensure`](#-redis--service_ensure)
-* [`service_group`](#-redis--service_group)
-* [`service_name`](#-redis--service_name)
-* [`service_user`](#-redis--service_user)
-* [`service_timeout_start`](#-redis--service_timeout_start)
-* [`service_timeout_stop`](#-redis--service_timeout_stop)
-* [`set_max_intset_entries`](#-redis--set_max_intset_entries)
-* [`slave_priority`](#-redis--slave_priority)
-* [`slave_read_only`](#-redis--slave_read_only)
-* [`slave_serve_stale_data`](#-redis--slave_serve_stale_data)
-* [`slaveof`](#-redis--slaveof)
-* [`replicaof`](#-redis--replicaof)
-* [`slowlog_log_slower_than`](#-redis--slowlog_log_slower_than)
-* [`slowlog_max_len`](#-redis--slowlog_max_len)
-* [`stop_writes_on_bgsave_error`](#-redis--stop_writes_on_bgsave_error)
-* [`syslog_enabled`](#-redis--syslog_enabled)
-* [`syslog_facility`](#-redis--syslog_facility)
-* [`tcp_backlog`](#-redis--tcp_backlog)
-* [`tcp_keepalive`](#-redis--tcp_keepalive)
-* [`timeout`](#-redis--timeout)
-* [`tls_port`](#-redis--tls_port)
-* [`tls_cert_file`](#-redis--tls_cert_file)
-* [`tls_key_file`](#-redis--tls_key_file)
-* [`tls_ca_cert_file`](#-redis--tls_ca_cert_file)
-* [`tls_ca_cert_dir`](#-redis--tls_ca_cert_dir)
-* [`tls_auth_clients`](#-redis--tls_auth_clients)
-* [`tls_replication`](#-redis--tls_replication)
-* [`tls_cluster`](#-redis--tls_cluster)
-* [`tls_ciphers`](#-redis--tls_ciphers)
-* [`tls_ciphersuites`](#-redis--tls_ciphersuites)
-* [`tls_protocols`](#-redis--tls_protocols)
-* [`tls_prefer_server_ciphers`](#-redis--tls_prefer_server_ciphers)
-* [`ulimit`](#-redis--ulimit)
-* [`ulimit_managed`](#-redis--ulimit_managed)
-* [`unixsocket`](#-redis--unixsocket)
-* [`unixsocketperm`](#-redis--unixsocketperm)
-* [`workdir`](#-redis--workdir)
-* [`workdir_mode`](#-redis--workdir_mode)
-* [`zset_max_ziplist_entries`](#-redis--zset_max_ziplist_entries)
-* [`zset_max_ziplist_value`](#-redis--zset_max_ziplist_value)
-* [`cluster_enabled`](#-redis--cluster_enabled)
-* [`cluster_config_file`](#-redis--cluster_config_file)
-* [`cluster_node_timeout`](#-redis--cluster_node_timeout)
-* [`cluster_slave_validity_factor`](#-redis--cluster_slave_validity_factor)
-* [`cluster_require_full_coverage`](#-redis--cluster_require_full_coverage)
-* [`cluster_migration_barrier`](#-redis--cluster_migration_barrier)
-* [`instances`](#-redis--instances)
-* [`io_threads`](#-redis--io_threads)
-* [`io_threads_do_reads`](#-redis--io_threads_do_reads)
-* [`cluster_allow_reads_when_down`](#-redis--cluster_allow_reads_when_down)
-* [`cluster_replica_no_failover`](#-redis--cluster_replica_no_failover)
-* [`dynamic_hz`](#-redis--dynamic_hz)
-* [`activedefrag`](#-redis--activedefrag)
-* [`active_defrag_ignore_bytes`](#-redis--active_defrag_ignore_bytes)
-* [`active_defrag_threshold_lower`](#-redis--active_defrag_threshold_lower)
-* [`active_defrag_threshold_upper`](#-redis--active_defrag_threshold_upper)
-* [`active_defrag_cycle_min`](#-redis--active_defrag_cycle_min)
-* [`active_defrag_cycle_max`](#-redis--active_defrag_cycle_max)
-* [`active_defrag_max_scan_fields`](#-redis--active_defrag_max_scan_fields)
-* [`jemalloc_bg_thread`](#-redis--jemalloc_bg_thread)
-* [`rdb_save_incremental_fsync`](#-redis--rdb_save_incremental_fsync)
-* [`dnf_module_stream`](#-redis--dnf_module_stream)
-* [`output_buffer_limit_slave`](#-redis--output_buffer_limit_slave)
-* [`output_buffer_limit_pubsub`](#-redis--output_buffer_limit_pubsub)
-* [`manage_service_file`](#-redis--manage_service_file)
+* [`activerehashing`](#activerehashing)
+* [`aof_load_truncated`](#aof_load_truncated)
+* [`aof_rewrite_incremental_fsync`](#aof_rewrite_incremental_fsync)
+* [`appendfilename`](#appendfilename)
+* [`appendfsync`](#appendfsync)
+* [`appendonly`](#appendonly)
+* [`auto_aof_rewrite_min_size`](#auto_aof_rewrite_min_size)
+* [`auto_aof_rewrite_percentage`](#auto_aof_rewrite_percentage)
+* [`bind`](#bind)
+* [`bin_path`](#bin_path)
+* [`config_dir`](#config_dir)
+* [`config_dir_mode`](#config_dir_mode)
+* [`config_file_orig`](#config_file_orig)
+* [`config_file`](#config_file)
+* [`config_file_mode`](#config_file_mode)
+* [`config_group`](#config_group)
+* [`config_owner`](#config_owner)
+* [`conf_template`](#conf_template)
+* [`daemonize`](#daemonize)
+* [`default_install`](#default_install)
+* [`databases`](#databases)
+* [`dbfilename`](#dbfilename)
+* [`extra_config_file`](#extra_config_file)
+* [`hash_max_ziplist_entries`](#hash_max_ziplist_entries)
+* [`hash_max_ziplist_value`](#hash_max_ziplist_value)
+* [`hll_sparse_max_bytes`](#hll_sparse_max_bytes)
+* [`hz`](#hz)
+* [`latency_monitor_threshold`](#latency_monitor_threshold)
+* [`list_max_ziplist_entries`](#list_max_ziplist_entries)
+* [`list_max_ziplist_value`](#list_max_ziplist_value)
+* [`log_dir`](#log_dir)
+* [`log_dir_mode`](#log_dir_mode)
+* [`log_file`](#log_file)
+* [`log_level`](#log_level)
+* [`manage_repo`](#manage_repo)
+* [`manage_package`](#manage_package)
+* [`managed_by_cluster_manager`](#managed_by_cluster_manager)
+* [`masterauth`](#masterauth)
+* [`maxclients`](#maxclients)
+* [`maxmemory`](#maxmemory)
+* [`maxmemory_policy`](#maxmemory_policy)
+* [`maxmemory_samples`](#maxmemory_samples)
+* [`min_slaves_max_lag`](#min_slaves_max_lag)
+* [`min_slaves_to_write`](#min_slaves_to_write)
+* [`modules`](#modules)
+* [`no_appendfsync_on_rewrite`](#no_appendfsync_on_rewrite)
+* [`notify_keyspace_events`](#notify_keyspace_events)
+* [`notify_service`](#notify_service)
+* [`output_buffer_limit_slave`](#output_buffer_limit_slave)
+* [`output_buffer_limit_pubsub`](#output_buffer_limit_pubsub)
+* [`package_ensure`](#package_ensure)
+* [`package_name`](#package_name)
+* [`pid_file`](#pid_file)
+* [`port`](#port)
+* [`protected_mode`](#protected_mode)
+* [`ppa_repo`](#ppa_repo)
+* [`redis_apt_repo`](#redis_apt_repo)
+* [`apt_location`](#apt_location)
+* [`apt_repos`](#apt_repos)
+* [`apt_release`](#apt_release)
+* [`apt_key_id`](#apt_key_id)
+* [`apt_key_server`](#apt_key_server)
+* [`apt_key_options`](#apt_key_options)
+* [`rdbcompression`](#rdbcompression)
+* [`rename_commands`](#rename_commands)
+* [`repl_announce_ip`](#repl_announce_ip)
+* [`repl_announce_port`](#repl_announce_port)
+* [`repl_backlog_size`](#repl_backlog_size)
+* [`repl_backlog_ttl`](#repl_backlog_ttl)
+* [`repl_disable_tcp_nodelay`](#repl_disable_tcp_nodelay)
+* [`repl_ping_slave_period`](#repl_ping_slave_period)
+* [`repl_timeout`](#repl_timeout)
+* [`requirepass`](#requirepass)
+* [`save_db_to_disk`](#save_db_to_disk)
+* [`save_db_to_disk_interval`](#save_db_to_disk_interval)
+* [`service_manage`](#service_manage)
+* [`service_enable`](#service_enable)
+* [`service_ensure`](#service_ensure)
+* [`service_group`](#service_group)
+* [`service_name`](#service_name)
+* [`service_user`](#service_user)
+* [`service_timeout_start`](#service_timeout_start)
+* [`service_timeout_stop`](#service_timeout_stop)
+* [`set_max_intset_entries`](#set_max_intset_entries)
+* [`slave_priority`](#slave_priority)
+* [`slave_read_only`](#slave_read_only)
+* [`slave_serve_stale_data`](#slave_serve_stale_data)
+* [`slaveof`](#slaveof)
+* [`replicaof`](#replicaof)
+* [`slowlog_log_slower_than`](#slowlog_log_slower_than)
+* [`slowlog_max_len`](#slowlog_max_len)
+* [`stop_writes_on_bgsave_error`](#stop_writes_on_bgsave_error)
+* [`syslog_enabled`](#syslog_enabled)
+* [`syslog_facility`](#syslog_facility)
+* [`tcp_backlog`](#tcp_backlog)
+* [`tcp_keepalive`](#tcp_keepalive)
+* [`timeout`](#timeout)
+* [`tls_port`](#tls_port)
+* [`tls_cert_file`](#tls_cert_file)
+* [`tls_key_file`](#tls_key_file)
+* [`tls_ca_cert_file`](#tls_ca_cert_file)
+* [`tls_ca_cert_dir`](#tls_ca_cert_dir)
+* [`tls_auth_clients`](#tls_auth_clients)
+* [`tls_replication`](#tls_replication)
+* [`tls_cluster`](#tls_cluster)
+* [`tls_ciphers`](#tls_ciphers)
+* [`tls_ciphersuites`](#tls_ciphersuites)
+* [`tls_protocols`](#tls_protocols)
+* [`tls_prefer_server_ciphers`](#tls_prefer_server_ciphers)
+* [`ulimit`](#ulimit)
+* [`ulimit_managed`](#ulimit_managed)
+* [`unixsocket`](#unixsocket)
+* [`unixsocketperm`](#unixsocketperm)
+* [`workdir`](#workdir)
+* [`workdir_mode`](#workdir_mode)
+* [`zset_max_ziplist_entries`](#zset_max_ziplist_entries)
+* [`zset_max_ziplist_value`](#zset_max_ziplist_value)
+* [`cluster_enabled`](#cluster_enabled)
+* [`cluster_config_file`](#cluster_config_file)
+* [`cluster_node_timeout`](#cluster_node_timeout)
+* [`cluster_slave_validity_factor`](#cluster_slave_validity_factor)
+* [`cluster_require_full_coverage`](#cluster_require_full_coverage)
+* [`cluster_migration_barrier`](#cluster_migration_barrier)
+* [`instances`](#instances)
+* [`io_threads`](#io_threads)
+* [`io_threads_do_reads`](#io_threads_do_reads)
+* [`cluster_allow_reads_when_down`](#cluster_allow_reads_when_down)
+* [`cluster_replica_no_failover`](#cluster_replica_no_failover)
+* [`dynamic_hz`](#dynamic_hz)
+* [`activedefrag`](#activedefrag)
+* [`active_defrag_ignore_bytes`](#active_defrag_ignore_bytes)
+* [`active_defrag_threshold_lower`](#active_defrag_threshold_lower)
+* [`active_defrag_threshold_upper`](#active_defrag_threshold_upper)
+* [`active_defrag_cycle_min`](#active_defrag_cycle_min)
+* [`active_defrag_cycle_max`](#active_defrag_cycle_max)
+* [`active_defrag_max_scan_fields`](#active_defrag_max_scan_fields)
+* [`jemalloc_bg_thread`](#jemalloc_bg_thread)
+* [`rdb_save_incremental_fsync`](#rdb_save_incremental_fsync)
+* [`dnf_module_stream`](#dnf_module_stream)
+* [`manage_service_file`](#manage_service_file)
 
-##### <a name="-redis--activerehashing"></a>`activerehashing`
+##### <a name="activerehashing"></a>`activerehashing`
 
 Data type: `Boolean`
 
 Enable/disable active rehashing.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--aof_load_truncated"></a>`aof_load_truncated`
+##### <a name="aof_load_truncated"></a>`aof_load_truncated`
 
 Data type: `Boolean`
 
 Enable/disable loading truncated AOF file
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--aof_rewrite_incremental_fsync"></a>`aof_rewrite_incremental_fsync`
+##### <a name="aof_rewrite_incremental_fsync"></a>`aof_rewrite_incremental_fsync`
 
 Data type: `Boolean`
 
 Enable/disable fsync for AOF file
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--appendfilename"></a>`appendfilename`
+##### <a name="appendfilename"></a>`appendfilename`
 
 Data type: `String[1]`
 
@@ -258,7 +258,7 @@ The name of the append only file
 
 Default value: `'appendonly.aof'`
 
-##### <a name="-redis--appendfsync"></a>`appendfsync`
+##### <a name="appendfsync"></a>`appendfsync`
 
 Data type: `Enum['no', 'always', 'everysec']`
 
@@ -266,15 +266,15 @@ Adjust fsync mode
 
 Default value: `'everysec'`
 
-##### <a name="-redis--appendonly"></a>`appendonly`
+##### <a name="appendonly"></a>`appendonly`
 
 Data type: `Boolean`
 
 Enable/disable appendonly mode.
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--auto_aof_rewrite_min_size"></a>`auto_aof_rewrite_min_size`
+##### <a name="auto_aof_rewrite_min_size"></a>`auto_aof_rewrite_min_size`
 
 Data type: `String[1]`
 
@@ -282,7 +282,7 @@ Adjust minimum size for auto-aof-rewrite.
 
 Default value: `'64mb'`
 
-##### <a name="-redis--auto_aof_rewrite_percentage"></a>`auto_aof_rewrite_percentage`
+##### <a name="auto_aof_rewrite_percentage"></a>`auto_aof_rewrite_percentage`
 
 Data type: `Integer[0]`
 
@@ -290,7 +290,7 @@ Adjust percentatge for auto-aof-rewrite.
 
 Default value: `100`
 
-##### <a name="-redis--bind"></a>`bind`
+##### <a name="bind"></a>`bind`
 
 Data type: `Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]]`
 
@@ -298,7 +298,7 @@ Configure which IP address(es) to listen on. To bind on all interfaces, use an e
 
 Default value: `['127.0.0.1']`
 
-##### <a name="-redis--bin_path"></a>`bin_path`
+##### <a name="bin_path"></a>`bin_path`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -306,7 +306,7 @@ Directory containing redis binary executables.
 
 Default value: `$redis::params::bin_path`
 
-##### <a name="-redis--config_dir"></a>`config_dir`
+##### <a name="config_dir"></a>`config_dir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -314,7 +314,7 @@ Directory containing the configuration files.
 
 Default value: `$redis::params::config_dir`
 
-##### <a name="-redis--config_dir_mode"></a>`config_dir_mode`
+##### <a name="config_dir_mode"></a>`config_dir_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -322,7 +322,7 @@ Adjust mode for directory containing configuration files.
 
 Default value: `$redis::params::config_dir_mode`
 
-##### <a name="-redis--config_file_orig"></a>`config_file_orig`
+##### <a name="config_file_orig"></a>`config_file_orig`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -330,7 +330,7 @@ The location and name of a config file that provides the source
 
 Default value: `$redis::params::config_file_orig`
 
-##### <a name="-redis--config_file"></a>`config_file`
+##### <a name="config_file"></a>`config_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -338,7 +338,7 @@ Adjust main configuration file.
 
 Default value: `$redis::params::config_file`
 
-##### <a name="-redis--config_file_mode"></a>`config_file_mode`
+##### <a name="config_file_mode"></a>`config_file_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -346,7 +346,7 @@ Adjust permissions for configuration files.
 
 Default value: `'0640'`
 
-##### <a name="-redis--config_group"></a>`config_group`
+##### <a name="config_group"></a>`config_group`
 
 Data type: `String[1]`
 
@@ -354,7 +354,7 @@ Adjust filesystem group for config files.
 
 Default value: `$redis::params::config_group`
 
-##### <a name="-redis--config_owner"></a>`config_owner`
+##### <a name="config_owner"></a>`config_owner`
 
 Data type: `String[1]`
 
@@ -362,7 +362,7 @@ Adjust filesystem owner for config files.
 
 Default value: `$redis::params::config_owner`
 
-##### <a name="-redis--conf_template"></a>`conf_template`
+##### <a name="conf_template"></a>`conf_template`
 
 Data type: `String[1]`
 
@@ -370,7 +370,7 @@ Define which template to use.
 
 Default value: `'redis/redis.conf.epp'`
 
-##### <a name="-redis--daemonize"></a>`daemonize`
+##### <a name="daemonize"></a>`daemonize`
 
 Data type: `Boolean`
 
@@ -378,15 +378,15 @@ Have Redis run as a daemon.
 
 Default value: `$redis::params::daemonize`
 
-##### <a name="-redis--default_install"></a>`default_install`
+##### <a name="default_install"></a>`default_install`
 
 Data type: `Boolean`
 
 Configure a default install of redis.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--databases"></a>`databases`
+##### <a name="databases"></a>`databases`
 
 Data type: `Integer[1]`
 
@@ -394,7 +394,7 @@ Set the number of databases.
 
 Default value: `16`
 
-##### <a name="-redis--dbfilename"></a>`dbfilename`
+##### <a name="dbfilename"></a>`dbfilename`
 
 Data type: `Variant[String[1], Boolean]`
 
@@ -402,15 +402,15 @@ The filename where to dump the DB
 
 Default value: `'dump.rdb'`
 
-##### <a name="-redis--extra_config_file"></a>`extra_config_file`
+##### <a name="extra_config_file"></a>`extra_config_file`
 
 Data type: `Optional[String]`
 
 Optional extra config file to include
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--hash_max_ziplist_entries"></a>`hash_max_ziplist_entries`
+##### <a name="hash_max_ziplist_entries"></a>`hash_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -418,7 +418,7 @@ Set max ziplist entries for hashes.
 
 Default value: `512`
 
-##### <a name="-redis--hash_max_ziplist_value"></a>`hash_max_ziplist_value`
+##### <a name="hash_max_ziplist_value"></a>`hash_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -426,7 +426,7 @@ Set max ziplist values for hashes.
 
 Default value: `64`
 
-##### <a name="-redis--hll_sparse_max_bytes"></a>`hll_sparse_max_bytes`
+##### <a name="hll_sparse_max_bytes"></a>`hll_sparse_max_bytes`
 
 Data type: `Integer[0]`
 
@@ -434,7 +434,7 @@ HyperLogLog sparse representation bytes limit
 
 Default value: `3000`
 
-##### <a name="-redis--hz"></a>`hz`
+##### <a name="hz"></a>`hz`
 
 Data type: `Integer[1, 500]`
 
@@ -442,7 +442,7 @@ Set redis background tasks frequency
 
 Default value: `10`
 
-##### <a name="-redis--latency_monitor_threshold"></a>`latency_monitor_threshold`
+##### <a name="latency_monitor_threshold"></a>`latency_monitor_threshold`
 
 Data type: `Integer[0]`
 
@@ -450,7 +450,7 @@ Latency monitoring threshold in milliseconds
 
 Default value: `0`
 
-##### <a name="-redis--list_max_ziplist_entries"></a>`list_max_ziplist_entries`
+##### <a name="list_max_ziplist_entries"></a>`list_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -458,7 +458,7 @@ Set max ziplist entries for lists.
 
 Default value: `512`
 
-##### <a name="-redis--list_max_ziplist_value"></a>`list_max_ziplist_value`
+##### <a name="list_max_ziplist_value"></a>`list_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -466,7 +466,7 @@ Set max ziplist values for lists.
 
 Default value: `64`
 
-##### <a name="-redis--log_dir"></a>`log_dir`
+##### <a name="log_dir"></a>`log_dir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -474,7 +474,7 @@ Specify directory where to write log entries.
 
 Default value: `$redis::params::log_dir`
 
-##### <a name="-redis--log_dir_mode"></a>`log_dir_mode`
+##### <a name="log_dir_mode"></a>`log_dir_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -482,7 +482,7 @@ Adjust mode for directory containing log files.
 
 Default value: `$redis::params::log_dir_mode`
 
-##### <a name="-redis--log_file"></a>`log_file`
+##### <a name="log_file"></a>`log_file`
 
 Data type: `String`
 
@@ -491,7 +491,7 @@ with log_dir but absolute paths are also accepted.
 
 Default value: `'redis.log'`
 
-##### <a name="-redis--log_level"></a>`log_level`
+##### <a name="log_level"></a>`log_level`
 
 Data type: `Redis::LogLevel`
 
@@ -499,39 +499,39 @@ Specify the server verbosity level.
 
 Default value: `'notice'`
 
-##### <a name="-redis--manage_repo"></a>`manage_repo`
+##### <a name="manage_repo"></a>`manage_repo`
 
 Data type: `Boolean`
 
 Enable/disable upstream repository configuration.
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--manage_package"></a>`manage_package`
+##### <a name="manage_package"></a>`manage_package`
 
 Data type: `Boolean`
 
 Enable/disable management of package
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--managed_by_cluster_manager"></a>`managed_by_cluster_manager`
+##### <a name="managed_by_cluster_manager"></a>`managed_by_cluster_manager`
 
 Data type: `Boolean`
 
 Choose if redis will be managed by a cluster manager such as pacemaker or rgmanager
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--masterauth"></a>`masterauth`
+##### <a name="masterauth"></a>`masterauth`
 
 Data type: `Optional[Variant[String[1], Sensitive[String[1]], Deferred]]`
 
 If the master is password protected (using the "requirepass" configuration
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--maxclients"></a>`maxclients`
+##### <a name="maxclients"></a>`maxclients`
 
 Data type: `Integer[1]`
 
@@ -539,31 +539,31 @@ Set the max number of connected clients at the same time.
 
 Default value: `10000`
 
-##### <a name="-redis--maxmemory"></a>`maxmemory`
+##### <a name="maxmemory"></a>`maxmemory`
 
 Data type: `Any`
 
 Don't use more memory than the specified amount of bytes.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--maxmemory_policy"></a>`maxmemory_policy`
+##### <a name="maxmemory_policy"></a>`maxmemory_policy`
 
 Data type: `Optional[Redis::MemoryPolicy]`
 
 How Redis will select what to remove when maxmemory is reached.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--maxmemory_samples"></a>`maxmemory_samples`
+##### <a name="maxmemory_samples"></a>`maxmemory_samples`
 
 Data type: `Optional[Integer[1, 10]]`
 
 Select as well the sample size to check.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--min_slaves_max_lag"></a>`min_slaves_max_lag`
+##### <a name="min_slaves_max_lag"></a>`min_slaves_max_lag`
 
 Data type: `Integer[0]`
 
@@ -571,7 +571,7 @@ The lag in seconds
 
 Default value: `10`
 
-##### <a name="-redis--min_slaves_to_write"></a>`min_slaves_to_write`
+##### <a name="min_slaves_to_write"></a>`min_slaves_to_write`
 
 Data type: `Integer[0]`
 
@@ -579,7 +579,7 @@ Minimum number of slaves to be in "online" state
 
 Default value: `0`
 
-##### <a name="-redis--modules"></a>`modules`
+##### <a name="modules"></a>`modules`
 
 Data type: `Array[Stdlib::Absolutepath]`
 
@@ -587,31 +587,47 @@ Additional redis modules to load (.so path)
 
 Default value: `[]`
 
-##### <a name="-redis--no_appendfsync_on_rewrite"></a>`no_appendfsync_on_rewrite`
+##### <a name="no_appendfsync_on_rewrite"></a>`no_appendfsync_on_rewrite`
 
 Data type: `Boolean`
 
 If you have latency problems turn this to 'true'. Otherwise leave it as
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--notify_keyspace_events"></a>`notify_keyspace_events`
+##### <a name="notify_keyspace_events"></a>`notify_keyspace_events`
 
 Data type: `Optional[String[1]]`
 
 Which events to notify Pub/Sub clients about events happening
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--notify_service"></a>`notify_service`
+##### <a name="notify_service"></a>`notify_service`
 
 Data type: `Boolean`
 
 You may disable service reloads when config files change
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--package_ensure"></a>`package_ensure`
+##### <a name="output_buffer_limit_slave"></a>`output_buffer_limit_slave`
+
+Data type: `String[1]`
+
+Value of client-output-buffer-limit-slave in redis config
+
+Default value: `'256mb 64mb 60'`
+
+##### <a name="output_buffer_limit_pubsub"></a>`output_buffer_limit_pubsub`
+
+Data type: `String[1]`
+
+Value of client-output-buffer-limit-pubsub in redis config
+
+Default value: `'32mb 8mb 60'`
+
+##### <a name="package_ensure"></a>`package_ensure`
 
 Data type: `String[1]`
 
@@ -619,7 +635,7 @@ Default action for package.
 
 Default value: `'installed'`
 
-##### <a name="-redis--package_name"></a>`package_name`
+##### <a name="package_name"></a>`package_name`
 
 Data type: `String[1]`
 
@@ -627,7 +643,7 @@ Upstream package name.
 
 Default value: `$redis::params::package_name`
 
-##### <a name="-redis--pid_file"></a>`pid_file`
+##### <a name="pid_file"></a>`pid_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -635,7 +651,7 @@ Where to store the pid.
 
 Default value: `$redis::params::pid_file`
 
-##### <a name="-redis--port"></a>`port`
+##### <a name="port"></a>`port`
 
 Data type: `Stdlib::Port`
 
@@ -643,31 +659,31 @@ Configure which port to listen on.
 
 Default value: `6379`
 
-##### <a name="-redis--protected_mode"></a>`protected_mode`
+##### <a name="protected_mode"></a>`protected_mode`
 
 Data type: `Boolean`
 
 Whether protected mode is enabled or not.  Only applicable when no bind is set.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--ppa_repo"></a>`ppa_repo`
+##### <a name="ppa_repo"></a>`ppa_repo`
 
 Data type: `Optional[String]`
 
 Specify upstream (Ubuntu) PPA entry.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--redis_apt_repo"></a>`redis_apt_repo`
+##### <a name="redis_apt_repo"></a>`redis_apt_repo`
 
 Data type: `Boolean`
 
 If you want to use the redis apt repository.
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--apt_location"></a>`apt_location`
+##### <a name="apt_location"></a>`apt_location`
 
 Data type: `Stdlib::HTTPSUrl`
 
@@ -675,7 +691,7 @@ Specify the URL of the apt repository.
 
 Default value: `'https://packages.redis.io/deb/'`
 
-##### <a name="-redis--apt_repos"></a>`apt_repos`
+##### <a name="apt_repos"></a>`apt_repos`
 
 Data type: `String[1]`
 
@@ -683,15 +699,15 @@ Specify the repository to use for apt. Defaults to 'main'.
 
 Default value: `'main'`
 
-##### <a name="-redis--apt_release"></a>`apt_release`
+##### <a name="apt_release"></a>`apt_release`
 
 Data type: `Optional[String]`
 
 Specify the os codename.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--apt_key_id"></a>`apt_key_id`
+##### <a name="apt_key_id"></a>`apt_key_id`
 
 Data type: `String[1]`
 
@@ -699,7 +715,7 @@ Specify the PGP key id to use for apt.
 
 Default value: `'54318FA4052D1E61A6B6F7BB5F4349D6BF53AA0C'`
 
-##### <a name="-redis--apt_key_server"></a>`apt_key_server`
+##### <a name="apt_key_server"></a>`apt_key_server`
 
 Data type: `String[1]`
 
@@ -707,23 +723,23 @@ Specify the PGP key server to use for apt.
 
 Default value: `'hkp://keyserver.ubuntu.com/'`
 
-##### <a name="-redis--apt_key_options"></a>`apt_key_options`
+##### <a name="apt_key_options"></a>`apt_key_options`
 
 Data type: `Optional[String]`
 
 Passes additional options to `apt-key adv --keyserver-options`.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--rdbcompression"></a>`rdbcompression`
+##### <a name="rdbcompression"></a>`rdbcompression`
 
 Data type: `Boolean`
 
 Enable/disable compression of string objects using LZF when dumping.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--rename_commands"></a>`rename_commands`
+##### <a name="rename_commands"></a>`rename_commands`
 
 Data type: `Hash[String,String]`
 
@@ -731,23 +747,23 @@ A list of Redis commands to rename or disable for security reasons
 
 Default value: `{}`
 
-##### <a name="-redis--repl_announce_ip"></a>`repl_announce_ip`
+##### <a name="repl_announce_ip"></a>`repl_announce_ip`
 
 Data type: `Optional[Stdlib::Host]`
 
 The specific IP or hostname a replica will report to its master
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--repl_announce_port"></a>`repl_announce_port`
+##### <a name="repl_announce_port"></a>`repl_announce_port`
 
 Data type: `Optional[Stdlib::Port]`
 
 The specific port a replica will report to its master
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--repl_backlog_size"></a>`repl_backlog_size`
+##### <a name="repl_backlog_size"></a>`repl_backlog_size`
 
 Data type: `String[1]`
 
@@ -755,7 +771,7 @@ The replication backlog size
 
 Default value: `'1mb'`
 
-##### <a name="-redis--repl_backlog_ttl"></a>`repl_backlog_ttl`
+##### <a name="repl_backlog_ttl"></a>`repl_backlog_ttl`
 
 Data type: `Integer[0]`
 
@@ -763,15 +779,15 @@ The number of seconds to elapse before freeing backlog buffer
 
 Default value: `3600`
 
-##### <a name="-redis--repl_disable_tcp_nodelay"></a>`repl_disable_tcp_nodelay`
+##### <a name="repl_disable_tcp_nodelay"></a>`repl_disable_tcp_nodelay`
 
 Data type: `Boolean`
 
 Enable/disable TCP_NODELAY on the slave socket after SYNC
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--repl_ping_slave_period"></a>`repl_ping_slave_period`
+##### <a name="repl_ping_slave_period"></a>`repl_ping_slave_period`
 
 Data type: `Integer[1]`
 
@@ -779,7 +795,7 @@ Slaves send PINGs to server in a predefined interval. It's possible
 
 Default value: `10`
 
-##### <a name="-redis--repl_timeout"></a>`repl_timeout`
+##### <a name="repl_timeout"></a>`repl_timeout`
 
 Data type: `Integer[1]`
 
@@ -787,23 +803,23 @@ Set the replication timeout for:
 
 Default value: `60`
 
-##### <a name="-redis--requirepass"></a>`requirepass`
+##### <a name="requirepass"></a>`requirepass`
 
 Data type: `Optional[Variant[String, Deferred]]`
 
 Require clients to issue AUTH <PASSWORD> before processing any other commands.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--save_db_to_disk"></a>`save_db_to_disk`
+##### <a name="save_db_to_disk"></a>`save_db_to_disk`
 
 Data type: `Boolean`
 
 Set if save db to disk.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--save_db_to_disk_interval"></a>`save_db_to_disk_interval`
+##### <a name="save_db_to_disk_interval"></a>`save_db_to_disk_interval`
 
 Data type: `Hash`
 
@@ -811,23 +827,23 @@ save the dataset every N seconds if there are at least M changes in the dataset
 
 Default value: `{ '900' => '1', '300' => '10', '60' => '10000' }`
 
-##### <a name="-redis--service_manage"></a>`service_manage`
+##### <a name="service_manage"></a>`service_manage`
 
 Data type: `Boolean`
 
 Specify if the service should be part of the catalog.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--service_enable"></a>`service_enable`
+##### <a name="service_enable"></a>`service_enable`
 
 Data type: `Boolean`
 
 Enable/disable daemon at boot.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--service_ensure"></a>`service_ensure`
+##### <a name="service_ensure"></a>`service_ensure`
 
 Data type: `Stdlib::Ensure::Service`
 
@@ -835,7 +851,7 @@ Specify if the server should be running.
 
 Default value: `'running'`
 
-##### <a name="-redis--service_group"></a>`service_group`
+##### <a name="service_group"></a>`service_group`
 
 Data type: `String[1]`
 
@@ -843,7 +859,7 @@ Specify which group to run as.
 
 Default value: `'redis'`
 
-##### <a name="-redis--service_name"></a>`service_name`
+##### <a name="service_name"></a>`service_name`
 
 Data type: `String[1]`
 
@@ -851,7 +867,7 @@ Specify the service name for Init or Systemd.
 
 Default value: `$redis::params::service_name`
 
-##### <a name="-redis--service_user"></a>`service_user`
+##### <a name="service_user"></a>`service_user`
 
 Data type: `String[1]`
 
@@ -859,23 +875,23 @@ Specify which user to run as.
 
 Default value: `'redis'`
 
-##### <a name="-redis--service_timeout_start"></a>`service_timeout_start`
+##### <a name="service_timeout_start"></a>`service_timeout_start`
 
 Data type: `Optional[Integer[0]]`
 
 Specify the time after which a service startup should be considered as failed.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--service_timeout_stop"></a>`service_timeout_stop`
+##### <a name="service_timeout_stop"></a>`service_timeout_stop`
 
 Data type: `Optional[Integer[0]]`
 
 Specify the time after which a service stop should be considered as failed.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--set_max_intset_entries"></a>`set_max_intset_entries`
+##### <a name="set_max_intset_entries"></a>`set_max_intset_entries`
 
 Data type: `Integer[0]`
 
@@ -884,7 +900,7 @@ in order to use this special memory saving encoding.
 
 Default value: `512`
 
-##### <a name="-redis--slave_priority"></a>`slave_priority`
+##### <a name="slave_priority"></a>`slave_priority`
 
 Data type: `Integer[0]`
 
@@ -892,15 +908,15 @@ The priority number for slave promotion by Sentinel
 
 Default value: `100`
 
-##### <a name="-redis--slave_read_only"></a>`slave_read_only`
+##### <a name="slave_read_only"></a>`slave_read_only`
 
 Data type: `Boolean`
 
 You can configure a slave instance to accept writes or not.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--slave_serve_stale_data"></a>`slave_serve_stale_data`
+##### <a name="slave_serve_stale_data"></a>`slave_serve_stale_data`
 
 Data type: `Boolean`
 
@@ -913,25 +929,25 @@ is still in progress, the slave can act in two different ways:
    an error "SYNC with master in progress" to all the kind of commands
    but to INFO and SLAVEOF.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--slaveof"></a>`slaveof`
+##### <a name="slaveof"></a>`slaveof`
 
 Data type: `Optional[String[1]]`
 
 Use slaveof to make a Redis instance a copy of another Redis server.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--replicaof"></a>`replicaof`
+##### <a name="replicaof"></a>`replicaof`
 
 Data type: `Optional[String[1]]`
 
 Use replicaof to make a Redis instance a copy of another Redis server.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--slowlog_log_slower_than"></a>`slowlog_log_slower_than`
+##### <a name="slowlog_log_slower_than"></a>`slowlog_log_slower_than`
 
 Data type: `Integer[-1]`
 
@@ -940,7 +956,7 @@ for the command to get logged.
 
 Default value: `10000`
 
-##### <a name="-redis--slowlog_max_len"></a>`slowlog_max_len`
+##### <a name="slowlog_max_len"></a>`slowlog_max_len`
 
 Data type: `Integer[0]`
 
@@ -949,32 +965,32 @@ logged.
 
 Default value: `1024`
 
-##### <a name="-redis--stop_writes_on_bgsave_error"></a>`stop_writes_on_bgsave_error`
+##### <a name="stop_writes_on_bgsave_error"></a>`stop_writes_on_bgsave_error`
 
 Data type: `Boolean`
 
 If false then Redis will continue to work as usual even if there are
 problems with disk, permissions, and so forth.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--syslog_enabled"></a>`syslog_enabled`
+##### <a name="syslog_enabled"></a>`syslog_enabled`
 
 Data type: `Boolean`
 
 Enable/disable logging to the system logger.
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--syslog_facility"></a>`syslog_facility`
+##### <a name="syslog_facility"></a>`syslog_facility`
 
 Data type: `Optional[String[1]]`
 
 Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--tcp_backlog"></a>`tcp_backlog`
+##### <a name="tcp_backlog"></a>`tcp_backlog`
 
 Data type: `Integer[0]`
 
@@ -982,7 +998,7 @@ Sets the TCP backlog
 
 Default value: `511`
 
-##### <a name="-redis--tcp_keepalive"></a>`tcp_keepalive`
+##### <a name="tcp_keepalive"></a>`tcp_keepalive`
 
 Data type: `Integer[0]`
 
@@ -990,7 +1006,7 @@ TCP keepalive.
 
 Default value: `0`
 
-##### <a name="-redis--timeout"></a>`timeout`
+##### <a name="timeout"></a>`timeout`
 
 Data type: `Integer[0]`
 
@@ -998,47 +1014,47 @@ Close the connection after a client is idle for N seconds (0 to disable).
 
 Default value: `0`
 
-##### <a name="-redis--tls_port"></a>`tls_port`
+##### <a name="tls_port"></a>`tls_port`
 
 Data type: `Optional[Stdlib::Port]`
 
 Configure which TLS port to listen on.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--tls_cert_file"></a>`tls_cert_file`
+##### <a name="tls_cert_file"></a>`tls_cert_file`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
 Specify which X.509 certificate file to use for TLS connections.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--tls_key_file"></a>`tls_key_file`
+##### <a name="tls_key_file"></a>`tls_key_file`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
 Specify which privaye key file to use for TLS connections.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--tls_ca_cert_file"></a>`tls_ca_cert_file`
+##### <a name="tls_ca_cert_file"></a>`tls_ca_cert_file`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
 Specify which X.509 CA certificate(s) bundle file to use.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--tls_ca_cert_dir"></a>`tls_ca_cert_dir`
+##### <a name="tls_ca_cert_dir"></a>`tls_ca_cert_dir`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
 Specify which X.509 CA certificate(s) bundle directory to use.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--tls_auth_clients"></a>`tls_auth_clients`
+##### <a name="tls_auth_clients"></a>`tls_auth_clients`
 
 Data type: `Enum['yes', 'no', 'optional']`
 
@@ -1046,55 +1062,55 @@ Specify if clients and replicas are required to authenticate using valid client 
 
 Default value: `'no'`
 
-##### <a name="-redis--tls_replication"></a>`tls_replication`
+##### <a name="tls_replication"></a>`tls_replication`
 
 Data type: `Boolean`
 
 Specify if TLS should be enabled on replication links.
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--tls_cluster"></a>`tls_cluster`
+##### <a name="tls_cluster"></a>`tls_cluster`
 
 Data type: `Boolean`
 
 Specify if TLS should be used for the bus protocol.
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--tls_ciphers"></a>`tls_ciphers`
+##### <a name="tls_ciphers"></a>`tls_ciphers`
 
 Data type: `Optional[String[1]]`
 
 Configure allowed ciphers for TLS <= TLSv1.2.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--tls_ciphersuites"></a>`tls_ciphersuites`
+##### <a name="tls_ciphersuites"></a>`tls_ciphersuites`
 
 Data type: `Optional[String[1]]`
 
 Configure allowed TLSv1.3 ciphersuites.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--tls_protocols"></a>`tls_protocols`
+##### <a name="tls_protocols"></a>`tls_protocols`
 
 Data type: `Optional[String[1]]`
 
 Configure allowed TLS protocol versions.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--tls_prefer_server_ciphers"></a>`tls_prefer_server_ciphers`
+##### <a name="tls_prefer_server_ciphers"></a>`tls_prefer_server_ciphers`
 
 Data type: `Boolean`
 
 Specify if the server's preference should be used when choosing a cipher.
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--ulimit"></a>`ulimit`
+##### <a name="ulimit"></a>`ulimit`
 
 Data type: `Integer[0]`
 
@@ -1102,16 +1118,16 @@ Limit the use of system-wide resources.
 
 Default value: `65536`
 
-##### <a name="-redis--ulimit_managed"></a>`ulimit_managed`
+##### <a name="ulimit_managed"></a>`ulimit_managed`
 
 Data type: `Boolean`
 
 Defines wheter the max number of open files for the
 systemd service unit is explicitly managed.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--unixsocket"></a>`unixsocket`
+##### <a name="unixsocket"></a>`unixsocket`
 
 Data type: `Variant[Stdlib::Absolutepath, Enum['']]`
 
@@ -1119,7 +1135,7 @@ Define unix socket path
 
 Default value: `'/var/run/redis/redis.sock'`
 
-##### <a name="-redis--unixsocketperm"></a>`unixsocketperm`
+##### <a name="unixsocketperm"></a>`unixsocketperm`
 
 Data type: `Variant[Stdlib::Filemode, Enum['']]`
 
@@ -1127,7 +1143,7 @@ Define unix socket file permissions
 
 Default value: `'0755'`
 
-##### <a name="-redis--workdir"></a>`workdir`
+##### <a name="workdir"></a>`workdir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1136,7 +1152,7 @@ above using the 'dbfilename' configuration directive.
 
 Default value: `$redis::params::workdir`
 
-##### <a name="-redis--workdir_mode"></a>`workdir_mode`
+##### <a name="workdir_mode"></a>`workdir_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -1144,7 +1160,7 @@ Adjust mode for data directory.
 
 Default value: `'0750'`
 
-##### <a name="-redis--zset_max_ziplist_entries"></a>`zset_max_ziplist_entries`
+##### <a name="zset_max_ziplist_entries"></a>`zset_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -1152,7 +1168,7 @@ Set max entries for sorted sets.
 
 Default value: `128`
 
-##### <a name="-redis--zset_max_ziplist_value"></a>`zset_max_ziplist_value`
+##### <a name="zset_max_ziplist_value"></a>`zset_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -1160,15 +1176,15 @@ Set max values for sorted sets.
 
 Default value: `64`
 
-##### <a name="-redis--cluster_enabled"></a>`cluster_enabled`
+##### <a name="cluster_enabled"></a>`cluster_enabled`
 
 Data type: `Boolean`
 
 Enables redis 3.0 cluster functionality
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--cluster_config_file"></a>`cluster_config_file`
+##### <a name="cluster_config_file"></a>`cluster_config_file`
 
 Data type: `String[1]`
 
@@ -1177,7 +1193,7 @@ touched by humans. Only set if cluster_enabled is true
 
 Default value: `'nodes.conf'`
 
-##### <a name="-redis--cluster_node_timeout"></a>`cluster_node_timeout`
+##### <a name="cluster_node_timeout"></a>`cluster_node_timeout`
 
 Data type: `Integer[1]`
 
@@ -1185,7 +1201,7 @@ Node timeout. Only set if cluster_enabled is true
 
 Default value: `5000`
 
-##### <a name="-redis--cluster_slave_validity_factor"></a>`cluster_slave_validity_factor`
+##### <a name="cluster_slave_validity_factor"></a>`cluster_slave_validity_factor`
 
 Data type: `Integer[0]`
 
@@ -1194,16 +1210,16 @@ Only set if cluster_enabled is true
 
 Default value: `0`
 
-##### <a name="-redis--cluster_require_full_coverage"></a>`cluster_require_full_coverage`
+##### <a name="cluster_require_full_coverage"></a>`cluster_require_full_coverage`
 
 Data type: `Boolean`
 
 If false Redis Cluster will server queries even if requests about a subset of keys can be processed
 Only set if cluster_enabled is true
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--cluster_migration_barrier"></a>`cluster_migration_barrier`
+##### <a name="cluster_migration_barrier"></a>`cluster_migration_barrier`
 
 Data type: `Integer[0]`
 
@@ -1213,7 +1229,7 @@ Only set if cluster_enabled is true
 
 Default value: `1`
 
-##### <a name="-redis--instances"></a>`instances`
+##### <a name="instances"></a>`instances`
 
 Data type: `Hash[String[1], Hash]`
 
@@ -1221,39 +1237,39 @@ Iterate through multiple instance configurations
 
 Default value: `{}`
 
-##### <a name="-redis--io_threads"></a>`io_threads`
+##### <a name="io_threads"></a>`io_threads`
 
 Data type: `Optional[Integer[1]]`
 
 Number of threads to handle IO operations in Redis
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--io_threads_do_reads"></a>`io_threads_do_reads`
+##### <a name="io_threads_do_reads"></a>`io_threads_do_reads`
 
 Data type: `Optional[Boolean]`
 
 Enabled/disable io_threads to handle reads
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--cluster_allow_reads_when_down"></a>`cluster_allow_reads_when_down`
+##### <a name="cluster_allow_reads_when_down"></a>`cluster_allow_reads_when_down`
 
 Data type: `Optional[Boolean]`
 
 Allows nodes to serve read data while cluster status is down
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--cluster_replica_no_failover"></a>`cluster_replica_no_failover`
+##### <a name="cluster_replica_no_failover"></a>`cluster_replica_no_failover`
 
 Data type: `Optional[Boolean]`
 
 Disabled automatic failover for replica
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--dynamic_hz"></a>`dynamic_hz`
+##### <a name="dynamic_hz"></a>`dynamic_hz`
 
 Data type: `Optional[Boolean]`
 
@@ -1261,17 +1277,17 @@ When dynamic HZ is enabled, the actual configured HZ will be used
 as a baseline, but multiples of the configured HZ value will be actually
 used as needed once more clients are connected.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--activedefrag"></a>`activedefrag`
+##### <a name="activedefrag"></a>`activedefrag`
 
 Data type: `Optional[Boolean]`
 
 Enable/disable active defragmentation
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--active_defrag_ignore_bytes"></a>`active_defrag_ignore_bytes`
+##### <a name="active_defrag_ignore_bytes"></a>`active_defrag_ignore_bytes`
 
 Data type: `String[1]`
 
@@ -1280,7 +1296,7 @@ Only set if activedefrag is true
 
 Default value: `'100mb'`
 
-##### <a name="-redis--active_defrag_threshold_lower"></a>`active_defrag_threshold_lower`
+##### <a name="active_defrag_threshold_lower"></a>`active_defrag_threshold_lower`
 
 Data type: `Integer[1, 100]`
 
@@ -1289,7 +1305,7 @@ Only set if activedefrag is true
 
 Default value: `10`
 
-##### <a name="-redis--active_defrag_threshold_upper"></a>`active_defrag_threshold_upper`
+##### <a name="active_defrag_threshold_upper"></a>`active_defrag_threshold_upper`
 
 Data type: `Integer[1, 100]`
 
@@ -1298,7 +1314,7 @@ Only set if activedefrag is true
 
 Default value: `100`
 
-##### <a name="-redis--active_defrag_cycle_min"></a>`active_defrag_cycle_min`
+##### <a name="active_defrag_cycle_min"></a>`active_defrag_cycle_min`
 
 Data type: `Integer[1, 100]`
 
@@ -1308,7 +1324,7 @@ Only set if activedefrag is true
 
 Default value: `1`
 
-##### <a name="-redis--active_defrag_cycle_max"></a>`active_defrag_cycle_max`
+##### <a name="active_defrag_cycle_max"></a>`active_defrag_cycle_max`
 
 Data type: `Integer[1, 100]`
 
@@ -1318,7 +1334,7 @@ Only set if activedefrag is true
 
 Default value: `100`
 
-##### <a name="-redis--active_defrag_max_scan_fields"></a>`active_defrag_max_scan_fields`
+##### <a name="active_defrag_max_scan_fields"></a>`active_defrag_max_scan_fields`
 
 Data type: `Integer[1]`
 
@@ -1328,57 +1344,41 @@ Only set if activedefrag is true
 
 Default value: `1000`
 
-##### <a name="-redis--jemalloc_bg_thread"></a>`jemalloc_bg_thread`
+##### <a name="jemalloc_bg_thread"></a>`jemalloc_bg_thread`
 
 Data type: `Optional[Boolean]`
 
 Jemalloc background thread for purging will be enabled by default
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--rdb_save_incremental_fsync"></a>`rdb_save_incremental_fsync`
+##### <a name="rdb_save_incremental_fsync"></a>`rdb_save_incremental_fsync`
 
 Data type: `Optional[Boolean]`
 
 When redis saves RDB file, if the following option is enabled
 the file will be fsync-ed every 32 MB of data generated.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--dnf_module_stream"></a>`dnf_module_stream`
+##### <a name="dnf_module_stream"></a>`dnf_module_stream`
 
 Data type: `Optional[String[1]]`
 
 Manage the DNF module and set the version. This only makes sense on distributions
 that use DNF package manager, such as EL8 or Fedora.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--output_buffer_limit_slave"></a>`output_buffer_limit_slave`
-
-Data type: `String[1]`
-
-
-
-Default value: `'256mb 64mb 60'`
-
-##### <a name="-redis--output_buffer_limit_pubsub"></a>`output_buffer_limit_pubsub`
-
-Data type: `String[1]`
-
-
-
-Default value: `'32mb 8mb 60'`
-
-##### <a name="-redis--manage_service_file"></a>`manage_service_file`
+##### <a name="manage_service_file"></a>`manage_service_file`
 
 Data type: `Boolean`
 
+Determine if the systemd service file should be managed
 
+Default value: ``false``
 
-Default value: `false`
-
-### <a name="redis--administration"></a>`redis::administration`
+### <a name="redisadministration"></a>`redis::administration`
 
 As documented in the FAQ and https://redis.io/topics/admin.
 For disabling Transparent Huge Pages (THP), use separate module such as:
@@ -1410,18 +1410,18 @@ class {'redis::administration':
 
 The following parameters are available in the `redis::administration` class:
 
-* [`enable_overcommit_memory`](#-redis--administration--enable_overcommit_memory)
-* [`somaxconn`](#-redis--administration--somaxconn)
+* [`enable_overcommit_memory`](#enable_overcommit_memory)
+* [`somaxconn`](#somaxconn)
 
-##### <a name="-redis--administration--enable_overcommit_memory"></a>`enable_overcommit_memory`
+##### <a name="enable_overcommit_memory"></a>`enable_overcommit_memory`
 
 Data type: `Boolean`
 
 Enable the overcommit memory setting
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--administration--somaxconn"></a>`somaxconn`
+##### <a name="somaxconn"></a>`somaxconn`
 
 Data type: `Integer[0]`
 
@@ -1429,7 +1429,7 @@ Set somaxconn value
 
 Default value: `65535`
 
-### <a name="redis--globals"></a>`redis::globals`
+### <a name="redisglobals"></a>`redis::globals`
 
 Set a global config for Redis
 
@@ -1437,17 +1437,17 @@ Set a global config for Redis
 
 The following parameters are available in the `redis::globals` class:
 
-* [`scl`](#-redis--globals--scl)
+* [`scl`](#scl)
 
-##### <a name="-redis--globals--scl"></a>`scl`
+##### <a name="scl"></a>`scl`
 
 Data type: `Optional[String]`
 
 Use a specific Software Collection on Red Hat 7 based systems
 
-Default value: `undef`
+Default value: ``undef``
 
-### <a name="redis--sentinel"></a>`redis::sentinel`
+### <a name="redissentinel"></a>`redis::sentinel`
 
 Install redis-sentinel
 
@@ -1472,56 +1472,56 @@ class {'redis::sentinel':
 
 The following parameters are available in the `redis::sentinel` class:
 
-* [`auth_pass`](#-redis--sentinel--auth_pass)
-* [`config_file`](#-redis--sentinel--config_file)
-* [`config_file_orig`](#-redis--sentinel--config_file_orig)
-* [`config_file_mode`](#-redis--sentinel--config_file_mode)
-* [`conf_template`](#-redis--sentinel--conf_template)
-* [`daemonize`](#-redis--sentinel--daemonize)
-* [`down_after`](#-redis--sentinel--down_after)
-* [`failover_timeout`](#-redis--sentinel--failover_timeout)
-* [`log_file`](#-redis--sentinel--log_file)
-* [`log_level`](#-redis--sentinel--log_level)
-* [`master_name`](#-redis--sentinel--master_name)
-* [`redis_host`](#-redis--sentinel--redis_host)
-* [`redis_port`](#-redis--sentinel--redis_port)
-* [`requirepass`](#-redis--sentinel--requirepass)
-* [`protected_mode`](#-redis--sentinel--protected_mode)
-* [`package_name`](#-redis--sentinel--package_name)
-* [`package_ensure`](#-redis--sentinel--package_ensure)
-* [`parallel_sync`](#-redis--sentinel--parallel_sync)
-* [`pid_file`](#-redis--sentinel--pid_file)
-* [`quorum`](#-redis--sentinel--quorum)
-* [`sentinel_announce_hostnames`](#-redis--sentinel--sentinel_announce_hostnames)
-* [`sentinel_announce_ip`](#-redis--sentinel--sentinel_announce_ip)
-* [`sentinel_bind`](#-redis--sentinel--sentinel_bind)
-* [`sentinel_port`](#-redis--sentinel--sentinel_port)
-* [`sentinel_resolve_hostnames`](#-redis--sentinel--sentinel_resolve_hostnames)
-* [`sentinel_tls_port`](#-redis--sentinel--sentinel_tls_port)
-* [`service_group`](#-redis--sentinel--service_group)
-* [`service_name`](#-redis--sentinel--service_name)
-* [`service_user`](#-redis--sentinel--service_user)
-* [`service_enable`](#-redis--sentinel--service_enable)
-* [`tls_cert_file`](#-redis--sentinel--tls_cert_file)
-* [`tls_key_file`](#-redis--sentinel--tls_key_file)
-* [`tls_ca_cert_file`](#-redis--sentinel--tls_ca_cert_file)
-* [`tls_ca_cert_dir`](#-redis--sentinel--tls_ca_cert_dir)
-* [`tls_auth_clients`](#-redis--sentinel--tls_auth_clients)
-* [`tls_replication`](#-redis--sentinel--tls_replication)
-* [`working_dir`](#-redis--sentinel--working_dir)
-* [`notification_script`](#-redis--sentinel--notification_script)
-* [`client_reconfig_script`](#-redis--sentinel--client_reconfig_script)
-* [`service_ensure`](#-redis--sentinel--service_ensure)
+* [`auth_pass`](#auth_pass)
+* [`config_file`](#config_file)
+* [`config_file_orig`](#config_file_orig)
+* [`config_file_mode`](#config_file_mode)
+* [`conf_template`](#conf_template)
+* [`daemonize`](#daemonize)
+* [`down_after`](#down_after)
+* [`failover_timeout`](#failover_timeout)
+* [`log_file`](#log_file)
+* [`log_level`](#log_level)
+* [`master_name`](#master_name)
+* [`redis_host`](#redis_host)
+* [`redis_port`](#redis_port)
+* [`requirepass`](#requirepass)
+* [`protected_mode`](#protected_mode)
+* [`package_name`](#package_name)
+* [`package_ensure`](#package_ensure)
+* [`parallel_sync`](#parallel_sync)
+* [`pid_file`](#pid_file)
+* [`quorum`](#quorum)
+* [`sentinel_announce_hostnames`](#sentinel_announce_hostnames)
+* [`sentinel_announce_ip`](#sentinel_announce_ip)
+* [`sentinel_bind`](#sentinel_bind)
+* [`sentinel_port`](#sentinel_port)
+* [`sentinel_resolve_hostnames`](#sentinel_resolve_hostnames)
+* [`sentinel_tls_port`](#sentinel_tls_port)
+* [`service_group`](#service_group)
+* [`service_name`](#service_name)
+* [`service_user`](#service_user)
+* [`service_enable`](#service_enable)
+* [`tls_cert_file`](#tls_cert_file)
+* [`tls_key_file`](#tls_key_file)
+* [`tls_ca_cert_file`](#tls_ca_cert_file)
+* [`tls_ca_cert_dir`](#tls_ca_cert_dir)
+* [`tls_auth_clients`](#tls_auth_clients)
+* [`tls_replication`](#tls_replication)
+* [`working_dir`](#working_dir)
+* [`notification_script`](#notification_script)
+* [`client_reconfig_script`](#client_reconfig_script)
+* [`service_ensure`](#service_ensure)
 
-##### <a name="-redis--sentinel--auth_pass"></a>`auth_pass`
+##### <a name="auth_pass"></a>`auth_pass`
 
 Data type: `Optional[Variant[String[1], Sensitive[String[1]]]]`
 
 The password to use to authenticate with the master and slaves.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--config_file"></a>`config_file`
+##### <a name="config_file"></a>`config_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1529,7 +1529,7 @@ The location and name of the sentinel config file.
 
 Default value: `$redis::params::sentinel_config_file`
 
-##### <a name="-redis--sentinel--config_file_orig"></a>`config_file_orig`
+##### <a name="config_file_orig"></a>`config_file_orig`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1541,7 +1541,7 @@ changes from the manifests.
 
 Default value: `$redis::params::sentinel_config_file_orig`
 
-##### <a name="-redis--sentinel--config_file_mode"></a>`config_file_mode`
+##### <a name="config_file_mode"></a>`config_file_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -1549,7 +1549,7 @@ Permissions of config file.
 
 Default value: `'0644'`
 
-##### <a name="-redis--sentinel--conf_template"></a>`conf_template`
+##### <a name="conf_template"></a>`conf_template`
 
 Data type: `String[1]`
 
@@ -1557,7 +1557,7 @@ Define which template to use.
 
 Default value: `'redis/redis-sentinel.conf.erb'`
 
-##### <a name="-redis--sentinel--daemonize"></a>`daemonize`
+##### <a name="daemonize"></a>`daemonize`
 
 Data type: `Boolean`
 
@@ -1565,7 +1565,7 @@ Have Redis sentinel run as a daemon.
 
 Default value: `$redis::params::sentinel_daemonize`
 
-##### <a name="-redis--sentinel--down_after"></a>`down_after`
+##### <a name="down_after"></a>`down_after`
 
 Data type: `Integer[1]`
 
@@ -1575,7 +1575,7 @@ for the specified period) in order to consider it in S_DOWN state.
 
 Default value: `30000`
 
-##### <a name="-redis--sentinel--failover_timeout"></a>`failover_timeout`
+##### <a name="failover_timeout"></a>`failover_timeout`
 
 Data type: `Integer[1]`
 
@@ -1583,7 +1583,7 @@ Specify the failover timeout in milliseconds.
 
 Default value: `180000`
 
-##### <a name="-redis--sentinel--log_file"></a>`log_file`
+##### <a name="log_file"></a>`log_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1591,7 +1591,7 @@ Specify where to write log entries.
 
 Default value: `$redis::params::sentinel_log_file`
 
-##### <a name="-redis--sentinel--log_level"></a>`log_level`
+##### <a name="log_level"></a>`log_level`
 
 Data type: `Redis::LogLevel`
 
@@ -1599,7 +1599,7 @@ Specify how much we should log.
 
 Default value: `'notice'`
 
-##### <a name="-redis--sentinel--master_name"></a>`master_name`
+##### <a name="master_name"></a>`master_name`
 
 Data type: `String[1]`
 
@@ -1608,7 +1608,7 @@ The valid charset is A-z 0-9 and the three characters ".-_".
 
 Default value: `'mymaster'`
 
-##### <a name="-redis--sentinel--redis_host"></a>`redis_host`
+##### <a name="redis_host"></a>`redis_host`
 
 Data type: `Stdlib::Host`
 
@@ -1616,7 +1616,7 @@ Specify the bound host of the master redis server.
 
 Default value: `'127.0.0.1'`
 
-##### <a name="-redis--sentinel--redis_port"></a>`redis_port`
+##### <a name="redis_port"></a>`redis_port`
 
 Data type: `Stdlib::Port`
 
@@ -1624,23 +1624,23 @@ Specify the port of the master redis server.
 
 Default value: `6379`
 
-##### <a name="-redis--sentinel--requirepass"></a>`requirepass`
+##### <a name="requirepass"></a>`requirepass`
 
 Data type: `Optional[String[1]]`
 
 Specify the password to require client authentication via the AUTH command, however this feature is only available starting with Redis 5.0.1.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--protected_mode"></a>`protected_mode`
+##### <a name="protected_mode"></a>`protected_mode`
 
 Data type: `Boolean`
 
 Whether protected mode is enabled or not. Only applicable when no bind is set.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--sentinel--package_name"></a>`package_name`
+##### <a name="package_name"></a>`package_name`
 
 Data type: `String[1]`
 
@@ -1648,7 +1648,7 @@ The name of the package that installs sentinel.
 
 Default value: `$redis::params::sentinel_package_name`
 
-##### <a name="-redis--sentinel--package_ensure"></a>`package_ensure`
+##### <a name="package_ensure"></a>`package_ensure`
 
 Data type: `String[1]`
 
@@ -1657,7 +1657,7 @@ an independent package is required for sentinel.
 
 Default value: `'installed'`
 
-##### <a name="-redis--sentinel--parallel_sync"></a>`parallel_sync`
+##### <a name="parallel_sync"></a>`parallel_sync`
 
 Data type: `Integer[0]`
 
@@ -1666,7 +1666,7 @@ new master after a failover.
 
 Default value: `1`
 
-##### <a name="-redis--sentinel--pid_file"></a>`pid_file`
+##### <a name="pid_file"></a>`pid_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1674,7 +1674,7 @@ If sentinel is daemonized it will write its pid at this location.
 
 Default value: `$redis::params::sentinel_pid_file`
 
-##### <a name="-redis--sentinel--quorum"></a>`quorum`
+##### <a name="quorum"></a>`quorum`
 
 Data type: `Integer[1]`
 
@@ -1683,33 +1683,33 @@ signal sdown state.
 
 Default value: `2`
 
-##### <a name="-redis--sentinel--sentinel_announce_hostnames"></a>`sentinel_announce_hostnames`
+##### <a name="sentinel_announce_hostnames"></a>`sentinel_announce_hostnames`
 
 Data type: `Optional[Enum['yes', 'no']]`
 
 Whether or not sentinels will announce hostnames instead of ip addresses
 to clients.  This can be required for TLS.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--sentinel_announce_ip"></a>`sentinel_announce_ip`
+##### <a name="sentinel_announce_ip"></a>`sentinel_announce_ip`
 
 Data type: `Optional[Stdlib::Host]`
 
 Specify the IP or hostname that Sentinel will announce
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--sentinel_bind"></a>`sentinel_bind`
+##### <a name="sentinel_bind"></a>`sentinel_bind`
 
 Data type: `Variant[Undef, Stdlib::IP::Address, Array[Stdlib::IP::Address]]`
 
 Allow optional sentinel server ip binding.  Can help overcome
 issues arising from protect-mode added Redis 3.2
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--sentinel_port"></a>`sentinel_port`
+##### <a name="sentinel_port"></a>`sentinel_port`
 
 Data type: `Stdlib::Port`
 
@@ -1717,23 +1717,23 @@ The port of sentinel server.
 
 Default value: `26379`
 
-##### <a name="-redis--sentinel--sentinel_resolve_hostnames"></a>`sentinel_resolve_hostnames`
+##### <a name="sentinel_resolve_hostnames"></a>`sentinel_resolve_hostnames`
 
 Data type: `Optional[Enum['yes', 'no']]`
 
 Whether or not sentinels can resolve hostnames to ip addresses.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--sentinel_tls_port"></a>`sentinel_tls_port`
+##### <a name="sentinel_tls_port"></a>`sentinel_tls_port`
 
 Data type: `Optional[Stdlib::Port::Unprivileged]`
 
 Configure which TLS port to listen on.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--service_group"></a>`service_group`
+##### <a name="service_group"></a>`service_group`
 
 Data type: `String[1]`
 
@@ -1741,7 +1741,7 @@ The group of the config file.
 
 Default value: `'redis'`
 
-##### <a name="-redis--sentinel--service_name"></a>`service_name`
+##### <a name="service_name"></a>`service_name`
 
 Data type: `String[1]`
 
@@ -1749,7 +1749,7 @@ The name of the service (for puppet to manage).
 
 Default value: `$redis::params::sentinel_service_name`
 
-##### <a name="-redis--sentinel--service_user"></a>`service_user`
+##### <a name="service_user"></a>`service_user`
 
 Data type: `String[1]`
 
@@ -1757,47 +1757,47 @@ The owner of the config file.
 
 Default value: `'redis'`
 
-##### <a name="-redis--sentinel--service_enable"></a>`service_enable`
+##### <a name="service_enable"></a>`service_enable`
 
 Data type: `Boolean`
 
 Enable the service at boot time.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--sentinel--tls_cert_file"></a>`tls_cert_file`
+##### <a name="tls_cert_file"></a>`tls_cert_file`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
 Specify which X.509 certificate file to use for TLS connections.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--tls_key_file"></a>`tls_key_file`
+##### <a name="tls_key_file"></a>`tls_key_file`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
 Specify which privaye key file to use for TLS connections.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--tls_ca_cert_file"></a>`tls_ca_cert_file`
+##### <a name="tls_ca_cert_file"></a>`tls_ca_cert_file`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
 Specify which X.509 CA certificate(s) bundle file to use.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--tls_ca_cert_dir"></a>`tls_ca_cert_dir`
+##### <a name="tls_ca_cert_dir"></a>`tls_ca_cert_dir`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
 Specify which X.509 CA certificate(s) bundle directory to use.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--tls_auth_clients"></a>`tls_auth_clients`
+##### <a name="tls_auth_clients"></a>`tls_auth_clients`
 
 Data type: `Enum['yes', 'no', 'optional']`
 
@@ -1805,15 +1805,15 @@ Specify if clients and replicas are required to authenticate using valid client 
 
 Default value: `'no'`
 
-##### <a name="-redis--sentinel--tls_replication"></a>`tls_replication`
+##### <a name="tls_replication"></a>`tls_replication`
 
 Data type: `Boolean`
 
 Specify if TLS should be enabled on replication links.
 
-Default value: `false`
+Default value: ``false``
 
-##### <a name="-redis--sentinel--working_dir"></a>`working_dir`
+##### <a name="working_dir"></a>`working_dir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -1822,23 +1822,23 @@ conflicts.
 
 Default value: `$redis::params::sentinel_working_dir`
 
-##### <a name="-redis--sentinel--notification_script"></a>`notification_script`
+##### <a name="notification_script"></a>`notification_script`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
 Path to the notification script
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--client_reconfig_script"></a>`client_reconfig_script`
+##### <a name="client_reconfig_script"></a>`client_reconfig_script`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
 Path to the client-reconfig script
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-redis--sentinel--service_ensure"></a>`service_ensure`
+##### <a name="service_ensure"></a>`service_ensure`
 
 Data type: `Stdlib::Ensure::Service`
 
@@ -1848,7 +1848,7 @@ Default value: `'running'`
 
 ## Defined types
 
-### <a name="redis--instance"></a>`redis::instance`
+### <a name="redisinstance"></a>`redis::instance`
 
 This is an defined type to allow the configuration of
 multiple redis instances on one machine without conflicts
@@ -1867,129 +1867,129 @@ redis::instance {'6380':
 
 The following parameters are available in the `redis::instance` defined type:
 
-* [`activerehashing`](#-redis--instance--activerehashing)
-* [`aof_load_truncated`](#-redis--instance--aof_load_truncated)
-* [`aof_rewrite_incremental_fsync`](#-redis--instance--aof_rewrite_incremental_fsync)
-* [`appendfilename`](#-redis--instance--appendfilename)
-* [`appendfsync`](#-redis--instance--appendfsync)
-* [`appendonly`](#-redis--instance--appendonly)
-* [`auto_aof_rewrite_min_size`](#-redis--instance--auto_aof_rewrite_min_size)
-* [`auto_aof_rewrite_percentage`](#-redis--instance--auto_aof_rewrite_percentage)
-* [`bind`](#-redis--instance--bind)
-* [`config_file_orig`](#-redis--instance--config_file_orig)
-* [`config_file`](#-redis--instance--config_file)
-* [`config_file_mode`](#-redis--instance--config_file_mode)
-* [`config_group`](#-redis--instance--config_group)
-* [`config_owner`](#-redis--instance--config_owner)
-* [`conf_template`](#-redis--instance--conf_template)
-* [`daemonize`](#-redis--instance--daemonize)
-* [`databases`](#-redis--instance--databases)
-* [`dbfilename`](#-redis--instance--dbfilename)
-* [`extra_config_file`](#-redis--instance--extra_config_file)
-* [`hash_max_ziplist_entries`](#-redis--instance--hash_max_ziplist_entries)
-* [`hash_max_ziplist_value`](#-redis--instance--hash_max_ziplist_value)
-* [`hll_sparse_max_bytes`](#-redis--instance--hll_sparse_max_bytes)
-* [`hz`](#-redis--instance--hz)
-* [`latency_monitor_threshold`](#-redis--instance--latency_monitor_threshold)
-* [`list_max_ziplist_entries`](#-redis--instance--list_max_ziplist_entries)
-* [`list_max_ziplist_value`](#-redis--instance--list_max_ziplist_value)
-* [`log_dir`](#-redis--instance--log_dir)
-* [`log_dir_mode`](#-redis--instance--log_dir_mode)
-* [`log_file`](#-redis--instance--log_file)
-* [`log_level`](#-redis--instance--log_level)
-* [`masterauth`](#-redis--instance--masterauth)
-* [`maxclients`](#-redis--instance--maxclients)
-* [`maxmemory`](#-redis--instance--maxmemory)
-* [`maxmemory_policy`](#-redis--instance--maxmemory_policy)
-* [`maxmemory_samples`](#-redis--instance--maxmemory_samples)
-* [`min_slaves_max_lag`](#-redis--instance--min_slaves_max_lag)
-* [`min_slaves_to_write`](#-redis--instance--min_slaves_to_write)
-* [`modules`](#-redis--instance--modules)
-* [`no_appendfsync_on_rewrite`](#-redis--instance--no_appendfsync_on_rewrite)
-* [`notify_keyspace_events`](#-redis--instance--notify_keyspace_events)
-* [`notify_service`](#-redis--instance--notify_service)
-* [`pid_file`](#-redis--instance--pid_file)
-* [`port`](#-redis--instance--port)
-* [`protected_mode`](#-redis--instance--protected_mode)
-* [`rdbcompression`](#-redis--instance--rdbcompression)
-* [`rename_commands`](#-redis--instance--rename_commands)
-* [`repl_announce_ip`](#-redis--instance--repl_announce_ip)
-* [`repl_announce_port`](#-redis--instance--repl_announce_port)
-* [`repl_backlog_size`](#-redis--instance--repl_backlog_size)
-* [`repl_backlog_ttl`](#-redis--instance--repl_backlog_ttl)
-* [`repl_disable_tcp_nodelay`](#-redis--instance--repl_disable_tcp_nodelay)
-* [`repl_ping_slave_period`](#-redis--instance--repl_ping_slave_period)
-* [`repl_timeout`](#-redis--instance--repl_timeout)
-* [`requirepass`](#-redis--instance--requirepass)
-* [`save_db_to_disk`](#-redis--instance--save_db_to_disk)
-* [`save_db_to_disk_interval`](#-redis--instance--save_db_to_disk_interval)
-* [`service_name`](#-redis--instance--service_name)
-* [`service_enable`](#-redis--instance--service_enable)
-* [`service_ensure`](#-redis--instance--service_ensure)
-* [`service_group`](#-redis--instance--service_group)
-* [`service_user`](#-redis--instance--service_user)
-* [`service_timeout_start`](#-redis--instance--service_timeout_start)
-* [`service_timeout_stop`](#-redis--instance--service_timeout_stop)
-* [`set_max_intset_entries`](#-redis--instance--set_max_intset_entries)
-* [`slave_priority`](#-redis--instance--slave_priority)
-* [`slave_read_only`](#-redis--instance--slave_read_only)
-* [`slave_serve_stale_data`](#-redis--instance--slave_serve_stale_data)
-* [`slaveof`](#-redis--instance--slaveof)
-* [`replicaof`](#-redis--instance--replicaof)
-* [`slowlog_log_slower_than`](#-redis--instance--slowlog_log_slower_than)
-* [`slowlog_max_len`](#-redis--instance--slowlog_max_len)
-* [`stop_writes_on_bgsave_error`](#-redis--instance--stop_writes_on_bgsave_error)
-* [`syslog_enabled`](#-redis--instance--syslog_enabled)
-* [`syslog_facility`](#-redis--instance--syslog_facility)
-* [`tcp_backlog`](#-redis--instance--tcp_backlog)
-* [`tcp_keepalive`](#-redis--instance--tcp_keepalive)
-* [`timeout`](#-redis--instance--timeout)
-* [`tls_port`](#-redis--instance--tls_port)
-* [`tls_cert_file`](#-redis--instance--tls_cert_file)
-* [`tls_key_file`](#-redis--instance--tls_key_file)
-* [`tls_ca_cert_file`](#-redis--instance--tls_ca_cert_file)
-* [`tls_ca_cert_dir`](#-redis--instance--tls_ca_cert_dir)
-* [`tls_auth_clients`](#-redis--instance--tls_auth_clients)
-* [`tls_replication`](#-redis--instance--tls_replication)
-* [`tls_cluster`](#-redis--instance--tls_cluster)
-* [`tls_ciphers`](#-redis--instance--tls_ciphers)
-* [`tls_ciphersuites`](#-redis--instance--tls_ciphersuites)
-* [`tls_protocols`](#-redis--instance--tls_protocols)
-* [`tls_prefer_server_ciphers`](#-redis--instance--tls_prefer_server_ciphers)
-* [`ulimit`](#-redis--instance--ulimit)
-* [`ulimit_managed`](#-redis--instance--ulimit_managed)
-* [`unixsocket`](#-redis--instance--unixsocket)
-* [`unixsocketperm`](#-redis--instance--unixsocketperm)
-* [`workdir`](#-redis--instance--workdir)
-* [`workdir_mode`](#-redis--instance--workdir_mode)
-* [`zset_max_ziplist_entries`](#-redis--instance--zset_max_ziplist_entries)
-* [`zset_max_ziplist_value`](#-redis--instance--zset_max_ziplist_value)
-* [`cluster_enabled`](#-redis--instance--cluster_enabled)
-* [`cluster_config_file`](#-redis--instance--cluster_config_file)
-* [`cluster_node_timeout`](#-redis--instance--cluster_node_timeout)
-* [`cluster_slave_validity_factor`](#-redis--instance--cluster_slave_validity_factor)
-* [`cluster_require_full_coverage`](#-redis--instance--cluster_require_full_coverage)
-* [`cluster_migration_barrier`](#-redis--instance--cluster_migration_barrier)
-* [`io_threads`](#-redis--instance--io_threads)
-* [`io_threads_do_reads`](#-redis--instance--io_threads_do_reads)
-* [`cluster_allow_reads_when_down`](#-redis--instance--cluster_allow_reads_when_down)
-* [`cluster_replica_no_failover`](#-redis--instance--cluster_replica_no_failover)
-* [`dynamic_hz`](#-redis--instance--dynamic_hz)
-* [`activedefrag`](#-redis--instance--activedefrag)
-* [`active_defrag_ignore_bytes`](#-redis--instance--active_defrag_ignore_bytes)
-* [`active_defrag_threshold_lower`](#-redis--instance--active_defrag_threshold_lower)
-* [`active_defrag_threshold_upper`](#-redis--instance--active_defrag_threshold_upper)
-* [`active_defrag_cycle_min`](#-redis--instance--active_defrag_cycle_min)
-* [`active_defrag_cycle_max`](#-redis--instance--active_defrag_cycle_max)
-* [`active_defrag_max_scan_fields`](#-redis--instance--active_defrag_max_scan_fields)
-* [`jemalloc_bg_thread`](#-redis--instance--jemalloc_bg_thread)
-* [`rdb_save_incremental_fsync`](#-redis--instance--rdb_save_incremental_fsync)
-* [`output_buffer_limit_slave`](#-redis--instance--output_buffer_limit_slave)
-* [`output_buffer_limit_pubsub`](#-redis--instance--output_buffer_limit_pubsub)
-* [`managed_by_cluster_manager`](#-redis--instance--managed_by_cluster_manager)
-* [`manage_service_file`](#-redis--instance--manage_service_file)
+* [`activerehashing`](#activerehashing)
+* [`aof_load_truncated`](#aof_load_truncated)
+* [`aof_rewrite_incremental_fsync`](#aof_rewrite_incremental_fsync)
+* [`appendfilename`](#appendfilename)
+* [`appendfsync`](#appendfsync)
+* [`appendonly`](#appendonly)
+* [`auto_aof_rewrite_min_size`](#auto_aof_rewrite_min_size)
+* [`auto_aof_rewrite_percentage`](#auto_aof_rewrite_percentage)
+* [`bind`](#bind)
+* [`config_file_orig`](#config_file_orig)
+* [`config_file`](#config_file)
+* [`config_file_mode`](#config_file_mode)
+* [`config_group`](#config_group)
+* [`config_owner`](#config_owner)
+* [`conf_template`](#conf_template)
+* [`daemonize`](#daemonize)
+* [`databases`](#databases)
+* [`dbfilename`](#dbfilename)
+* [`extra_config_file`](#extra_config_file)
+* [`hash_max_ziplist_entries`](#hash_max_ziplist_entries)
+* [`hash_max_ziplist_value`](#hash_max_ziplist_value)
+* [`hll_sparse_max_bytes`](#hll_sparse_max_bytes)
+* [`hz`](#hz)
+* [`latency_monitor_threshold`](#latency_monitor_threshold)
+* [`list_max_ziplist_entries`](#list_max_ziplist_entries)
+* [`list_max_ziplist_value`](#list_max_ziplist_value)
+* [`log_dir`](#log_dir)
+* [`log_dir_mode`](#log_dir_mode)
+* [`log_file`](#log_file)
+* [`log_level`](#log_level)
+* [`managed_by_cluster_manager`](#managed_by_cluster_manager)
+* [`manage_service_file`](#manage_service_file)
+* [`masterauth`](#masterauth)
+* [`maxclients`](#maxclients)
+* [`maxmemory`](#maxmemory)
+* [`maxmemory_policy`](#maxmemory_policy)
+* [`maxmemory_samples`](#maxmemory_samples)
+* [`min_slaves_max_lag`](#min_slaves_max_lag)
+* [`min_slaves_to_write`](#min_slaves_to_write)
+* [`modules`](#modules)
+* [`no_appendfsync_on_rewrite`](#no_appendfsync_on_rewrite)
+* [`notify_keyspace_events`](#notify_keyspace_events)
+* [`notify_service`](#notify_service)
+* [`pid_file`](#pid_file)
+* [`port`](#port)
+* [`protected_mode`](#protected_mode)
+* [`rdbcompression`](#rdbcompression)
+* [`rename_commands`](#rename_commands)
+* [`repl_announce_ip`](#repl_announce_ip)
+* [`repl_announce_port`](#repl_announce_port)
+* [`repl_backlog_size`](#repl_backlog_size)
+* [`repl_backlog_ttl`](#repl_backlog_ttl)
+* [`repl_disable_tcp_nodelay`](#repl_disable_tcp_nodelay)
+* [`repl_ping_slave_period`](#repl_ping_slave_period)
+* [`repl_timeout`](#repl_timeout)
+* [`requirepass`](#requirepass)
+* [`save_db_to_disk`](#save_db_to_disk)
+* [`save_db_to_disk_interval`](#save_db_to_disk_interval)
+* [`service_name`](#service_name)
+* [`service_enable`](#service_enable)
+* [`service_ensure`](#service_ensure)
+* [`service_group`](#service_group)
+* [`service_user`](#service_user)
+* [`service_timeout_start`](#service_timeout_start)
+* [`service_timeout_stop`](#service_timeout_stop)
+* [`set_max_intset_entries`](#set_max_intset_entries)
+* [`slave_priority`](#slave_priority)
+* [`slave_read_only`](#slave_read_only)
+* [`slave_serve_stale_data`](#slave_serve_stale_data)
+* [`slaveof`](#slaveof)
+* [`replicaof`](#replicaof)
+* [`slowlog_log_slower_than`](#slowlog_log_slower_than)
+* [`slowlog_max_len`](#slowlog_max_len)
+* [`stop_writes_on_bgsave_error`](#stop_writes_on_bgsave_error)
+* [`syslog_enabled`](#syslog_enabled)
+* [`syslog_facility`](#syslog_facility)
+* [`tcp_backlog`](#tcp_backlog)
+* [`tcp_keepalive`](#tcp_keepalive)
+* [`timeout`](#timeout)
+* [`tls_port`](#tls_port)
+* [`tls_cert_file`](#tls_cert_file)
+* [`tls_key_file`](#tls_key_file)
+* [`tls_ca_cert_file`](#tls_ca_cert_file)
+* [`tls_ca_cert_dir`](#tls_ca_cert_dir)
+* [`tls_auth_clients`](#tls_auth_clients)
+* [`tls_replication`](#tls_replication)
+* [`tls_cluster`](#tls_cluster)
+* [`tls_ciphers`](#tls_ciphers)
+* [`tls_ciphersuites`](#tls_ciphersuites)
+* [`tls_protocols`](#tls_protocols)
+* [`tls_prefer_server_ciphers`](#tls_prefer_server_ciphers)
+* [`ulimit`](#ulimit)
+* [`ulimit_managed`](#ulimit_managed)
+* [`unixsocket`](#unixsocket)
+* [`unixsocketperm`](#unixsocketperm)
+* [`workdir`](#workdir)
+* [`workdir_mode`](#workdir_mode)
+* [`zset_max_ziplist_entries`](#zset_max_ziplist_entries)
+* [`zset_max_ziplist_value`](#zset_max_ziplist_value)
+* [`cluster_enabled`](#cluster_enabled)
+* [`cluster_config_file`](#cluster_config_file)
+* [`cluster_node_timeout`](#cluster_node_timeout)
+* [`cluster_slave_validity_factor`](#cluster_slave_validity_factor)
+* [`cluster_require_full_coverage`](#cluster_require_full_coverage)
+* [`cluster_migration_barrier`](#cluster_migration_barrier)
+* [`io_threads`](#io_threads)
+* [`io_threads_do_reads`](#io_threads_do_reads)
+* [`cluster_allow_reads_when_down`](#cluster_allow_reads_when_down)
+* [`cluster_replica_no_failover`](#cluster_replica_no_failover)
+* [`dynamic_hz`](#dynamic_hz)
+* [`activedefrag`](#activedefrag)
+* [`active_defrag_ignore_bytes`](#active_defrag_ignore_bytes)
+* [`active_defrag_threshold_lower`](#active_defrag_threshold_lower)
+* [`active_defrag_threshold_upper`](#active_defrag_threshold_upper)
+* [`active_defrag_cycle_min`](#active_defrag_cycle_min)
+* [`active_defrag_cycle_max`](#active_defrag_cycle_max)
+* [`active_defrag_max_scan_fields`](#active_defrag_max_scan_fields)
+* [`jemalloc_bg_thread`](#jemalloc_bg_thread)
+* [`rdb_save_incremental_fsync`](#rdb_save_incremental_fsync)
+* [`output_buffer_limit_slave`](#output_buffer_limit_slave)
+* [`output_buffer_limit_pubsub`](#output_buffer_limit_pubsub)
 
-##### <a name="-redis--instance--activerehashing"></a>`activerehashing`
+##### <a name="activerehashing"></a>`activerehashing`
 
 Data type: `Boolean`
 
@@ -1997,7 +1997,7 @@ Enable/disable active rehashing.
 
 Default value: `$redis::activerehashing`
 
-##### <a name="-redis--instance--aof_load_truncated"></a>`aof_load_truncated`
+##### <a name="aof_load_truncated"></a>`aof_load_truncated`
 
 Data type: `Boolean`
 
@@ -2005,7 +2005,7 @@ Enable/disable loading truncated AOF file
 
 Default value: `$redis::aof_load_truncated`
 
-##### <a name="-redis--instance--aof_rewrite_incremental_fsync"></a>`aof_rewrite_incremental_fsync`
+##### <a name="aof_rewrite_incremental_fsync"></a>`aof_rewrite_incremental_fsync`
 
 Data type: `Boolean`
 
@@ -2013,7 +2013,7 @@ Enable/disable fsync for AOF file
 
 Default value: `$redis::aof_rewrite_incremental_fsync`
 
-##### <a name="-redis--instance--appendfilename"></a>`appendfilename`
+##### <a name="appendfilename"></a>`appendfilename`
 
 Data type: `String[1]`
 
@@ -2021,7 +2021,7 @@ The name of the append only file
 
 Default value: `$redis::appendfilename`
 
-##### <a name="-redis--instance--appendfsync"></a>`appendfsync`
+##### <a name="appendfsync"></a>`appendfsync`
 
 Data type: `Enum['no', 'always', 'everysec']`
 
@@ -2029,7 +2029,7 @@ Adjust fsync mode. Valid options: always, everysec, no.
 
 Default value: `$redis::appendfsync`
 
-##### <a name="-redis--instance--appendonly"></a>`appendonly`
+##### <a name="appendonly"></a>`appendonly`
 
 Data type: `Boolean`
 
@@ -2037,7 +2037,7 @@ Enable/disable appendonly mode.
 
 Default value: `$redis::appendonly`
 
-##### <a name="-redis--instance--auto_aof_rewrite_min_size"></a>`auto_aof_rewrite_min_size`
+##### <a name="auto_aof_rewrite_min_size"></a>`auto_aof_rewrite_min_size`
 
 Data type: `String[1]`
 
@@ -2045,7 +2045,7 @@ Adjust minimum size for auto-aof-rewrite.
 
 Default value: `$redis::auto_aof_rewrite_min_size`
 
-##### <a name="-redis--instance--auto_aof_rewrite_percentage"></a>`auto_aof_rewrite_percentage`
+##### <a name="auto_aof_rewrite_percentage"></a>`auto_aof_rewrite_percentage`
 
 Data type: `Integer[0]`
 
@@ -2053,7 +2053,7 @@ Adjust percentatge for auto-aof-rewrite.
 
 Default value: `$redis::auto_aof_rewrite_percentage`
 
-##### <a name="-redis--instance--bind"></a>`bind`
+##### <a name="bind"></a>`bind`
 
 Data type: `Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]]`
 
@@ -2061,7 +2061,7 @@ Configure which IP address(es) to listen on. To bind on all interfaces, use an e
 
 Default value: `$redis::bind`
 
-##### <a name="-redis--instance--config_file_orig"></a>`config_file_orig`
+##### <a name="config_file_orig"></a>`config_file_orig`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -2069,7 +2069,7 @@ The location and name of a config file that provides the source
 
 Default value: `$redis::config_file_orig`
 
-##### <a name="-redis--instance--config_file"></a>`config_file`
+##### <a name="config_file"></a>`config_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -2077,7 +2077,7 @@ Adjust main configuration file.
 
 Default value: `$redis::config_file`
 
-##### <a name="-redis--instance--config_file_mode"></a>`config_file_mode`
+##### <a name="config_file_mode"></a>`config_file_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -2085,7 +2085,7 @@ Adjust permissions for configuration files.
 
 Default value: `$redis::config_file_mode`
 
-##### <a name="-redis--instance--config_group"></a>`config_group`
+##### <a name="config_group"></a>`config_group`
 
 Data type: `String[1]`
 
@@ -2093,7 +2093,7 @@ Adjust filesystem group for config files.
 
 Default value: `$redis::config_group`
 
-##### <a name="-redis--instance--config_owner"></a>`config_owner`
+##### <a name="config_owner"></a>`config_owner`
 
 Data type: `String[1]`
 
@@ -2101,7 +2101,7 @@ Adjust filesystem owner for config files.
 
 Default value: `$redis::config_owner`
 
-##### <a name="-redis--instance--conf_template"></a>`conf_template`
+##### <a name="conf_template"></a>`conf_template`
 
 Data type: `String[1]`
 
@@ -2109,15 +2109,15 @@ Define which template to use.
 
 Default value: `$redis::conf_template`
 
-##### <a name="-redis--instance--daemonize"></a>`daemonize`
+##### <a name="daemonize"></a>`daemonize`
 
 Data type: `Boolean`
 
 Have Redis run as a daemon.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--instance--databases"></a>`databases`
+##### <a name="databases"></a>`databases`
 
 Data type: `Integer[1]`
 
@@ -2125,7 +2125,7 @@ Set the number of databases.
 
 Default value: `$redis::databases`
 
-##### <a name="-redis--instance--dbfilename"></a>`dbfilename`
+##### <a name="dbfilename"></a>`dbfilename`
 
 Data type: `Variant[String[1], Boolean]`
 
@@ -2133,7 +2133,7 @@ The filename where to dump the DB
 
 Default value: `$redis::dbfilename`
 
-##### <a name="-redis--instance--extra_config_file"></a>`extra_config_file`
+##### <a name="extra_config_file"></a>`extra_config_file`
 
 Data type: `Optional[String]`
 
@@ -2141,7 +2141,7 @@ Optional extra config file to include
 
 Default value: `$redis::extra_config_file`
 
-##### <a name="-redis--instance--hash_max_ziplist_entries"></a>`hash_max_ziplist_entries`
+##### <a name="hash_max_ziplist_entries"></a>`hash_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -2149,7 +2149,7 @@ Set max ziplist entries for hashes.
 
 Default value: `$redis::hash_max_ziplist_entries`
 
-##### <a name="-redis--instance--hash_max_ziplist_value"></a>`hash_max_ziplist_value`
+##### <a name="hash_max_ziplist_value"></a>`hash_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -2157,7 +2157,7 @@ Set max ziplist values for hashes.
 
 Default value: `$redis::hash_max_ziplist_value`
 
-##### <a name="-redis--instance--hll_sparse_max_bytes"></a>`hll_sparse_max_bytes`
+##### <a name="hll_sparse_max_bytes"></a>`hll_sparse_max_bytes`
 
 Data type: `Integer[0]`
 
@@ -2165,7 +2165,7 @@ HyperLogLog sparse representation bytes limit
 
 Default value: `$redis::hll_sparse_max_bytes`
 
-##### <a name="-redis--instance--hz"></a>`hz`
+##### <a name="hz"></a>`hz`
 
 Data type: `Integer[1, 500]`
 
@@ -2173,7 +2173,7 @@ Set redis background tasks frequency
 
 Default value: `$redis::hz`
 
-##### <a name="-redis--instance--latency_monitor_threshold"></a>`latency_monitor_threshold`
+##### <a name="latency_monitor_threshold"></a>`latency_monitor_threshold`
 
 Data type: `Integer[0]`
 
@@ -2181,7 +2181,7 @@ Latency monitoring threshold in milliseconds
 
 Default value: `$redis::latency_monitor_threshold`
 
-##### <a name="-redis--instance--list_max_ziplist_entries"></a>`list_max_ziplist_entries`
+##### <a name="list_max_ziplist_entries"></a>`list_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -2189,7 +2189,7 @@ Set max ziplist entries for lists.
 
 Default value: `$redis::list_max_ziplist_entries`
 
-##### <a name="-redis--instance--list_max_ziplist_value"></a>`list_max_ziplist_value`
+##### <a name="list_max_ziplist_value"></a>`list_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -2197,7 +2197,7 @@ Set max ziplist values for lists.
 
 Default value: `$redis::list_max_ziplist_value`
 
-##### <a name="-redis--instance--log_dir"></a>`log_dir`
+##### <a name="log_dir"></a>`log_dir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -2205,7 +2205,7 @@ Specify directory where to write log entries.
 
 Default value: `$redis::log_dir`
 
-##### <a name="-redis--instance--log_dir_mode"></a>`log_dir_mode`
+##### <a name="log_dir_mode"></a>`log_dir_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -2213,7 +2213,7 @@ Adjust mode for directory containing log files.
 
 Default value: `$redis::log_dir_mode`
 
-##### <a name="-redis--instance--log_file"></a>`log_file`
+##### <a name="log_file"></a>`log_file`
 
 Data type: `String`
 
@@ -2222,7 +2222,7 @@ with log_dir but absolute paths are also accepted.
 
 Default value: `"redis-server-${name}.log"`
 
-##### <a name="-redis--instance--log_level"></a>`log_level`
+##### <a name="log_level"></a>`log_level`
 
 Data type: `Redis::LogLevel`
 
@@ -2230,7 +2230,23 @@ Specify the server verbosity level.
 
 Default value: `$redis::log_level`
 
-##### <a name="-redis--instance--masterauth"></a>`masterauth`
+##### <a name="managed_by_cluster_manager"></a>`managed_by_cluster_manager`
+
+Data type: `Boolean`
+
+Choose if redis will be managed by a cluster manager such as pacemaker or rgmanager
+
+Default value: `$redis::managed_by_cluster_manager`
+
+##### <a name="manage_service_file"></a>`manage_service_file`
+
+Data type: `Boolean`
+
+Determine if the systemd service file should be managed
+
+Default value: ``true``
+
+##### <a name="masterauth"></a>`masterauth`
 
 Data type: `Optional[Variant[String[1], Sensitive[String[1]], Deferred]]`
 
@@ -2238,7 +2254,7 @@ If the master is password protected (using the "requirepass" configuration
 
 Default value: `$redis::masterauth`
 
-##### <a name="-redis--instance--maxclients"></a>`maxclients`
+##### <a name="maxclients"></a>`maxclients`
 
 Data type: `Integer[1]`
 
@@ -2246,7 +2262,7 @@ Set the max number of connected clients at the same time.
 
 Default value: `$redis::maxclients`
 
-##### <a name="-redis--instance--maxmemory"></a>`maxmemory`
+##### <a name="maxmemory"></a>`maxmemory`
 
 Data type: `Optional[Variant[Integer, String]]`
 
@@ -2254,7 +2270,7 @@ Don't use more memory than the specified amount of bytes.
 
 Default value: `$redis::maxmemory`
 
-##### <a name="-redis--instance--maxmemory_policy"></a>`maxmemory_policy`
+##### <a name="maxmemory_policy"></a>`maxmemory_policy`
 
 Data type: `Optional[Redis::MemoryPolicy]`
 
@@ -2262,7 +2278,7 @@ How Redis will select what to remove when maxmemory is reached.
 
 Default value: `$redis::maxmemory_policy`
 
-##### <a name="-redis--instance--maxmemory_samples"></a>`maxmemory_samples`
+##### <a name="maxmemory_samples"></a>`maxmemory_samples`
 
 Data type: `Optional[Integer[1, 10]]`
 
@@ -2270,7 +2286,7 @@ Select as well the sample size to check.
 
 Default value: `$redis::maxmemory_samples`
 
-##### <a name="-redis--instance--min_slaves_max_lag"></a>`min_slaves_max_lag`
+##### <a name="min_slaves_max_lag"></a>`min_slaves_max_lag`
 
 Data type: `Integer[0]`
 
@@ -2278,7 +2294,7 @@ The lag in seconds
 
 Default value: `$redis::min_slaves_max_lag`
 
-##### <a name="-redis--instance--min_slaves_to_write"></a>`min_slaves_to_write`
+##### <a name="min_slaves_to_write"></a>`min_slaves_to_write`
 
 Data type: `Integer[0]`
 
@@ -2286,7 +2302,7 @@ Minimum number of slaves to be in "online" state
 
 Default value: `$redis::min_slaves_to_write`
 
-##### <a name="-redis--instance--modules"></a>`modules`
+##### <a name="modules"></a>`modules`
 
 Data type: `Array[Stdlib::Absolutepath]`
 
@@ -2294,7 +2310,7 @@ Additional redis modules to load (.so path)
 
 Default value: `$redis::modules`
 
-##### <a name="-redis--instance--no_appendfsync_on_rewrite"></a>`no_appendfsync_on_rewrite`
+##### <a name="no_appendfsync_on_rewrite"></a>`no_appendfsync_on_rewrite`
 
 Data type: `Boolean`
 
@@ -2302,7 +2318,7 @@ If you have latency problems turn this to 'true'. Otherwise leave it as
 
 Default value: `$redis::no_appendfsync_on_rewrite`
 
-##### <a name="-redis--instance--notify_keyspace_events"></a>`notify_keyspace_events`
+##### <a name="notify_keyspace_events"></a>`notify_keyspace_events`
 
 Data type: `Optional[String[1]]`
 
@@ -2310,15 +2326,15 @@ Which events to notify Pub/Sub clients about events happening
 
 Default value: `$redis::notify_keyspace_events`
 
-##### <a name="-redis--instance--notify_service"></a>`notify_service`
+##### <a name="notify_service"></a>`notify_service`
 
 Data type: `Boolean`
 
 You may disable instance service reloads when config file changes
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-redis--instance--pid_file"></a>`pid_file`
+##### <a name="pid_file"></a>`pid_file`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -2326,7 +2342,7 @@ Where to store the pid.
 
 Default value: `"/var/run/${service_name}/redis.pid"`
 
-##### <a name="-redis--instance--port"></a>`port`
+##### <a name="port"></a>`port`
 
 Data type: `Stdlib::Port`
 
@@ -2334,7 +2350,7 @@ Configure which port to listen on.
 
 Default value: `$redis::port`
 
-##### <a name="-redis--instance--protected_mode"></a>`protected_mode`
+##### <a name="protected_mode"></a>`protected_mode`
 
 Data type: `Boolean`
 
@@ -2342,7 +2358,7 @@ Whether protected mode is enabled or not.  Only applicable when no bind is set.
 
 Default value: `$redis::protected_mode`
 
-##### <a name="-redis--instance--rdbcompression"></a>`rdbcompression`
+##### <a name="rdbcompression"></a>`rdbcompression`
 
 Data type: `Boolean`
 
@@ -2350,7 +2366,7 @@ Enable/disable compression of string objects using LZF when dumping.
 
 Default value: `$redis::rdbcompression`
 
-##### <a name="-redis--instance--rename_commands"></a>`rename_commands`
+##### <a name="rename_commands"></a>`rename_commands`
 
 Data type: `Hash[String,String]`
 
@@ -2358,7 +2374,7 @@ A list of Redis commands to rename or disable for security reasons
 
 Default value: `$redis::rename_commands`
 
-##### <a name="-redis--instance--repl_announce_ip"></a>`repl_announce_ip`
+##### <a name="repl_announce_ip"></a>`repl_announce_ip`
 
 Data type: `Optional[Stdlib::Host]`
 
@@ -2366,7 +2382,7 @@ The specific IP or hostname a replica will report to its master
 
 Default value: `$redis::repl_announce_ip`
 
-##### <a name="-redis--instance--repl_announce_port"></a>`repl_announce_port`
+##### <a name="repl_announce_port"></a>`repl_announce_port`
 
 Data type: `Optional[Stdlib::Port]`
 
@@ -2374,7 +2390,7 @@ The specific port a replica will report to its master
 
 Default value: `$redis::repl_announce_port`
 
-##### <a name="-redis--instance--repl_backlog_size"></a>`repl_backlog_size`
+##### <a name="repl_backlog_size"></a>`repl_backlog_size`
 
 Data type: `String[1]`
 
@@ -2382,7 +2398,7 @@ The replication backlog size
 
 Default value: `$redis::repl_backlog_size`
 
-##### <a name="-redis--instance--repl_backlog_ttl"></a>`repl_backlog_ttl`
+##### <a name="repl_backlog_ttl"></a>`repl_backlog_ttl`
 
 Data type: `Integer[0]`
 
@@ -2390,7 +2406,7 @@ The number of seconds to elapse before freeing backlog buffer
 
 Default value: `$redis::repl_backlog_ttl`
 
-##### <a name="-redis--instance--repl_disable_tcp_nodelay"></a>`repl_disable_tcp_nodelay`
+##### <a name="repl_disable_tcp_nodelay"></a>`repl_disable_tcp_nodelay`
 
 Data type: `Boolean`
 
@@ -2398,7 +2414,7 @@ Enable/disable TCP_NODELAY on the slave socket after SYNC
 
 Default value: `$redis::repl_disable_tcp_nodelay`
 
-##### <a name="-redis--instance--repl_ping_slave_period"></a>`repl_ping_slave_period`
+##### <a name="repl_ping_slave_period"></a>`repl_ping_slave_period`
 
 Data type: `Integer[1]`
 
@@ -2406,7 +2422,7 @@ Slaves send PINGs to server in a predefined interval. It's possible
 
 Default value: `$redis::repl_ping_slave_period`
 
-##### <a name="-redis--instance--repl_timeout"></a>`repl_timeout`
+##### <a name="repl_timeout"></a>`repl_timeout`
 
 Data type: `Integer[1]`
 
@@ -2414,7 +2430,7 @@ Set the replication timeout for:
 
 Default value: `$redis::repl_timeout`
 
-##### <a name="-redis--instance--requirepass"></a>`requirepass`
+##### <a name="requirepass"></a>`requirepass`
 
 Data type: `Optional[Variant[String, Deferred]]`
 
@@ -2423,7 +2439,7 @@ commands.
 
 Default value: `$redis::requirepass`
 
-##### <a name="-redis--instance--save_db_to_disk"></a>`save_db_to_disk`
+##### <a name="save_db_to_disk"></a>`save_db_to_disk`
 
 Data type: `Boolean`
 
@@ -2431,7 +2447,7 @@ Set if save db to disk.
 
 Default value: `$redis::save_db_to_disk`
 
-##### <a name="-redis--instance--save_db_to_disk_interval"></a>`save_db_to_disk_interval`
+##### <a name="save_db_to_disk_interval"></a>`save_db_to_disk_interval`
 
 Data type: `Hash`
 
@@ -2439,7 +2455,7 @@ save the dataset every N seconds if there are at least M changes in the dataset
 
 Default value: `$redis::save_db_to_disk_interval`
 
-##### <a name="-redis--instance--service_name"></a>`service_name`
+##### <a name="service_name"></a>`service_name`
 
 Data type: `String[1]`
 
@@ -2447,7 +2463,7 @@ The service name for this instance
 
 Default value: `"redis-server-${name}"`
 
-##### <a name="-redis--instance--service_enable"></a>`service_enable`
+##### <a name="service_enable"></a>`service_enable`
 
 Data type: `Boolean`
 
@@ -2455,7 +2471,7 @@ Enable/disable daemon at boot.
 
 Default value: `$redis::service_enable`
 
-##### <a name="-redis--instance--service_ensure"></a>`service_ensure`
+##### <a name="service_ensure"></a>`service_ensure`
 
 Data type: `Stdlib::Ensure::Service`
 
@@ -2463,7 +2479,7 @@ Specify if the server should be running.
 
 Default value: `$redis::service_ensure`
 
-##### <a name="-redis--instance--service_group"></a>`service_group`
+##### <a name="service_group"></a>`service_group`
 
 Data type: `String[1]`
 
@@ -2471,7 +2487,7 @@ Specify which group to run as.
 
 Default value: `$redis::service_group`
 
-##### <a name="-redis--instance--service_user"></a>`service_user`
+##### <a name="service_user"></a>`service_user`
 
 Data type: `String[1]`
 
@@ -2479,7 +2495,7 @@ Specify which user to run as.
 
 Default value: `$redis::service_user`
 
-##### <a name="-redis--instance--service_timeout_start"></a>`service_timeout_start`
+##### <a name="service_timeout_start"></a>`service_timeout_start`
 
 Data type: `Optional[Integer[0]]`
 
@@ -2487,7 +2503,7 @@ Specify the time after which a service startup should be considered as failed.
 
 Default value: `$redis::service_timeout_start`
 
-##### <a name="-redis--instance--service_timeout_stop"></a>`service_timeout_stop`
+##### <a name="service_timeout_stop"></a>`service_timeout_stop`
 
 Data type: `Optional[Integer[0]]`
 
@@ -2495,7 +2511,7 @@ Specify the time after which a service stop should be considered as failed.
 
 Default value: `$redis::service_timeout_stop`
 
-##### <a name="-redis--instance--set_max_intset_entries"></a>`set_max_intset_entries`
+##### <a name="set_max_intset_entries"></a>`set_max_intset_entries`
 
 Data type: `Integer[0]`
 
@@ -2504,7 +2520,7 @@ in order to use this special memory saving encoding.
 
 Default value: `$redis::set_max_intset_entries`
 
-##### <a name="-redis--instance--slave_priority"></a>`slave_priority`
+##### <a name="slave_priority"></a>`slave_priority`
 
 Data type: `Integer[0]`
 
@@ -2512,7 +2528,7 @@ The priority number for slave promotion by Sentinel
 
 Default value: `$redis::slave_priority`
 
-##### <a name="-redis--instance--slave_read_only"></a>`slave_read_only`
+##### <a name="slave_read_only"></a>`slave_read_only`
 
 Data type: `Boolean`
 
@@ -2520,7 +2536,7 @@ You can configure a slave instance to accept writes or not.
 
 Default value: `$redis::slave_read_only`
 
-##### <a name="-redis--instance--slave_serve_stale_data"></a>`slave_serve_stale_data`
+##### <a name="slave_serve_stale_data"></a>`slave_serve_stale_data`
 
 Data type: `Boolean`
 
@@ -2535,7 +2551,7 @@ is still in progress, the slave can act in two different ways:
 
 Default value: `$redis::slave_serve_stale_data`
 
-##### <a name="-redis--instance--slaveof"></a>`slaveof`
+##### <a name="slaveof"></a>`slaveof`
 
 Data type: `Optional[String[1]]`
 
@@ -2543,7 +2559,7 @@ Use slaveof to make a Redis instance a copy of another Redis server.
 
 Default value: `$redis::slaveof`
 
-##### <a name="-redis--instance--replicaof"></a>`replicaof`
+##### <a name="replicaof"></a>`replicaof`
 
 Data type: `Optional[String[1]]`
 
@@ -2551,7 +2567,7 @@ Use replicaof to make a Redis instance a copy of another Redis server.
 
 Default value: `$redis::replicaof`
 
-##### <a name="-redis--instance--slowlog_log_slower_than"></a>`slowlog_log_slower_than`
+##### <a name="slowlog_log_slower_than"></a>`slowlog_log_slower_than`
 
 Data type: `Integer[-1]`
 
@@ -2560,7 +2576,7 @@ for the command to get logged.
 
 Default value: `$redis::slowlog_log_slower_than`
 
-##### <a name="-redis--instance--slowlog_max_len"></a>`slowlog_max_len`
+##### <a name="slowlog_max_len"></a>`slowlog_max_len`
 
 Data type: `Integer[0]`
 
@@ -2569,7 +2585,7 @@ to get logged.
 
 Default value: `$redis::slowlog_max_len`
 
-##### <a name="-redis--instance--stop_writes_on_bgsave_error"></a>`stop_writes_on_bgsave_error`
+##### <a name="stop_writes_on_bgsave_error"></a>`stop_writes_on_bgsave_error`
 
 Data type: `Boolean`
 
@@ -2578,7 +2594,7 @@ are problems with disk, permissions, and so forth.
 
 Default value: `$redis::stop_writes_on_bgsave_error`
 
-##### <a name="-redis--instance--syslog_enabled"></a>`syslog_enabled`
+##### <a name="syslog_enabled"></a>`syslog_enabled`
 
 Data type: `Boolean`
 
@@ -2586,7 +2602,7 @@ Enable/disable logging to the system logger.
 
 Default value: `$redis::syslog_enabled`
 
-##### <a name="-redis--instance--syslog_facility"></a>`syslog_facility`
+##### <a name="syslog_facility"></a>`syslog_facility`
 
 Data type: `Optional[String[1]]`
 
@@ -2594,7 +2610,7 @@ Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
 
 Default value: `$redis::syslog_facility`
 
-##### <a name="-redis--instance--tcp_backlog"></a>`tcp_backlog`
+##### <a name="tcp_backlog"></a>`tcp_backlog`
 
 Data type: `Integer[0]`
 
@@ -2602,7 +2618,7 @@ Sets the TCP backlog
 
 Default value: `$redis::tcp_backlog`
 
-##### <a name="-redis--instance--tcp_keepalive"></a>`tcp_keepalive`
+##### <a name="tcp_keepalive"></a>`tcp_keepalive`
 
 Data type: `Integer[0]`
 
@@ -2610,7 +2626,7 @@ TCP keepalive.
 
 Default value: `$redis::tcp_keepalive`
 
-##### <a name="-redis--instance--timeout"></a>`timeout`
+##### <a name="timeout"></a>`timeout`
 
 Data type: `Integer[0]`
 
@@ -2618,7 +2634,7 @@ Close the connection after a client is idle for N seconds (0 to disable).
 
 Default value: `$redis::timeout`
 
-##### <a name="-redis--instance--tls_port"></a>`tls_port`
+##### <a name="tls_port"></a>`tls_port`
 
 Data type: `Optional[Stdlib::Port]`
 
@@ -2626,7 +2642,7 @@ Configure which TLS port to listen on.
 
 Default value: `$redis::tls_port`
 
-##### <a name="-redis--instance--tls_cert_file"></a>`tls_cert_file`
+##### <a name="tls_cert_file"></a>`tls_cert_file`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
@@ -2634,7 +2650,7 @@ Specify which X.509 certificate file to use for TLS connections.
 
 Default value: `$redis::tls_cert_file`
 
-##### <a name="-redis--instance--tls_key_file"></a>`tls_key_file`
+##### <a name="tls_key_file"></a>`tls_key_file`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
@@ -2642,7 +2658,7 @@ Specify which privaye key file to use for TLS connections.
 
 Default value: `$redis::tls_key_file`
 
-##### <a name="-redis--instance--tls_ca_cert_file"></a>`tls_ca_cert_file`
+##### <a name="tls_ca_cert_file"></a>`tls_ca_cert_file`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
@@ -2650,7 +2666,7 @@ Specify which X.509 CA certificate(s) bundle file to use.
 
 Default value: `$redis::tls_ca_cert_file`
 
-##### <a name="-redis--instance--tls_ca_cert_dir"></a>`tls_ca_cert_dir`
+##### <a name="tls_ca_cert_dir"></a>`tls_ca_cert_dir`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
@@ -2658,7 +2674,7 @@ Specify which X.509 CA certificate(s) bundle directory to use.
 
 Default value: `$redis::tls_ca_cert_dir`
 
-##### <a name="-redis--instance--tls_auth_clients"></a>`tls_auth_clients`
+##### <a name="tls_auth_clients"></a>`tls_auth_clients`
 
 Data type: `Enum['yes', 'no', 'optional']`
 
@@ -2666,7 +2682,7 @@ Specify if clients and replicas are required to authenticate using valid client 
 
 Default value: `$redis::tls_auth_clients`
 
-##### <a name="-redis--instance--tls_replication"></a>`tls_replication`
+##### <a name="tls_replication"></a>`tls_replication`
 
 Data type: `Boolean`
 
@@ -2674,7 +2690,7 @@ Specify if TLS should be enabled on replication links.
 
 Default value: `$redis::tls_replication`
 
-##### <a name="-redis--instance--tls_cluster"></a>`tls_cluster`
+##### <a name="tls_cluster"></a>`tls_cluster`
 
 Data type: `Boolean`
 
@@ -2682,7 +2698,7 @@ Specify if TLS should be used for the bus protocol.
 
 Default value: `$redis::tls_cluster`
 
-##### <a name="-redis--instance--tls_ciphers"></a>`tls_ciphers`
+##### <a name="tls_ciphers"></a>`tls_ciphers`
 
 Data type: `Optional[String[1]]`
 
@@ -2690,7 +2706,7 @@ Configure allowed ciphers for TLS <= TLSv1.2.
 
 Default value: `$redis::tls_ciphers`
 
-##### <a name="-redis--instance--tls_ciphersuites"></a>`tls_ciphersuites`
+##### <a name="tls_ciphersuites"></a>`tls_ciphersuites`
 
 Data type: `Optional[String[1]]`
 
@@ -2698,7 +2714,7 @@ Configure allowed TLSv1.3 ciphersuites.
 
 Default value: `$redis::tls_ciphersuites`
 
-##### <a name="-redis--instance--tls_protocols"></a>`tls_protocols`
+##### <a name="tls_protocols"></a>`tls_protocols`
 
 Data type: `Optional[String[1]]`
 
@@ -2706,7 +2722,7 @@ Configure allowed TLS protocol versions.
 
 Default value: `$redis::tls_protocols`
 
-##### <a name="-redis--instance--tls_prefer_server_ciphers"></a>`tls_prefer_server_ciphers`
+##### <a name="tls_prefer_server_ciphers"></a>`tls_prefer_server_ciphers`
 
 Data type: `Optional[Boolean]`
 
@@ -2714,7 +2730,7 @@ Specify if the server's preference should be used when choosing a cipher.
 
 Default value: `$redis::tls_prefer_server_ciphers`
 
-##### <a name="-redis--instance--ulimit"></a>`ulimit`
+##### <a name="ulimit"></a>`ulimit`
 
 Data type: `Integer[0]`
 
@@ -2722,7 +2738,7 @@ Limit the use of system-wide resources.
 
 Default value: `$redis::ulimit`
 
-##### <a name="-redis--instance--ulimit_managed"></a>`ulimit_managed`
+##### <a name="ulimit_managed"></a>`ulimit_managed`
 
 Data type: `Boolean`
 
@@ -2731,7 +2747,7 @@ systemd service unit is explicitly managed.
 
 Default value: `$redis::ulimit_managed`
 
-##### <a name="-redis--instance--unixsocket"></a>`unixsocket`
+##### <a name="unixsocket"></a>`unixsocket`
 
 Data type: `Variant[Stdlib::Absolutepath, Enum['']]`
 
@@ -2739,7 +2755,7 @@ Define unix socket path
 
 Default value: `"/var/run/${service_name}/redis.sock"`
 
-##### <a name="-redis--instance--unixsocketperm"></a>`unixsocketperm`
+##### <a name="unixsocketperm"></a>`unixsocketperm`
 
 Data type: `Variant[Stdlib::Filemode, Enum['']]`
 
@@ -2747,7 +2763,7 @@ Define unix socket file permissions
 
 Default value: `$redis::unixsocketperm`
 
-##### <a name="-redis--instance--workdir"></a>`workdir`
+##### <a name="workdir"></a>`workdir`
 
 Data type: `Stdlib::Absolutepath`
 
@@ -2756,7 +2772,7 @@ above using the 'dbfilename' configuration directive.
 
 Default value: `"${redis::workdir}/redis-server-${name}"`
 
-##### <a name="-redis--instance--workdir_mode"></a>`workdir_mode`
+##### <a name="workdir_mode"></a>`workdir_mode`
 
 Data type: `Stdlib::Filemode`
 
@@ -2764,7 +2780,7 @@ Adjust mode for data directory.
 
 Default value: `$redis::workdir_mode`
 
-##### <a name="-redis--instance--zset_max_ziplist_entries"></a>`zset_max_ziplist_entries`
+##### <a name="zset_max_ziplist_entries"></a>`zset_max_ziplist_entries`
 
 Data type: `Integer[0]`
 
@@ -2772,7 +2788,7 @@ Set max entries for sorted sets.
 
 Default value: `$redis::zset_max_ziplist_entries`
 
-##### <a name="-redis--instance--zset_max_ziplist_value"></a>`zset_max_ziplist_value`
+##### <a name="zset_max_ziplist_value"></a>`zset_max_ziplist_value`
 
 Data type: `Integer[0]`
 
@@ -2780,7 +2796,7 @@ Set max values for sorted sets.
 
 Default value: `$redis::zset_max_ziplist_value`
 
-##### <a name="-redis--instance--cluster_enabled"></a>`cluster_enabled`
+##### <a name="cluster_enabled"></a>`cluster_enabled`
 
 Data type: `Boolean`
 
@@ -2788,7 +2804,7 @@ Enables redis 3.0 cluster functionality
 
 Default value: `$redis::cluster_enabled`
 
-##### <a name="-redis--instance--cluster_config_file"></a>`cluster_config_file`
+##### <a name="cluster_config_file"></a>`cluster_config_file`
 
 Data type: `String[1]`
 
@@ -2797,7 +2813,7 @@ touched by humans.  Only set if cluster_enabled is true
 
 Default value: `$redis::cluster_config_file`
 
-##### <a name="-redis--instance--cluster_node_timeout"></a>`cluster_node_timeout`
+##### <a name="cluster_node_timeout"></a>`cluster_node_timeout`
 
 Data type: `Integer[1]`
 
@@ -2805,7 +2821,7 @@ Node timeout. Only set if cluster_enabled is true
 
 Default value: `$redis::cluster_node_timeout`
 
-##### <a name="-redis--instance--cluster_slave_validity_factor"></a>`cluster_slave_validity_factor`
+##### <a name="cluster_slave_validity_factor"></a>`cluster_slave_validity_factor`
 
 Data type: `Integer[0]`
 
@@ -2814,7 +2830,7 @@ master Only set if cluster_enabled is true
 
 Default value: `$redis::cluster_slave_validity_factor`
 
-##### <a name="-redis--instance--cluster_require_full_coverage"></a>`cluster_require_full_coverage`
+##### <a name="cluster_require_full_coverage"></a>`cluster_require_full_coverage`
 
 Data type: `Boolean`
 
@@ -2823,7 +2839,7 @@ of keys can be processed Only set if cluster_enabled is true
 
 Default value: `$redis::cluster_require_full_coverage`
 
-##### <a name="-redis--instance--cluster_migration_barrier"></a>`cluster_migration_barrier`
+##### <a name="cluster_migration_barrier"></a>`cluster_migration_barrier`
 
 Data type: `Integer[0]`
 
@@ -2833,7 +2849,7 @@ set if cluster_enabled is true
 
 Default value: `$redis::cluster_migration_barrier`
 
-##### <a name="-redis--instance--io_threads"></a>`io_threads`
+##### <a name="io_threads"></a>`io_threads`
 
 Data type: `Optional[Integer[1]]`
 
@@ -2841,7 +2857,7 @@ Number of threads to handle IO operations in Redis
 
 Default value: `$redis::io_threads`
 
-##### <a name="-redis--instance--io_threads_do_reads"></a>`io_threads_do_reads`
+##### <a name="io_threads_do_reads"></a>`io_threads_do_reads`
 
 Data type: `Optional[Boolean]`
 
@@ -2849,7 +2865,7 @@ Enabled/disable io_threads to handle reads
 
 Default value: `$redis::io_threads_do_reads`
 
-##### <a name="-redis--instance--cluster_allow_reads_when_down"></a>`cluster_allow_reads_when_down`
+##### <a name="cluster_allow_reads_when_down"></a>`cluster_allow_reads_when_down`
 
 Data type: `Optional[Boolean]`
 
@@ -2857,7 +2873,7 @@ Allows nodes to serve read data while cluster status is down
 
 Default value: `$redis::cluster_allow_reads_when_down`
 
-##### <a name="-redis--instance--cluster_replica_no_failover"></a>`cluster_replica_no_failover`
+##### <a name="cluster_replica_no_failover"></a>`cluster_replica_no_failover`
 
 Data type: `Optional[Boolean]`
 
@@ -2865,7 +2881,7 @@ Disabled automatic failover for replica
 
 Default value: `$redis::cluster_replica_no_failover`
 
-##### <a name="-redis--instance--dynamic_hz"></a>`dynamic_hz`
+##### <a name="dynamic_hz"></a>`dynamic_hz`
 
 Data type: `Optional[Boolean]`
 
@@ -2875,7 +2891,7 @@ used as needed once more clients are connected.
 
 Default value: `$redis::dynamic_hz`
 
-##### <a name="-redis--instance--activedefrag"></a>`activedefrag`
+##### <a name="activedefrag"></a>`activedefrag`
 
 Data type: `Optional[Boolean]`
 
@@ -2883,7 +2899,7 @@ Enable/disable active defragmentation
 
 Default value: `$redis::activedefrag`
 
-##### <a name="-redis--instance--active_defrag_ignore_bytes"></a>`active_defrag_ignore_bytes`
+##### <a name="active_defrag_ignore_bytes"></a>`active_defrag_ignore_bytes`
 
 Data type: `String[1]`
 
@@ -2892,7 +2908,7 @@ Only set if activedefrag is true
 
 Default value: `$redis::active_defrag_ignore_bytes`
 
-##### <a name="-redis--instance--active_defrag_threshold_lower"></a>`active_defrag_threshold_lower`
+##### <a name="active_defrag_threshold_lower"></a>`active_defrag_threshold_lower`
 
 Data type: `Integer[1, 100]`
 
@@ -2901,7 +2917,7 @@ Only set if activedefrag is true
 
 Default value: `$redis::active_defrag_threshold_lower`
 
-##### <a name="-redis--instance--active_defrag_threshold_upper"></a>`active_defrag_threshold_upper`
+##### <a name="active_defrag_threshold_upper"></a>`active_defrag_threshold_upper`
 
 Data type: `Integer[1, 100]`
 
@@ -2910,7 +2926,7 @@ Only set if activedefrag is true
 
 Default value: `$redis::active_defrag_threshold_upper`
 
-##### <a name="-redis--instance--active_defrag_cycle_min"></a>`active_defrag_cycle_min`
+##### <a name="active_defrag_cycle_min"></a>`active_defrag_cycle_min`
 
 Data type: `Integer[1, 100]`
 
@@ -2920,7 +2936,7 @@ Only set if activedefrag is true
 
 Default value: `$redis::active_defrag_cycle_min`
 
-##### <a name="-redis--instance--active_defrag_cycle_max"></a>`active_defrag_cycle_max`
+##### <a name="active_defrag_cycle_max"></a>`active_defrag_cycle_max`
 
 Data type: `Integer[1, 100]`
 
@@ -2930,7 +2946,7 @@ Only set if activedefrag is true
 
 Default value: `$redis::active_defrag_cycle_max`
 
-##### <a name="-redis--instance--active_defrag_max_scan_fields"></a>`active_defrag_max_scan_fields`
+##### <a name="active_defrag_max_scan_fields"></a>`active_defrag_max_scan_fields`
 
 Data type: `Integer[1]`
 
@@ -2940,7 +2956,7 @@ Only set if activedefrag is true
 
 Default value: `$redis::active_defrag_max_scan_fields`
 
-##### <a name="-redis--instance--jemalloc_bg_thread"></a>`jemalloc_bg_thread`
+##### <a name="jemalloc_bg_thread"></a>`jemalloc_bg_thread`
 
 Data type: `Optional[Boolean]`
 
@@ -2948,7 +2964,7 @@ Jemalloc background thread for purging will be enabled by default
 
 Default value: `$redis::jemalloc_bg_thread`
 
-##### <a name="-redis--instance--rdb_save_incremental_fsync"></a>`rdb_save_incremental_fsync`
+##### <a name="rdb_save_incremental_fsync"></a>`rdb_save_incremental_fsync`
 
 Data type: `Optional[Boolean]`
 
@@ -2957,41 +2973,25 @@ the file will be fsync-ed every 32 MB of data generated.
 
 Default value: `$redis::rdb_save_incremental_fsync`
 
-##### <a name="-redis--instance--output_buffer_limit_slave"></a>`output_buffer_limit_slave`
+##### <a name="output_buffer_limit_slave"></a>`output_buffer_limit_slave`
 
 Data type: `String[1]`
 
-
+Value of client-output-buffer-limit-slave in redis config
 
 Default value: `$redis::output_buffer_limit_slave`
 
-##### <a name="-redis--instance--output_buffer_limit_pubsub"></a>`output_buffer_limit_pubsub`
+##### <a name="output_buffer_limit_pubsub"></a>`output_buffer_limit_pubsub`
 
 Data type: `String[1]`
 
-
+Value of client-output-buffer-limit-pubsub in redis config
 
 Default value: `$redis::output_buffer_limit_pubsub`
 
-##### <a name="-redis--instance--managed_by_cluster_manager"></a>`managed_by_cluster_manager`
-
-Data type: `Boolean`
-
-
-
-Default value: `$redis::managed_by_cluster_manager`
-
-##### <a name="-redis--instance--manage_service_file"></a>`manage_service_file`
-
-Data type: `Boolean`
-
-
-
-Default value: `true`
-
 ## Functions
 
-### <a name="redis--get"></a>`redis::get`
+### <a name="redisget"></a>`redis::get`
 
 Type: Ruby 4.x API
 
@@ -3041,7 +3041,7 @@ The value to return if the key is not found or the connection to Redis fails
 
 ## Data types
 
-### <a name="Redis--LogLevel"></a>`Redis::LogLevel`
+### <a name="redisloglevel"></a>`Redis::LogLevel`
 
 This can be one of:
 * debug (a lot of information, useful for development/testing)
@@ -3049,9 +3049,13 @@ This can be one of:
 * notice (moderately verbose, what you want in production probably)
 * warning (only very important / critical messages are logged)
 
-Alias of `Enum['debug', 'verbose', 'notice', 'warning']`
+Alias of
 
-### <a name="Redis--MemoryPolicy"></a>`Redis::MemoryPolicy`
+```puppet
+Enum['debug', 'verbose', 'notice', 'warning']
+```
+
+### <a name="redismemorypolicy"></a>`Redis::MemoryPolicy`
 
 This can be one of:
 * volatile-lru (Evict using approximated LRU, only keys with an expire set)
@@ -3063,13 +3067,21 @@ This can be one of:
 * volatile-ttl (Remove the key with the nearest expire time (minor TTL)
 * noeviction (Don't evict anything, just return an error on write operations)
 
-Alias of `Enum['volatile-lru', 'allkeys-lru', 'volatile-lfu', 'allkeys-lfu', 'volatile-random', 'allkeys-random', 'volatile-ttl', 'noeviction']`
+Alias of
 
-### <a name="Redis--RedisUrl"></a>`Redis::RedisUrl`
+```puppet
+Enum['volatile-lru', 'allkeys-lru', 'volatile-lfu', 'allkeys-lfu', 'volatile-random', 'allkeys-random', 'volatile-ttl', 'noeviction']
+```
 
-The Redis::RedisUrl data type.
+### <a name="redisredisurl"></a>`Redis::RedisUrl`
 
-Alias of `Pattern[/(^redis:\/\/)/]`
+validate URL matches redis protocol
+
+Alias of
+
+```puppet
+Pattern[/(^redis:\/\/)/]
+```
 
 ## Tasks
 

--- a/manifests/dnfmodule.pp
+++ b/manifests/dnfmodule.pp
@@ -4,6 +4,12 @@
 # multiple versions on the same OS. Only one DNF module stream can be active at the
 # same time.
 #
+# @param ensure
+#   Value of ensure parameter for redis dns module package
+#
+# @param module
+#   Name of the redis dns package
+#
 # @api private
 class redis::dnfmodule (
   String[1] $ensure = 'installed',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,6 +116,10 @@
 #   Which events to notify Pub/Sub clients about events happening
 # @param notify_service
 #   You may disable service reloads when config files change
+# @param output_buffer_limit_slave
+#   Value of client-output-buffer-limit-slave in redis config
+# @param output_buffer_limit_pubsub
+#   Value of client-output-buffer-limit-pubsub in redis config
 # @param package_ensure
 #   Default action for package.
 # @param package_name
@@ -325,6 +329,9 @@
 # @param dnf_module_stream
 #   Manage the DNF module and set the version. This only makes sense on distributions
 #   that use DNF package manager, such as EL8 or Fedora.
+# @param manage_service_file
+#   Determine if the systemd service file should be managed
+#
 class redis (
   Boolean $activerehashing                                       = true,
   Boolean $aof_load_truncated                                    = true,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -69,6 +69,10 @@
 #   with log_dir but absolute paths are also accepted.
 # @param log_level
 #   Specify the server verbosity level.
+# @param managed_by_cluster_manager
+#   Choose if redis will be managed by a cluster manager such as pacemaker or rgmanager
+# @param manage_service_file
+#   Determine if the systemd service file should be managed
 # @param masterauth
 #   If the master is password protected (using the "requirepass" configuration
 # @param maxclients
@@ -274,6 +278,11 @@
 # @param rdb_save_incremental_fsync
 #   When redis saves RDB file, if the following option is enabled
 #   the file will be fsync-ed every 32 MB of data generated.
+# @param output_buffer_limit_slave
+#   Value of client-output-buffer-limit-slave in redis config
+# @param output_buffer_limit_pubsub
+#   Value of client-output-buffer-limit-pubsub in redis config
+#
 define redis::instance (
   Boolean $activerehashing                                       = $redis::activerehashing,
   Boolean $aof_load_truncated                                    = $redis::aof_load_truncated,

--- a/types/redisurl.pp
+++ b/types/redisurl.pp
@@ -1,1 +1,2 @@
+# @summary validate URL matches redis protocol
 type Redis::RedisUrl = Pattern[/(^redis:\/\/)/]


### PR DESCRIPTION
Without this patch, the rake task 'strings:validate:reference' fails and a new release cannot be done.