### PR TITLE
Implement rudimentary Redis and Sentinel ACLs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1375,10 +1375,10 @@ Default value: `undef`
 
 Data type: `Array[String[1]]`
 
-This is a way to pass raw ACLs to Redis. Must be in the form of
+This is a way to pass an array of raw ACLs to Redis. The ACLs must be
+in the form of:
 
-  user USERNAME1 [additional ACL options]
-  user USERNAME2 [additional ACL options]
+  user USERNAME [additional ACL options]
 
 Default value: `[]`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1855,10 +1855,10 @@ Default value: `undef`
 
 Data type: `Array[String[1]]`
 
-This is a way to pass raw ACLs to Redis. Must be in the form of
+This is a way to pass an array of raw ACLs to Sentinel. The ACLs must be
+in the form of:
 
-  user USERNAME1 [additional ACL options]
-  user USERNAME2 [additional ACL options]
+  user USERNAME [additional ACL options]
 
 Default value: `[]`
 
@@ -3002,10 +3002,10 @@ Default value: `$redis::rdb_save_incremental_fsync`
 
 Data type: `Array[String[1]]`
 
-This is a way to pass raw ACLs to Redis. Must be in the form of
+This is a way to pass an array of raw ACLs to Redis. The ACLs must be
+in the form of:
 
