### PR TITLE
Do not make `sentinel.conf` world readable

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1630,7 +1630,7 @@ Data type: `Stdlib::Filemode`
 
 Permissions of config file.
 
-Default value: `'0644'`
+Default value: `'0640'`
 
 ##### <a name="-redis--sentinel--conf_template"></a>`conf_template`
 

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -163,7 +163,7 @@ class redis::sentinel (
   Optional[Variant[String[1], Sensitive[String[1]]]] $auth_pass = undef,
   Stdlib::Absolutepath $config_file = $redis::params::sentinel_config_file,
   Stdlib::Absolutepath $config_file_orig = $redis::params::sentinel_config_file_orig,
-  Stdlib::Filemode $config_file_mode = '0644',
+  Stdlib::Filemode $config_file_mode = '0640',
   String[1] $conf_template = 'redis/redis-sentinel.conf.epp',
   Boolean $daemonize = $redis::params::sentinel_daemonize,
   Boolean $protected_mode = true,

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -95,7 +95,7 @@ describe 'redis::sentinel' do
         it {
           is_expected.to contain_file(config_file_orig).
             with_ensure('file').
-            with_mode('0644').
+            with_mode('0640').
             with_owner(redis).
             with_content(expected_content)
         }


### PR DESCRIPTION
#### Pull Request (PR) description
Remove world readable bit from sentinel.conf and its original file,
so that secrets like password used in authentication is not leaked.

#### This Pull Request (PR) fixes the following issues
n/a