### PR TITLE
Re-enable bolt tests on RedHat 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "11"
+        "11",
+        "12"
       ]
     },
     {

--- a/spec/acceptance/redis_cli_task_spec.rb
+++ b/spec/acceptance/redis_cli_task_spec.rb
@@ -9,7 +9,8 @@ describe 'redis-cli task' do
 
   let(:task_name) { 'redis::redis_cli' }
 
-  unless fact('os.family') == 'RedHat' && fact('os.release.major').to_i >= 9
+  unless fact('os.name') == 'Debian' && fact('os.release.major').to_i >= 12
+
     include_examples 'an idempotent resource' do
       let(:manifest) { 'include redis' }
     end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,9 +6,8 @@ configure_beaker do |host|
   # sysctl is untestable in docker
   install_puppet_module_via_pmt_on(host, 'puppet-augeasproviders_sysctl') unless host['hypervisor'] == 'docker'
 
-  unless fact_on(host, 'os.family') == 'RedHat' && fact_on(host, 'os.release.major').to_i >= 9
-    # puppet-bolt rpm for CentOS 9 is not yet available
-    # https://tickets.puppetlabs.com/browse/MODULES-11275
+  unless fact_on(host, 'os.name') == 'Debian' && fact_on(host, 'os.release.major').to_i >= 12
+    # puppet-bolt for Debian 12 is not yet available
     host.install_package('puppet-bolt')
   end
 


### PR DESCRIPTION
#### Pull Request (PR) description

Bolt packages now exist for RedHat 9. Re-enable acceptance tests.

#### This Pull Request (PR) fixes the following issues

Fixes #492


