### PR TITLE
Avoid deprecated systemd::service_limits

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -483,11 +483,13 @@ define redis::instance (
     }
   } else {
     if $ulimit_managed {
-      systemd::service_limits { "${service_name}.service":
-        limits          => {
+      systemd::manage_dropin { "${service_name}-90-limits.conf":
+        ensure         => present,
+        unit           => "${service_name}.service",
+        service_entry  => {
           'LimitNOFILE' => $ulimit,
         },
-        restart_service => false,
+        notify_service => false,
       }
     }
   }

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -109,10 +109,10 @@ describe 'redis' do
             is_expected.to contain_file("/etc/systemd/system/#{service_name}.service.d/limit.conf").
               with_ensure('absent')
 
-            is_expected.to contain_systemd__service_limits("#{service_name}.service").
-              with_limits({ 'LimitNOFILE' => 7777 }).
-              with_restart_service(false).
-              with_ensure('present')
+            is_expected.to contain_systemd__manage_dropin("#{service_name}-90-limits.conf").
+              with_service_entry({ 'LimitNOFILE' => 7777 }).
+              with_ensure('present').
+              with_unit("#{service_name}.service")
           end
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description

`systemd::service_limits` was deprecated

https://github.com/voxpupuli/puppet-systemd/pull/437

