### PR TITLE
Use namespace function from puppetlabs-stdlib

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -201,7 +201,7 @@ class redis::sentinel (
   contain 'redis'
 
   if $package_name != $redis::package_name {
-    ensure_packages([$package_name], {
+    stdlib::ensure_packages([$package_name], {
         ensure => $package_ensure
     })
     Package[$package_name] -> Class['redis']

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 8.4.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppet/systemd",


### PR DESCRIPTION
#### Pull Request (PR) description
The existing functions were deprecated in favor of the stdlib namespace functions in puppetlabs-stdlib 9.0.0 .
Adjust the function name accordingly to get rid of warnings.

#### This Pull Request (PR) fixes the following issues
N/A