### PR TITLE
Update config_dir_mode to 750 for RedHat family

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,7 +49,7 @@ class redis::params {
           $daemonize            = false
           $config_owner         = 'valkey'
           $config_group         = 'root'
-          $config_dir_mode      = '0755'
+          $config_dir_mode      = '0750'
           $log_dir_mode         = '0750'
           $log_file             = 'valkey.log'
 
@@ -80,7 +80,7 @@ class redis::params {
           $daemonize            = false
           $config_owner         = 'redis'
           $config_group         = 'root'
-          $config_dir_mode      = '0755'
+          $config_dir_mode      = '0750'
           $log_dir_mode         = '0750'
           $log_file             = 'redis.log'
 


### PR DESCRIPTION
In [1] for valkey/EL10 and [2] for redis/EL9 the permissions for the config_dir were updated to 750.

Update our params to match to avoid idempotency problems like

    Notice: /Stage[main]/Redis::Config/File[/etc/redis]/mode: mode changed '0750' to '0755'
    Info: Class[Redis::Config]: Scheduling refresh of Class[Redis::Service]
    Info: Class[Redis::Service]: Scheduling refresh of Service[redis]
    Notice: /Stage[main]/Redis::Service/Service[redis]: Triggered 'refresh' from 1 event

[1] https://gitlab.com/redhat/centos-stream/rpms/valkey/-/commit/129602a06fd50665f801b6b7d79dec4f3a30356f
[2] https://gitlab.com/redhat/centos-stream/rpms/redis/-/commit/b4ecefed2020a4aee1dc3a5844771f48b01dbe31

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
