### PR TITLE
Install redis-sentinal package before redis

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -194,12 +194,13 @@ class redis::sentinel (
     $auth_pass
   }
 
-  require 'redis'
+  contain 'redis'
 
   if $package_name != $redis::package_name {
     ensure_packages([$package_name], {
         ensure => $package_ensure
     })
+    Package[$package_name] -> Class['redis']
   }
   Package[$package_name] -> File[$config_file_orig]
 


### PR DESCRIPTION
#### Pull Request (PR) description

When the `redis-sentinal` package was installed it could
alter previously applied requested permissions and ownerships
of files.

Ensure that redis-sentinal package is installed before directory
permissions and ownerships are set.

