### PR TITLE
Add cluster-announce-ip parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ class { 'redis':
   cluster_enabled      => true,
   cluster_config_file  => 'nodes.conf',
   cluster_node_timeout => 5000,
+  cluster_announce_ip  => '10.0.1.2',
 }
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -217,6 +217,7 @@ The following parameters are available in the `redis` class:
 * [`cluster_slave_validity_factor`](#-redis--cluster_slave_validity_factor)
 * [`cluster_require_full_coverage`](#-redis--cluster_require_full_coverage)
 * [`cluster_migration_barrier`](#-redis--cluster_migration_barrier)
+* [`cluster_announce_ip`](#-redis--cluster_announce_ip)
 * [`instances`](#-redis--instances)
 * [`io_threads`](#-redis--io_threads)
 * [`io_threads_do_reads`](#-redis--io_threads_do_reads)
@@ -1314,6 +1315,15 @@ Only set if cluster_enabled is true
 
 Default value: `1`
 
+##### <a name="-redis--cluster_announce_ip"></a>`cluster_announce_ip`
+
+Data type: `Optional[Stdlib::Host]`
+
+The IP address that a Redis Cluster node should announce to the bus.
+Only set if cluster_enabled is true
+
+Default value: `undef`
+
 ##### <a name="-redis--instances"></a>`instances`
 
 Data type: `Hash[String[1], Hash]`
@@ -2129,6 +2139,7 @@ The following parameters are available in the `redis::instance` defined type:
 * [`cluster_slave_validity_factor`](#-redis--instance--cluster_slave_validity_factor)
 * [`cluster_require_full_coverage`](#-redis--instance--cluster_require_full_coverage)
 * [`cluster_migration_barrier`](#-redis--instance--cluster_migration_barrier)
+* [`cluster_announce_ip`](#-redis--instance--cluster_announce_ip)
 * [`io_threads`](#-redis--instance--io_threads)
 * [`io_threads_do_reads`](#-redis--instance--io_threads_do_reads)
 * [`cluster_allow_reads_when_down`](#-redis--instance--cluster_allow_reads_when_down)
@@ -3023,6 +3034,15 @@ slave to migrate to a  master which is no longer covered by any slave Only
 set if cluster_enabled is true
 
 Default value: `$redis::cluster_migration_barrier`
+
+##### <a name="-redis--instance--cluster_announce_ip"></a>`cluster_announce_ip`
+
+Data type: `Optional[Stdlib::Host]`
+
+The IP address that a Redis Cluster node should announce to the bus.
+Only set if cluster_enabled is true
+
+Default value: `$redis::cluster_announce_ip`
 
 ##### <a name="-redis--instance--io_threads"></a>`io_threads`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -305,6 +305,9 @@
 #   Minimum number of slaves master will remain connected with, for another
 #   slave to migrate to a master which is no longer covered by any slave.
 #   Only set if cluster_enabled is true
+# @param cluster_announce_ip
+#   The IP address that a Redis Cluster node should announce to the bus.
+#   Only set if cluster_enabled is true
 # @param instances
 #   Iterate through multiple instance configurations
 # @param io_threads
@@ -493,6 +496,7 @@ class redis (
   Integer[0] $cluster_slave_validity_factor                      = 0,
   Boolean $cluster_require_full_coverage                         = true,
   Integer[0] $cluster_migration_barrier                          = 1,
+  Optional[Stdlib::Host] $cluster_announce_ip                    = undef,
   Hash[String[1], Hash] $instances                               = {},
   Optional[Integer[1]] $io_threads                               = undef,
   Optional[Boolean] $io_threads_do_reads                         = undef,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -242,6 +242,9 @@
 #   Minimum number of slaves master will remain connected with, for another
 #   slave to migrate to a  master which is no longer covered by any slave Only
 #   set if cluster_enabled is true
+# @param cluster_announce_ip
+#   The IP address that a Redis Cluster node should announce to the bus.
+#   Only set if cluster_enabled is true
 # @param io_threads
 #   Number of threads to handle IO operations in Redis
 # @param io_threads_do_reads
@@ -394,6 +397,7 @@ define redis::instance (
   Integer[0] $cluster_slave_validity_factor                      = $redis::cluster_slave_validity_factor,
   Boolean $cluster_require_full_coverage                         = $redis::cluster_require_full_coverage,
   Integer[0] $cluster_migration_barrier                          = $redis::cluster_migration_barrier,
+  Optional[Stdlib::Host] $cluster_announce_ip                    = $redis::cluster_announce_ip,
   String[1] $service_name                                        = "${redis::provider}-server-${name}",
   Stdlib::Ensure::Service $service_ensure                        = $redis::service_ensure,
   Boolean $service_enable                                        = $redis::service_enable,
@@ -576,6 +580,7 @@ define redis::instance (
     cluster_slave_validity_factor => $cluster_slave_validity_factor,
     cluster_require_full_coverage => $cluster_require_full_coverage,
     cluster_migration_barrier     => $cluster_migration_barrier,
+    cluster_announce_ip           => $cluster_announce_ip,
     extra_config_file             => $extra_config_file,
     tls_port                      => $tls_port,
     tls_cert_file                 => $tls_cert_file,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -134,6 +134,8 @@ class redis::params {
       $pid_file                  = '/var/run/redis/redis.pid'
       $daemonize                 = true
       $service_name              = 'redis'
+      $service_group             = 'redis'
+      $service_user              = 'redis'
       $workdir                   = '/var/db/redis'
       $bin_path                  = '/usr/bin'
       $unixsocket                = '/var/run/redis/redis.sock'

--- a/templates/redis.conf.epp
+++ b/templates/redis.conf.epp
@@ -71,6 +71,7 @@
   Integer[0]                                         $cluster_slave_validity_factor,
   Boolean                                            $cluster_require_full_coverage,
   Integer[0]                                         $cluster_migration_barrier,
+  Optional[Stdlib::Host]                             $cluster_announce_ip,
   Optional[String]                                   $extra_config_file,
   Optional[Stdlib::Port]                             $tls_port,
   Optional[Stdlib::Absolutepath]                     $tls_cert_file,
@@ -1046,6 +1047,7 @@ cluster-node-timeout <%= $cluster_node_timeout %>
 cluster-slave-validity-factor <%= $cluster_slave_validity_factor %>
 cluster-require-full-coverage <%= bool2str($cluster_require_full_coverage, 'yes', 'no') %>
 cluster-migration-barrier <%= $cluster_migration_barrier %>
+<% if $cluster_announce_ip { -%>cluster-announce-ip <%= $cluster_announce_ip %><% } %>
 <% if $cluster_allow_reads_when_down { -%>cluster-allow-reads-when-down <%= $cluster_allow_reads_when_down ? {true => 'yes', default => 'no'} %><% } %>
 <% if $cluster_replica_no_failover { -%>cluster-replica-no-failover <%= $cluster_replica_no_failover ? {true => 'yes', default => 'no'} %><% } %>
 <% } -%>


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the cluster-announce-ip parameter to enable Redis cluster members to announce via a specific address (especially to avoid using 127.0.0.1)
