### PR TITLE
Allow to adjust the OOM score calculation for redis

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -35,6 +35,7 @@ repositories.
 
 * [`Redis::LogLevel`](#Redis--LogLevel): Specify the server verbosity level.
 * [`Redis::MemoryPolicy`](#Redis--MemoryPolicy): Specify the server maxmemory_policy.
+* [`Redis::OOMScoreAdjust`](#Redis--OOMScoreAdjust): Specify the OOMScoreAdjust range
 * [`Redis::RedisUrl`](#Redis--RedisUrl): validate URL matches redis protocol
 
 ### Tasks
@@ -169,6 +170,7 @@ The following parameters are available in the `redis` class:
 * [`service_user`](#-redis--service_user)
 * [`service_timeout_start`](#-redis--service_timeout_start)
 * [`service_timeout_stop`](#-redis--service_timeout_stop)
+* [`service_oom_score_adjust`](#-redis--service_oom_score_adjust)
 * [`set_max_intset_entries`](#-redis--set_max_intset_entries)
 * [`slave_priority`](#-redis--slave_priority)
 * [`slave_read_only`](#-redis--slave_read_only)
@@ -912,6 +914,14 @@ Default value: `undef`
 Data type: `Optional[Integer[0]]`
 
 Specify the time after which a service stop should be considered as failed.
+
+Default value: `undef`
+
+##### <a name="-redis--service_oom_score_adjust"></a>`service_oom_score_adjust`
+
+Data type: `Optional[Redis::OOMScoreAdjust]`
+
+Specity the OOMScoreAdust parameter for the service.
 
 Default value: `undef`
 
@@ -2050,6 +2060,7 @@ The following parameters are available in the `redis::instance` defined type:
 * [`service_user`](#-redis--instance--service_user)
 * [`service_timeout_start`](#-redis--instance--service_timeout_start)
 * [`service_timeout_stop`](#-redis--instance--service_timeout_stop)
+* [`service_oom_score_adjust`](#-redis--instance--service_oom_score_adjust)
 * [`set_max_intset_entries`](#-redis--instance--set_max_intset_entries)
 * [`slave_priority`](#-redis--instance--slave_priority)
 * [`slave_read_only`](#-redis--instance--slave_read_only)
@@ -2632,6 +2643,14 @@ Specify the time after which a service stop should be considered as failed.
 
 Default value: `$redis::service_timeout_stop`
 
+##### <a name="-redis--instance--service_oom_score_adjust"></a>`service_oom_score_adjust`
+
+Data type: `Optional[Redis::OOMScoreAdjust]`
+
+Specity the OOMScoreAdust parameter for the service.
+
+Default value: `$redis::service_oom_score_adjust`
+
 ##### <a name="-redis--instance--set_max_intset_entries"></a>`set_max_intset_entries`
 
 Data type: `Integer[0]`
@@ -3212,6 +3231,12 @@ This can be one of:
 * noeviction (Don't evict anything, just return an error on write operations)
 
 Alias of `Enum['volatile-lru', 'allkeys-lru', 'volatile-lfu', 'allkeys-lfu', 'volatile-random', 'allkeys-random', 'volatile-ttl', 'noeviction']`
+
+### <a name="Redis--OOMScoreAdjust"></a>`Redis::OOMScoreAdjust`
+
+Specify the OOMScoreAdjust range
+
+Alias of `Integer[-1000, 1000]`
 
 ### <a name="Redis--RedisUrl"></a>`Redis::RedisUrl`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -190,6 +190,8 @@
 #   Specify the time after which a service startup should be considered as failed.
 # @param service_timeout_stop
 #   Specify the time after which a service stop should be considered as failed.
+# @param service_oom_score_adjust
+#   Specity the OOMScoreAdust parameter for the service.
 # @param set_max_intset_entries
 #   The following configuration setting sets the limit in the size of the set
 #   in order to use this special memory saving encoding.
@@ -444,6 +446,7 @@ class redis (
   String[1] $service_user                                        = $redis::params::service_user,
   Optional[Integer[0]] $service_timeout_start                    = undef,
   Optional[Integer[0]] $service_timeout_stop                     = undef,
+  Optional[Redis::OOMScoreAdjust] $service_oom_score_adjust      = undef,
   Integer[0] $set_max_intset_entries                             = 512,
   Integer[0] $slave_priority                                     = 100,
   Boolean $slave_read_only                                       = true,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -140,6 +140,8 @@
 #   Specify the time after which a service startup should be considered as failed.
 # @param service_timeout_stop
 #   Specify the time after which a service stop should be considered as failed.
+# @param service_oom_score_adjust
+#   Specity the OOMScoreAdust parameter for the service.
 # @param set_max_intset_entries
 #   The following configuration setting sets the limit in the size of the set
 #   in order to use this special memory saving encoding.
@@ -398,6 +400,7 @@ define redis::instance (
   String[1] $service_group                                       = $redis::service_group,
   Optional[Integer[0]] $service_timeout_start                    = $redis::service_timeout_start,
   Optional[Integer[0]] $service_timeout_stop                     = $redis::service_timeout_stop,
+  Optional[Redis::OOMScoreAdjust] $service_oom_score_adjust      = $redis::service_oom_score_adjust,
   Boolean $manage_service_file                                   = true,
   String $log_file                                               = "${redis::provider}-server-${name}.log",
   Stdlib::Absolutepath $pid_file                                 = "/var/run/${service_name}/${redis::provider}.pid",
@@ -465,17 +468,18 @@ define redis::instance (
       content => epp(
         'redis/service_templates/redis.service.epp',
         {
-          provider              => $redis::provider,
-          bin_path              => $redis::bin_path,
-          instance_title        => $name,
-          port                  => $port,
-          redis_file_name       => $redis_file_name,
-          service_name          => $service_name,
-          service_user          => $service_user,
-          service_timeout_start => $service_timeout_start,
-          service_timeout_stop  => $service_timeout_stop,
-          ulimit                => $ulimit,
-          ulimit_managed        => $ulimit_managed,
+          provider                 => $redis::provider,
+          bin_path                 => $redis::bin_path,
+          instance_title           => $name,
+          port                     => $port,
+          redis_file_name          => $redis_file_name,
+          service_name             => $service_name,
+          service_user             => $service_user,
+          service_timeout_start    => $service_timeout_start,
+          service_timeout_stop     => $service_timeout_stop,
+          service_oom_score_adjust => $service_oom_score_adjust,
+          ulimit                   => $ulimit,
+          ulimit_managed           => $ulimit_managed,
         }
       ),
     }

--- a/spec/type_aliases/oomscoreadjust_spec.rb
+++ b/spec/type_aliases/oomscoreadjust_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Redis::OOMScoreAdjust' do
+  it { is_expected.to allow_values(1000, -1000, 0) }
+  it { is_expected.not_to allow_value(nil) }
+  it { is_expected.not_to allow_value(1001) }
+end

--- a/templates/service_templates/redis.service.epp
+++ b/templates/service_templates/redis.service.epp
@@ -10,6 +10,7 @@
   String[1]                                          $service_user,
   Optional[Integer[0]]                               $service_timeout_start,
   Optional[Integer[0]]                               $service_timeout_stop,
+  Optional[Redis::OOMScoreAdjust]                    $service_oom_score_adjust,
 | -%>
 [Unit]
 Description=<%= capitalize($provider) %> Advanced key-value store for instance <%= $instance_title %>
@@ -32,6 +33,9 @@ TimeoutStartSec=<%= $service_timeout_start %>
 <% } -%>
 <% if $service_timeout_stop { -%>
 TimeoutStopSec=<%= $service_timeout_stop %>
+<% } -%>
+<% if $service_oom_score_adjust { -%>
+OOMScoreAdjust=<%= $service_oom_score_adjust %>
 <% } -%>
 
 [Install]

--- a/types/oomscoreadjust.pp
+++ b/types/oomscoreadjust.pp
@@ -1,0 +1,2 @@
+# @summary Specify the OOMScoreAdjust range
+type Redis::OOMScoreAdjust = Integer[-1000,1000]


### PR DESCRIPTION
#### Pull Request (PR) description
Allow to set the OOMScoreAdjust for the systemd unit.

This allows to control how liklely oom-killer will target redis when in low memory situation.

#### This Pull Request (PR) fixes the following issues
N/A