### PR TITLE
Use bolt_supported beaker helper

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,9 @@
 ---
 Gemfile:
   optional:
+    ':system_tests':
+      - gem: 'voxpupuli-acceptance'
+        version: '~> 3.1'
     ':test':
       - gem: 'redis'
       - gem: 'mock_redis'

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development do
 end
 
 group :system_tests do
-  gem 'voxpupuli-acceptance', '~> 3.0',  :require => false
+  gem 'voxpupuli-acceptance', '~> 3.1',  :require => false
 end
 
 group :release do

--- a/spec/acceptance/redis_cli_task_spec.rb
+++ b/spec/acceptance/redis_cli_task_spec.rb
@@ -9,7 +9,7 @@ describe 'redis-cli task' do
 
   let(:task_name) { 'redis::redis_cli' }
 
-  unless fact('os.family') == 'RedHat' && fact('os.release.major').to_i >= 9
+  if bolt_supported?
     include_examples 'an idempotent resource' do
       let(:manifest) { 'include redis' }
     end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,11 +6,7 @@ configure_beaker do |host|
   # sysctl is untestable in docker
   install_puppet_module_via_pmt_on(host, 'puppet-augeasproviders_sysctl') unless host['hypervisor'] == 'docker'
 
-  unless fact_on(host, 'os.family') == 'RedHat' && fact_on(host, 'os.release.major').to_i >= 9
-    # puppet-bolt rpm for CentOS 9 is not yet available
-    # https://tickets.puppetlabs.com/browse/MODULES-11275
-    host.install_package('puppet-bolt')
-  end
+  host.install_package('puppet-bolt') if bolt_supported?(host)
 
   if fact_on(host, 'os.family') == 'Debian'
     # APT required for Debian based systems where `$redis::manage_repo` is `true`


### PR DESCRIPTION
#### Pull Request (PR) description

 Use new `bolt_supported?` helper to conditionally setup and run beaker tests.
 The `bolt_supported?` helper is available with rubygem-beaker_puppet_helpers v1.3.0
 
 Since bolt is available for RHEL9 at the time of writing this will
 enable bolt tests for RHEL9.


