### PR TITLE
fix spelling of "redis dnf module"

### DIFF
--- a/manifests/dnfmodule.pp
+++ b/manifests/dnfmodule.pp
@@ -5,10 +5,10 @@
 # same time.
 #
 # @param ensure
-#   Value of ensure parameter for redis dns module package
+#   Value of ensure parameter for redis dnf module package
 #
 # @param module
-#   Name of the redis dns package
+#   Name of the redis dnf package
 #
 # @api private
 class redis::dnfmodule (


### PR DESCRIPTION
it's always DNS, unless it's DNF.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
