### PR TITLE
remove legacy os'es and add current ones

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,21 +35,20 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
-        "11"
+        "11",
+        "12"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -57,7 +56,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -35,8 +35,7 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "11",
-        "12"
+        "11"
       ]
     },
     {


### PR DESCRIPTION
remove:
debian10, ubuntu18, rhel7, centos7

add: ubuntu22
(debian 12 might work, but is not testable because we have no official puppet packages)