### PR TITLE
Make it possible to install sentinel independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ class { 'redis::sentinel':
 }
 ```
 
+If installation without redis-server is desired, set `manage_redis` parameter to false, i.e
+```puppet
+class { 'redis::sentinel':
+  ...
+  manage_redis => false,
+  ...
+}
+```
+
 ### Soft dependency
 
 When managing the repo, it needs [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt).

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1594,6 +1594,7 @@ The following parameters are available in the `redis::sentinel` class:
 * [`sentinel_auth_pass`](#-redis--sentinel--sentinel_auth_pass)
 * [`sentinel_auth_user`](#-redis--sentinel--sentinel_auth_user)
 * [`acls`](#-redis--sentinel--acls)
+* [`manage_redis`](#-redis--sentinel--manage_redis)
 * [`service_ensure`](#-redis--sentinel--service_ensure)
 
 ##### <a name="-redis--sentinel--auth_pass"></a>`auth_pass`
@@ -1965,6 +1966,14 @@ in the form of:
   user USERNAME [additional ACL options]
 
 Default value: `[]`
+
+##### <a name="-redis--sentinel--manage_redis"></a>`manage_redis`
+
+Data type: `Boolean`
+
+Manage redis base class. If set to false, sentinel is installed without redis server.
+
+Default value: `true`
 
 ##### <a name="-redis--sentinel--service_ensure"></a>`service_ensure`
 

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -150,6 +150,10 @@
 #
 #     user USERNAME [additional ACL options]
 #
+# @param manage_redis
+#   Manage redis base class. If set to false, sentinel is installed without redis server.
+#
+#
 # @example Basic inclusion
 #   include redis::sentinel
 #
@@ -205,6 +209,7 @@ class redis::sentinel (
   Optional[Variant[String[1], Sensitive[String[1]]]] $sentinel_auth_pass = undef,
   Optional[String[1]] $sentinel_auth_user = undef,
   Array[String[1]] $acls = [],
+  Boolean $manage_redis = true,
 ) inherits redis::params {
   $auth_pass_unsensitive = if $auth_pass =~ Sensitive {
     $auth_pass.unwrap
@@ -212,7 +217,9 @@ class redis::sentinel (
     $auth_pass
   }
 
-  contain 'redis'
+  if $manage_redis {
+    contain 'redis'
+  }
 
   if $package_name != $redis::package_name {
     stdlib::ensure_packages([$package_name],
@@ -220,7 +227,9 @@ class redis::sentinel (
         ensure => $package_ensure
       },
     )
-    Package[$package_name] -> Class['redis']
+    if $manage_redis {
+      Package[$package_name] -> Class['redis']
+    }
   }
   Package[$package_name] -> File[$config_file_orig]
 


### PR DESCRIPTION
Hi there

This PR is a retake of https://github.com/voxpupuli/puppet-redis/pull/389

--------

This PR introduces the possibility to install redis::sentinel standalone, without redis::server. It comes in handy when you need your sentinels to be for example on a different node than your redis server.

The change itself is a pretty straightforward, I am just adding a contain_redis parameter, that makes the requirement of redis class conditional. The default value is true, which includes the redis and it is therefore backward compatible with the current setup.

The only downside of this approach I see currently is that in case someone needs a standalone redis-sentinel from a managed repository, the repository must be added manually as the redis::preinstall is no longer included (as was previously with the redis class)
This Pull Request (PR) fixes the following issues

    installation of standalone sentinel (no open issue for this one, so far)

