### PR TITLE
Improve `provider` data type

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -238,7 +238,7 @@ The following parameters are available in the `redis` class:
 
 ##### <a name="-redis--provider"></a>`provider`
 
-Data type: `String[1]`
+Data type: `Enum['redis', 'valkey']`
 
 Name of the redis server implementation.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -353,14 +353,14 @@
 # @param acls
 #   This is a way to pass an array of raw ACLs to Redis. The ACLs must be
 #   in the form of:
-# 
+#
 #     user USERNAME [additional ACL options]
 #
 # @param manage_service_file
 #   Determine if the systemd service file should be managed
 #
 class redis (
-  String[1] $provider                                            = $redis::params::provider,
+  Enum['redis', 'valkey'] $provider                              = $redis::params::provider,
   Boolean $activerehashing                                       = true,
   Boolean $aof_load_truncated                                    = true,
   Boolean $aof_rewrite_incremental_fsync                         = true,

--- a/templates/service_templates/redis.service.epp
+++ b/templates/service_templates/redis.service.epp
@@ -1,5 +1,5 @@
 <%- |
-  String                                             $provider,
+  Enum['redis', 'valkey']                            $provider,
   Boolean                                            $ulimit_managed,
   Integer[0]                                         $ulimit,
   Stdlib::Absolutepath                               $bin_path,


### PR DESCRIPTION
Instead of a String, prefer an Enum with a an explicit list of allowed
values.