-  user USERNAME1 [additional ACL options]
-  user USERNAME2 [additional ACL options]
+  user USERNAME [additional ACL options]
 
 Default value: `$redis::acls`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -224,6 +224,7 @@ The following parameters are available in the `redis` class:
 * [`jemalloc_bg_thread`](#-redis--jemalloc_bg_thread)
 * [`rdb_save_incremental_fsync`](#-redis--rdb_save_incremental_fsync)
 * [`dnf_module_stream`](#-redis--dnf_module_stream)
+* [`acls`](#-redis--acls)
 * [`manage_service_file`](#-redis--manage_service_file)
 
 ##### <a name="-redis--activerehashing"></a>`activerehashing`
@@ -1370,6 +1371,17 @@ that use DNF package manager, such as EL8 or Fedora.
 
 Default value: `undef`
 
+##### <a name="-redis--acls"></a>`acls`
+
+Data type: `Array[String[1]]`
+
+This is a way to pass raw ACLs to Redis. Must be in the form of
+
+  user USERNAME1 [additional ACL options]
+  user USERNAME2 [additional ACL options]
+
+Default value: `[]`
+
 ##### <a name="-redis--manage_service_file"></a>`manage_service_file`
 
 Data type: `Boolean`
@@ -1511,6 +1523,7 @@ The following parameters are available in the `redis::sentinel` class:
 * [`working_dir`](#-redis--sentinel--working_dir)
 * [`notification_script`](#-redis--sentinel--notification_script)
 * [`client_reconfig_script`](#-redis--sentinel--client_reconfig_script)
+* [`acls`](#-redis--sentinel--acls)
 * [`service_ensure`](#-redis--sentinel--service_ensure)
 
 ##### <a name="-redis--sentinel--auth_pass"></a>`auth_pass`
@@ -1838,6 +1851,17 @@ Path to the client-reconfig script
 
 Default value: `undef`
 
+##### <a name="-redis--sentinel--acls"></a>`acls`
+
+Data type: `Array[String[1]]`
+
+This is a way to pass raw ACLs to Redis. Must be in the form of
+
+  user USERNAME1 [additional ACL options]
+  user USERNAME2 [additional ACL options]
+
+Default value: `[]`
+
 ##### <a name="-redis--sentinel--service_ensure"></a>`service_ensure`
 
 Data type: `Stdlib::Ensure::Service`
@@ -1986,6 +2010,7 @@ The following parameters are available in the `redis::instance` defined type:
 * [`active_defrag_max_scan_fields`](#-redis--instance--active_defrag_max_scan_fields)
 * [`jemalloc_bg_thread`](#-redis--instance--jemalloc_bg_thread)
 * [`rdb_save_incremental_fsync`](#-redis--instance--rdb_save_incremental_fsync)
+* [`acls`](#-redis--instance--acls)
 * [`output_buffer_limit_slave`](#-redis--instance--output_buffer_limit_slave)
 * [`output_buffer_limit_pubsub`](#-redis--instance--output_buffer_limit_pubsub)
 
@@ -2972,6 +2997,17 @@ When redis saves RDB file, if the following option is enabled
 the file will be fsync-ed every 32 MB of data generated.
 
 Default value: `$redis::rdb_save_incremental_fsync`
+
+##### <a name="-redis--instance--acls"></a>`acls`
+
+Data type: `Array[String[1]]`
+
+This is a way to pass raw ACLs to Redis. Must be in the form of
+
+  user USERNAME1 [additional ACL options]
+  user USERNAME2 [additional ACL options]
+
+Default value: `$redis::acls`
 
 ##### <a name="-redis--instance--output_buffer_limit_slave"></a>`output_buffer_limit_slave`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,6 +35,7 @@ class redis::config {
       daemonize           => $redis::daemonize,
       service_name        => $redis::service_name,
       manage_service_file => $redis::manage_service_file,
+      acls                => $redis::acls,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -478,7 +478,7 @@ class redis (
   Optional[Boolean] $jemalloc_bg_thread                          = undef,
   Optional[Boolean] $rdb_save_incremental_fsync                  = undef,
   Optional[String[1]] $dnf_module_stream                         = undef,
-  Optional[String[1]] $acls                                      = undef,
+  Array[String[1]] $acls                                         = [],
 ) inherits redis::params {
   contain redis::preinstall
   contain redis::install

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -330,10 +330,11 @@
 #   Manage the DNF module and set the version. This only makes sense on distributions
 #   that use DNF package manager, such as EL8 or Fedora.
 # @param acls
-#   This is a way to pass raw ACLs to Redis. Must be in the form of
+#   This is a way to pass an array of raw ACLs to Redis. The ACLs must be
+#   in the form of:
+# 
+#     user USERNAME [additional ACL options]
 #
-#     user USERNAME1 [additional ACL options]
-#     user USERNAME2 [additional ACL options]
 # @param manage_service_file
 #   Determine if the systemd service file should be managed
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -473,6 +473,7 @@ class redis (
   Optional[Boolean] $jemalloc_bg_thread                          = undef,
   Optional[Boolean] $rdb_save_incremental_fsync                  = undef,
   Optional[String[1]] $dnf_module_stream                         = undef,
+  Optional[String[1]] $acls                                      = undef,
 ) inherits redis::params {
   contain redis::preinstall
   contain redis::install

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -329,6 +329,11 @@
 # @param dnf_module_stream
 #   Manage the DNF module and set the version. This only makes sense on distributions
 #   that use DNF package manager, such as EL8 or Fedora.
+# @param acls
+#   This is a way to pass raw ACLs to Redis. Must be in the form of
+#
+#     user USERNAME1 [additional ACL options]
+#     user USERNAME2 [additional ACL options]
 # @param manage_service_file
 #   Determine if the systemd service file should be managed
 #

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -405,6 +405,7 @@ define redis::instance (
   Integer[1] $active_defrag_max_scan_fields                      = $redis::active_defrag_max_scan_fields,
   Optional[Boolean] $jemalloc_bg_thread                          = $redis::jemalloc_bg_thread,
   Optional[Boolean] $rdb_save_incremental_fsync                  = $redis::rdb_save_incremental_fsync,
+  Optional[String[1]] $acls                                      = $redis::acls,
 ) {
   if $title == 'default' {
     $redis_file_name_orig = $config_file_orig
@@ -596,6 +597,7 @@ define redis::instance (
         active_defrag_max_scan_fields => $active_defrag_max_scan_fields,
         jemalloc_bg_thread            => $jemalloc_bg_thread,
         rdb_save_incremental_fsync    => $rdb_save_incremental_fsync,
+        acls                          => $acls,
       }
     ),
   }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -278,6 +278,11 @@
 # @param rdb_save_incremental_fsync
 #   When redis saves RDB file, if the following option is enabled
 #   the file will be fsync-ed every 32 MB of data generated.
+# @param acls
+#   This is a way to pass raw ACLs to Redis. Must be in the form of
+#
+#     user USERNAME1 [additional ACL options]
+#     user USERNAME2 [additional ACL options]
 # @param output_buffer_limit_slave
 #   Value of client-output-buffer-limit-slave in redis config
 # @param output_buffer_limit_pubsub

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -279,10 +279,11 @@
 #   When redis saves RDB file, if the following option is enabled
 #   the file will be fsync-ed every 32 MB of data generated.
 # @param acls
-#   This is a way to pass raw ACLs to Redis. Must be in the form of
+#   This is a way to pass an array of raw ACLs to Redis. The ACLs must be
+#   in the form of:
 #
-#     user USERNAME1 [additional ACL options]
-#     user USERNAME2 [additional ACL options]
+#     user USERNAME [additional ACL options]
+#
 # @param output_buffer_limit_slave
 #   Value of client-output-buffer-limit-slave in redis config
 # @param output_buffer_limit_pubsub

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -410,7 +410,7 @@ define redis::instance (
   Integer[1] $active_defrag_max_scan_fields                      = $redis::active_defrag_max_scan_fields,
   Optional[Boolean] $jemalloc_bg_thread                          = $redis::jemalloc_bg_thread,
   Optional[Boolean] $rdb_save_incremental_fsync                  = $redis::rdb_save_incremental_fsync,
-  Optional[String[1]] $acls                                      = $redis::acls,
+  Array[String[1]] $acls                                         = $redis::acls,
 ) {
   if $title == 'default' {
     $redis_file_name_orig = $config_file_orig

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -186,7 +186,7 @@ class redis::sentinel (
   Stdlib::Absolutepath $working_dir = $redis::params::sentinel_working_dir,
   Optional[Stdlib::Absolutepath] $notification_script = undef,
   Optional[Stdlib::Absolutepath] $client_reconfig_script = undef,
-  Optional[String[1]] $acls = undef,
+  Array[String[1]] $acls = [],
 ) inherits redis::params {
   $auth_pass_unsensitive = if $auth_pass =~ Sensitive {
     $auth_pass.unwrap

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -130,6 +130,12 @@
 # @param client_reconfig_script
 #   Path to the client-reconfig script
 #
+# @param acls
+#   This is a way to pass raw ACLs to Redis. Must be in the form of
+#
+#     user USERNAME1 [additional ACL options]
+#     user USERNAME2 [additional ACL options]
+#
 # @example Basic inclusion
 #   include redis::sentinel
 #

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -180,6 +180,7 @@ class redis::sentinel (
   Stdlib::Absolutepath $working_dir = $redis::params::sentinel_working_dir,
   Optional[Stdlib::Absolutepath] $notification_script = undef,
   Optional[Stdlib::Absolutepath] $client_reconfig_script = undef,
+  Optional[String[1]] $acls = undef,
 ) inherits redis::params {
   $auth_pass_unsensitive = if $auth_pass =~ Sensitive {
     $auth_pass.unwrap

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -131,10 +131,10 @@
 #   Path to the client-reconfig script
 #
 # @param acls
-#   This is a way to pass raw ACLs to Redis. Must be in the form of
-#
-#     user USERNAME1 [additional ACL options]
-#     user USERNAME2 [additional ACL options]
+#   This is a way to pass an array of raw ACLs to Sentinel. The ACLs must be
+#   in the form of:
+#   
+#     user USERNAME [additional ACL options]
 #
 # @example Basic inclusion
 #   include redis::sentinel

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -84,6 +84,19 @@ describe 'redis::sentinel' do
         it { is_expected.to contain_package(sentinel_package_name).with_ensure('installed') }
       end
 
+      describe 'with acls' do
+        let(:params) do
+          {
+            acls: ['user readolny on nopass ~* resetchannels -@all +get'],
+          }
+        end
+
+        it {
+          is_expected.to contain_file(config_file_orig).
+            with_content(%r{^user readolny on nopass ~\* resetchannels -@all \+get$})
+        }
+      end
+
       describe 'with custom parameters' do
         let(:pre_condition) do
           <<-PUPPET

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -1554,6 +1554,19 @@ describe 'redis' do
         }
       end
 
+      describe 'with acls' do
+        let(:params) do
+          {
+            acls: ['user readolny on nopass ~* resetchannels -@all +get'],
+          }
+        end
+
+        it {
+          is_expected.to contain_file(config_file_orig).
+            with_content(%r{^user readolny on nopass ~\* resetchannels -@all \+get$})
+        }
+      end
+
       describe 'test io-threads for redis6' do
         let(:params) do
           {

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -54,7 +54,9 @@ tls-replication <%= @tls_replication ? 'yes' : 'no' %>
 
 loglevel <%= @log_level %>
 logfile <%= @log_file %>
+<% unless @acls.empty? -%>
 
-<% if @acls -%>
-<%= @acls %>
+<%   @acls.each do |acl| -%>
+<%= acl %>
+<%   end -%>
 <% end -%>

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -54,3 +54,7 @@ tls-replication <%= @tls_replication ? 'yes' : 'no' %>
 
 loglevel <%= @log_level %>
 logfile <%= @log_file %>
+
+<% if @acls -%>
+<%= @acls %>
+<% end -%>

--- a/templates/redis.conf.epp
+++ b/templates/redis.conf.epp
@@ -99,6 +99,7 @@
   Integer[1]                                         $active_defrag_max_scan_fields,
   Optional[Boolean]                                  $jemalloc_bg_thread,
   Optional[Boolean]                                  $rdb_save_incremental_fsync,
+  Optional[String[1]]                                $acls,
 | -%>
 # Redis configuration file example
 
@@ -1200,4 +1201,8 @@ loadmodule <%= $module_path %>
 # include /path/to/other.conf
 <% if $extra_config_file { -%>
 include <%= $extra_config_file %>
+<% } -%>
+
+<% if $acls { -%>
+<%= $acls %>
 <% } -%>

--- a/templates/redis.conf.epp
+++ b/templates/redis.conf.epp
@@ -99,7 +99,7 @@
   Integer[1]                                         $active_defrag_max_scan_fields,
   Optional[Boolean]                                  $jemalloc_bg_thread,
   Optional[Boolean]                                  $rdb_save_incremental_fsync,
-  Optional[String[1]]                                $acls,
+  Array[String[1]]                                   $acls,
 | -%>
 # Redis configuration file example
 
@@ -1202,7 +1202,9 @@ loadmodule <%= $module_path %>
 <% if $extra_config_file { -%>
 include <%= $extra_config_file %>
 <% } -%>
+<% unless $acls.empty { -%>
 
-<% if $acls { -%>
-<%= $acls %>
+<%   $acls.each |$acl| { -%>
+<%= $acl %>
+<%   } -%>
 <% } -%>


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request implements the possibility to pass ACLs to redis::instance and redis::sentinel

It does not implement ACL verification / syntax checking, for the overhead of that would IMO not justify the amount of work you would need to put into that.

#### This Pull Request (PR) fixes the following issues
Closes #446 

