### PR TITLE
Make it possible to only install sentinel role

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ class { 'redis::sentinel':
 }
 ```
 
+If installation without redis-server is desired, set `contain_redis` parameter to false, i.e
+```puppet
+class { 'redis::sentinel':
+  ...
+  contain_redis => false,
+  ...
+}
+```
+
 ### Soft dependency
 
 When managing the repo, it needs [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt).

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1554,6 +1554,7 @@ The following parameters are available in the `redis::sentinel` class:
 * [`client_reconfig_script`](#-redis--sentinel--client_reconfig_script)
 * [`acls`](#-redis--sentinel--acls)
 * [`service_ensure`](#-redis--sentinel--service_ensure)
+* [`require_redis`](#-redis--sentinel--require_redis)
 
 ##### <a name="-redis--sentinel--auth_pass"></a>`auth_pass`
 
@@ -1895,9 +1896,17 @@ Default value: `[]`
 
 Data type: `Stdlib::Ensure::Service`
 
-
+Specify if the server should be running.
 
 Default value: `'running'`
+
+##### <a name="-redis--sentinel--require_redis"></a>`require_redis`
+
+Data type: `Boolean`
+
+Require redis base class. If set to false, sentinel is installed without redis server.
+
+Default value: `true`
 
 ## Defined types
 

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -133,7 +133,7 @@
 # @param acls
 #   This is a way to pass an array of raw ACLs to Sentinel. The ACLs must be
 #   in the form of:
-#   
+#
 #     user USERNAME [additional ACL options]
 #
 # @example Basic inclusion
@@ -145,48 +145,54 @@
 #     log_file   => '/var/log/redis/sentinel.log',
 #   }
 #
+# @param service_ensure
+#   Specify if the server should be running.
+# @param require_redis
+#   Require redis base class. If set to false, sentinel is installed without redis server.
+#
 class redis::sentinel (
-  Optional[Variant[String[1], Sensitive[String[1]]]] $auth_pass = undef,
-  Stdlib::Absolutepath $config_file = $redis::params::sentinel_config_file,
-  Stdlib::Absolutepath $config_file_orig = $redis::params::sentinel_config_file_orig,
-  Stdlib::Filemode $config_file_mode = '0644',
-  String[1] $conf_template = 'redis/redis-sentinel.conf.erb',
-  Boolean $daemonize = $redis::params::sentinel_daemonize,
-  Boolean $protected_mode = true,
-  Integer[1] $down_after = 30000,
-  Integer[1] $failover_timeout = 180000,
-  Redis::LogLevel $log_level = 'notice',
-  Stdlib::Absolutepath $log_file = $redis::params::sentinel_log_file,
-  String[1] $master_name  = 'mymaster',
-  Stdlib::Host $redis_host = '127.0.0.1',
-  Stdlib::Port $redis_port = 6379,
-  Optional[String[1]] $requirepass = undef,
-  String[1] $package_name = $redis::params::sentinel_package_name,
-  String[1] $package_ensure = 'installed',
-  Integer[0] $parallel_sync = 1,
-  Stdlib::Absolutepath $pid_file = $redis::params::sentinel_pid_file,
-  Integer[1] $quorum = 2,
-  Optional[Enum['yes', 'no']] $sentinel_announce_hostnames = undef,
-  Optional[Stdlib::Host] $sentinel_announce_ip = undef,
+  Optional[Variant[String[1], Sensitive[String[1]]]] $auth_pass                  = undef,
+  Stdlib::Absolutepath $config_file                                              = $redis::params::sentinel_config_file,
+  Stdlib::Absolutepath $config_file_orig                                         = $redis::params::sentinel_config_file_orig,
+  Stdlib::Filemode $config_file_mode                                             = '0644',
+  String[1] $conf_template                                                       = 'redis/redis-sentinel.conf.erb',
+  Boolean $daemonize                                                             = $redis::params::sentinel_daemonize,
+  Boolean $protected_mode                                                        = true,
+  Integer[1] $down_after                                                         = 30000,
+  Integer[1] $failover_timeout                                                   = 180000,
+  Redis::LogLevel $log_level                                                     = 'notice',
+  Stdlib::Absolutepath $log_file                                                 = $redis::params::sentinel_log_file,
+  String[1] $master_name                                                         = 'mymaster',
+  Stdlib::Host $redis_host                                                       = '127.0.0.1',
+  Stdlib::Port $redis_port                                                       = 6379,
+  Optional[String[1]] $requirepass                                               = undef,
+  String[1] $package_name                                                        = $redis::params::sentinel_package_name,
+  String[1] $package_ensure                                                      = 'installed',
+  Integer[0] $parallel_sync                                                      = 1,
+  Stdlib::Absolutepath $pid_file                                                 = $redis::params::sentinel_pid_file,
+  Integer[1] $quorum                                                             = 2,
+  Optional[Enum['yes', 'no']] $sentinel_announce_hostnames                       = undef,
+  Optional[Stdlib::Host] $sentinel_announce_ip                                   = undef,
   Variant[Undef, Stdlib::IP::Address, Array[Stdlib::IP::Address]] $sentinel_bind = undef,
-  Stdlib::Port $sentinel_port = 26379,
-  Optional[Enum['yes', 'no']] $sentinel_resolve_hostnames = undef,
-  Optional[Stdlib::Port::Unprivileged] $sentinel_tls_port = undef,
-  String[1] $service_group = 'redis',
-  String[1] $service_name = $redis::params::sentinel_service_name,
-  Stdlib::Ensure::Service $service_ensure = 'running',
-  Boolean $service_enable = true,
-  String[1] $service_user = 'redis',
-  Optional[Stdlib::Absolutepath] $tls_cert_file = undef,
-  Optional[Stdlib::Absolutepath] $tls_key_file = undef,
-  Optional[Stdlib::Absolutepath] $tls_ca_cert_file = undef,
-  Optional[Stdlib::Absolutepath] $tls_ca_cert_dir = undef,
-  Enum['yes', 'no', 'optional'] $tls_auth_clients = 'no',
-  Boolean $tls_replication = false,
-  Stdlib::Absolutepath $working_dir = $redis::params::sentinel_working_dir,
-  Optional[Stdlib::Absolutepath] $notification_script = undef,
-  Optional[Stdlib::Absolutepath] $client_reconfig_script = undef,
-  Array[String[1]] $acls = [],
+  Stdlib::Port $sentinel_port                                                    = 26379,
+  Optional[Enum['yes', 'no']] $sentinel_resolve_hostnames                        = undef,
+  Optional[Stdlib::Port::Unprivileged] $sentinel_tls_port                        = undef,
+  String[1] $service_group                                                       = 'redis',
+  String[1] $service_name                                                        = $redis::params::sentinel_service_name,
+  Stdlib::Ensure::Service $service_ensure                                        = 'running',
+  Boolean $service_enable                                                        = true,
+  String[1] $service_user                                                        = 'redis',
+  Optional[Stdlib::Absolutepath] $tls_cert_file                                  = undef,
+  Optional[Stdlib::Absolutepath] $tls_key_file                                   = undef,
+  Optional[Stdlib::Absolutepath] $tls_ca_cert_file                               = undef,
+  Optional[Stdlib::Absolutepath] $tls_ca_cert_dir                                = undef,
+  Enum['yes', 'no', 'optional'] $tls_auth_clients                                = 'no',
+  Boolean $tls_replication                                                       = false,
+  Stdlib::Absolutepath $working_dir                                              = $redis::params::sentinel_working_dir,
+  Optional[Stdlib::Absolutepath] $notification_script                            = undef,
+  Optional[Stdlib::Absolutepath] $client_reconfig_script                         = undef,
+  Array[String[1]] $acls                                                         = [],
+  Boolean $require_redis                                                         = true,
 ) inherits redis::params {
   $auth_pass_unsensitive = if $auth_pass =~ Sensitive {
     $auth_pass.unwrap
@@ -194,13 +200,17 @@ class redis::sentinel (
     $auth_pass
   }
 
-  contain 'redis'
+  if $require_redis {
+    contain 'redis'
+  }
 
   if $package_name != $redis::package_name {
     ensure_packages([$package_name], {
         ensure => $package_ensure
     })
-    Package[$package_name] -> Class['redis']
+    if $require_redis {
+      Package[$package_name] -> Class['redis']
+    }
   }
   Package[$package_name] -> File[$config_file_orig]
 


### PR DESCRIPTION

Pull Request (PR) description

This PR add the possibility to install redis::sentinel only without redis::server. For example when you need a member only for quorum

Already in use at work since this PR :  [https://github.com/voxpupuli/puppet-redis/pull/389]( #389)

This Pull Request (PR) fixes the following issues

    installation of standalone sentinel (no open issue for this one, so far)

Thanks!
