### PR TITLE
Don't manage ulimit with systemd on FreeBSD

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2147,6 +2147,7 @@ The following parameters are available in the `redis::instance` defined type:
 * [`output_buffer_limit_slave`](#-redis--instance--output_buffer_limit_slave)
 * [`output_buffer_limit_pubsub`](#-redis--instance--output_buffer_limit_pubsub)
 * [`custom_options`](#-redis--instance--custom_options)
+* [`config_dir`](#-redis--instance--config_dir)
 
 ##### <a name="-redis--instance--activerehashing"></a>`activerehashing`
 
@@ -3182,6 +3183,14 @@ Data type: `Hash[String[1],Variant[String[1], Integer]]`
 hash of custom options, not available as direct parameter.
 
 Default value: `{}`
+
+##### <a name="-redis--instance--config_dir"></a>`config_dir`
+
+Data type: `Stdlib::Absolutepath`
+
+
+
+Default value: `$redis::config_dir`
 
 ## Functions
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1167,7 +1167,7 @@ Data type: `Boolean`
 Defines wheter the max number of open files for the
 systemd service unit is explicitly managed.
 
-Default value: `true`
+Default value: `$redis::params::ulimit_managed`
 
 ##### <a name="-redis--unixsocket"></a>`unixsocket`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -477,7 +477,7 @@ class redis (
   Variant[Stdlib::Absolutepath, Enum['']] $unixsocket            = $redis::params::unixsocket,
   Variant[Stdlib::Filemode, Enum['']] $unixsocketperm            = '0755',
   Integer[0] $ulimit                                             = 65536,
-  Boolean $ulimit_managed                                        = true,
+  Boolean $ulimit_managed                                        = $redis::params::ulimit_managed,
   Stdlib::Absolutepath $workdir                                  = $redis::params::workdir,
   Stdlib::Filemode $workdir_mode                                 = '0750',
   Optional[String[1]] $workdir_group                             = undef,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -310,6 +310,7 @@ define redis::instance (
   String[1] $output_buffer_limit_pubsub                          = $redis::output_buffer_limit_pubsub,
   String[1] $conf_template                                       = $redis::conf_template,
   Stdlib::Absolutepath $config_file                              = $redis::config_file,
+  Stdlib::Absolutepath $config_dir                               = $redis::config_dir,
   Stdlib::Filemode $config_file_mode                             = $redis::config_file_mode,
   Stdlib::Absolutepath $config_file_orig                         = $redis::config_file_orig,
   String[1] $config_group                                        = $redis::config_group,
@@ -427,8 +428,8 @@ define redis::instance (
     $redis_file_name_orig = $config_file_orig
     $redis_file_name      = $config_file
   } else {
-    $redis_file_name_orig = sprintf('%s/%s.%s', dirname($config_file_orig), $service_name, 'conf.puppet')
-    $redis_file_name      = sprintf('%s/%s.%s', dirname($config_file), $service_name, 'conf')
+    $redis_file_name_orig = sprintf('%s/%s.%s', $config_dir, $service_name, 'conf.puppet')
+    $redis_file_name      = sprintf('%s/%s.%s', $config_dir, $service_name, 'conf')
   }
 
   if $log_dir != $redis::log_dir {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -137,6 +137,8 @@ class redis::params {
       $pid_file                  = '/var/run/redis/redis.pid'
       $daemonize                 = true
       $service_name              = 'redis'
+      $service_user              = 'redis'
+      $service_group             = 'redis'
       $workdir                   = '/var/db/redis'
       $bin_path                  = '/usr/bin'
       $unixsocket                = '/var/run/redis/redis.sock'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class redis::params {
       $workdir                   = '/var/lib/redis'
       $bin_path                  = '/usr/bin'
       $unixsocket                = '/var/run/redis/redis.sock'
+      $ulimit_managed            = true
       $daemonize                 = true
       $service_name              = 'redis-server'
       $service_group             = 'redis'
@@ -68,6 +69,7 @@ class redis::params {
           $workdir                   = '/var/lib/valkey'
           $bin_path                  = '/usr/bin'
           $unixsocket                = '/var/run/valkey/valkey.sock'
+          $ulimit_managed              = true
           $sentinel_config_file      = '/etc/valkey/sentinel.conf'
           $sentinel_config_file_orig = '/etc/valkey/sentinel.conf.puppet'
           $sentinel_service_name     = 'valkey-sentinel'
@@ -104,6 +106,7 @@ class redis::params {
           $workdir                     = '/var/lib/redis'
           $bin_path                    = '/usr/bin'
           $unixsocket                  = '/var/run/redis/redis.sock'
+          $ulimit_managed              = true
           if (versioncmp($facts['os']['release']['major'], '9') >= 0) {
             $sentinel_config_file      = '/etc/redis/sentinel.conf'
             $sentinel_config_file_orig = '/etc/redis/sentinel.conf.puppet'
@@ -137,6 +140,7 @@ class redis::params {
       $workdir                   = '/var/db/redis'
       $bin_path                  = '/usr/bin'
       $unixsocket                = '/var/run/redis/redis.sock'
+      $ulimit_managed            = false
 
       $sentinel_config_file      = '/usr/local/etc/redis-sentinel.conf'
       $sentinel_config_file_orig = '/usr/local/etc/redis-sentinel.conf.puppet'
@@ -168,6 +172,7 @@ class redis::params {
       $workdir                   = '/var/lib/redis'
       $bin_path                  = '/usr/bin'
       $unixsocket                = '/var/run/redis/redis.sock'
+      $ulimit_managed            = true
 
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
@@ -199,6 +204,7 @@ class redis::params {
       $workdir                   = '/var/lib/redis'
       $bin_path                  = '/usr/bin'
       $unixsocket                = '/var/run/redis/redis.sock'
+      $ulimit_managed            = true
 
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'

--- a/metadata.json
+++ b/metadata.json
@@ -77,6 +77,14 @@
         "9",
         "10"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "13",
+        "14",
+        "15"
+      ]
     }
   ]
 }

--- a/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
+++ b/spec/acceptance/suites/default/redis_multi_instances_one_host_spec.rb
@@ -17,10 +17,10 @@ describe 'redis::instance example' do
           end
 
   config_path = case fact('os.family')
-                when 'Debian'
+                when 'Debian', 'RedHat'
                   "/etc/#{redis}"
-                when 'RedHat'
-                  (fact('os.release.major').to_i >= 9) ? "/etc/#{redis}" : '/etc'
+                when 'FreeBSD'
+                  '/usr/local/etc/redis'
                 else
                   '/etc'
                 end

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -88,13 +88,18 @@ describe 'redis' do
         it { is_expected.to compile.with_all_deps }
 
         it do
-          is_expected.to contain_file("/etc/security/limits.d/#{redis}.conf").with(
-            'ensure' => 'file',
-            'owner' => 'root',
-            'group' => 'root',
-            'mode' => '0644',
-            'content' => "#{redis} soft nofile 65536\n#{redis} hard nofile 65536\n",
-          )
+          case facts['os']['family']
+          when 'FreeBSD'
+            # skip /etc/security/limits.d tests on FreeBSD
+          else
+            is_expected.to contain_file("/etc/security/limits.d/#{redis}.conf").with(
+              'ensure' => 'file',
+              'owner' => 'root',
+              'group' => 'root',
+              'mode' => '0644',
+              'content' => "#{redis} soft nofile 65536\n#{redis} hard nofile 65536\n",
+            )
+          end
         end
 
         context 'when not managing service' do
@@ -103,13 +108,18 @@ describe 'redis' do
           it { is_expected.to compile.with_all_deps }
 
           it do
-            is_expected.to contain_file("/etc/security/limits.d/#{redis}.conf").with(
-              'ensure' => 'file',
-              'owner' => 'root',
-              'group' => 'root',
-              'mode' => '0644',
-              'content' => "#{redis} soft nofile 65536\n#{redis} hard nofile 65536\n",
-            )
+            case facts['os']['family']
+            when 'FreeBSD'
+              # skip /etc/security/limits.d tests on FreeBSD
+            else
+              is_expected.to contain_file("/etc/security/limits.d/#{redis}.conf").with(
+                'ensure' => 'file',
+                'owner' => 'root',
+                'group' => 'root',
+                'mode' => '0644',
+                'content' => "#{redis} soft nofile 65536\n#{redis} hard nofile 65536\n",
+              )
+            end
           end
         end
       end
@@ -121,13 +131,18 @@ describe 'redis' do
           it { is_expected.to compile.with_all_deps }
 
           it do
-            is_expected.to contain_file("/etc/systemd/system/#{service_name}.service.d/limit.conf")
-              .with_ensure('absent')
+            case facts['os']['family']
+            when 'FreeBSD'
+              # skip systemd tests on FreeBSD
+            else
+              is_expected.to contain_file("/etc/systemd/system/#{service_name}.service.d/limit.conf")
+                .with_ensure('absent')
 
-            is_expected.to contain_systemd__manage_dropin("#{service_name}-90-limits.conf")
-              .with_service_entry({ 'LimitNOFILE' => 7777 })
-              .with_ensure('present')
-              .with_unit("#{service_name}.service")
+              is_expected.to contain_systemd__manage_dropin("#{service_name}-90-limits.conf")
+                .with_service_entry({ 'LimitNOFILE' => 7777 })
+                .with_ensure('present')
+                .with_unit("#{service_name}.service")
+            end
           end
         end
 
@@ -137,7 +152,12 @@ describe 'redis' do
           it { is_expected.to compile.with_all_deps }
 
           it do
-            is_expected.not_to contain_systemd__service_limits("#{service_name}.service")
+            case facts['os']['family']
+            when 'FreeBSD'
+              # skip systemd tests on FreeBSD
+            else
+              is_expected.not_to contain_systemd__service_limits("#{service_name}.service")
+            end
           end
         end
       end
@@ -279,9 +299,14 @@ describe 'redis' do
       end
 
       describe 'with parameter: config_dir_mode' do
-        let(:params) { { config_dir_mode: '0700' } }
+        let(:params) do
+          {
+            config_dir: '/etc/config_dir',
+            config_dir_mode: '0700',
+          }
+        end
 
-        it { is_expected.to contain_file("/etc/#{redis}").with_mode('0700') }
+        it { is_expected.to contain_file('/etc/config_dir').with_mode('0700') }
       end
 
       describe 'with parameter: log_dir_mode' do
@@ -303,15 +328,25 @@ describe 'redis' do
       end
 
       describe 'with parameter: config_group' do
-        let(:params) { { config_group: '_VALUE_' } }
+        let(:params) do
+          {
+            config_dir: '/etc/config_dir',
+            config_group: '_VALUE_',
+          }
+        end
 
-        it { is_expected.to contain_file("/etc/#{redis}").with_group('_VALUE_') }
+        it { is_expected.to contain_file('/etc/config_dir').with_group('_VALUE_') }
       end
 
       describe 'with parameter: config_owner' do
-        let(:params) { { config_owner: '_VALUE_' } }
+        let(:params) do
+          {
+            config_dir: '/etc/config_dir',
+            config_owner: '_VALUE_',
+          }
+        end
 
-        it { is_expected.to contain_file("/etc/#{redis}").with_owner('_VALUE_') }
+        it { is_expected.to contain_file('/etc/config_dir').with_owner('_VALUE_') }
       end
 
       describe 'with parameter daemonize' do
@@ -1523,32 +1558,44 @@ describe 'redis' do
           }
         end
 
-        it { is_expected.to contain_systemd__unit_file("#{service_name}.service") }
+        it do
+          case facts['os']['family']
+          when 'FreeBSD'
+            # skip systemd tests on FreeBSD
+          else
+            is_expected.to contain_systemd__unit_file("#{service_name}.service")
+          end
+        end
 
         it do
-          content = <<-END.gsub(%r{^\s+\|}, '')
-            |[Unit]
-            |Description=#{redis.capitalize} Advanced key-value store for instance default
-            |After=network.target
-            |After=network-online.target
-            |Wants=network-online.target
-            |
-            |[Service]
-            |RuntimeDirectory=#{service_name}
-            |RuntimeDirectoryMode=2755
-            |Type=notify
-            |ExecStart=/usr/bin/#{redis}-server #{config_file} --supervised systemd --daemonize no
-            |ExecStop=/usr/bin/#{redis}-cli -p 6379 shutdown
-            |Restart=always
-            |User=#{redis}
-            |Group=#{redis}
-            |LimitNOFILE=65536
-            |
-            |[Install]
-            |WantedBy=multi-user.target
-          END
+          case facts['os']['family']
+          when 'FreeBSD'
+            # skip systemd tests on FreeBSD
+          else
+            content = <<-END.gsub(%r{^\s+\|}, '')
+              |[Unit]
+              |Description=#{redis.capitalize} Advanced key-value store for instance default
+              |After=network.target
+              |After=network-online.target
+              |Wants=network-online.target
+              |
+              |[Service]
+              |RuntimeDirectory=#{service_name}
+              |RuntimeDirectoryMode=2755
+              |Type=notify
+              |ExecStart=/usr/bin/#{redis}-server #{config_file} --supervised systemd --daemonize no
+              |ExecStop=/usr/bin/#{redis}-cli -p 6379 shutdown
+              |Restart=always
+              |User=#{redis}
+              |Group=#{redis}
+              |LimitNOFILE=65536
+              |
+              |[Install]
+              |WantedBy=multi-user.target
+            END
 
-          is_expected.to contain_systemd__unit_file("#{service_name}.service").with_content(content)
+            is_expected.to contain_systemd__unit_file("#{service_name}.service").with_content(content)
+          end
         end
       end
 

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -28,35 +28,57 @@ describe 'redis::instance' do
         let(:title) { 'app2' }
         let(:config_file) do
           case facts['os']['family']
-          when 'RedHat'
-            if facts['os']['release']['major'].to_i > 8
-              "/etc/#{redis}/#{redis}-server-app2.conf"
-            else
-              "/etc/#{redis}-server-app2.conf"
-            end
+          when 'Debian', 'Archlinux', 'RedHat'
+            "/etc/#{redis}/#{redis}-server-#{title}.conf"
           when 'FreeBSD'
-            '/usr/local/etc/redis/redis-server-app2.conf'
-          when 'Debian', 'Archlinux'
-            "/etc/#{redis}/#{redis}-server-app2.conf"
+            "/usr/local/etc/redis/redis-server-#{title}.conf"
           end
         end
 
         it do
-          is_expected.to contain_file("#{config_file}.puppet")
-            .with_content(%r{^bind 127.0.0.1})
-            .with_content(%r{^logfile /var/log/#{redis}/#{redis}-server-app2\.log})
-            .with_content(%r{^dir /var/lib/#{redis}/#{redis}-server-app2})
-            .with_content(%r{^unixsocket /var/run/#{redis}-server-app2/#{redis}\.sock})
+          case facts['os']['family']
+          when 'FreeBSD'
+            is_expected.to contain_file("#{config_file}.puppet")
+              .with_content(%r{^bind 127.0.0.1})
+              .with_content(%r{^logfile /var/log/#{redis}/#{redis}-server-#{title}\.log})
+              .with_content(%r{^dir /var/db/redis/#{redis}-server-#{title}})
+              .with_content(%r{^unixsocket /var/run/#{redis}-server-#{title}/#{redis}\.sock})
+          else
+            is_expected.to contain_file("#{config_file}.puppet")
+              .with_content(%r{^bind 127.0.0.1})
+              .with_content(%r{^logfile /var/log/#{redis}/#{redis}-server-#{title}\.log})
+              .with_content(%r{^dir /var/lib/#{redis}/#{redis}-server-#{title}})
+              .with_content(%r{^unixsocket /var/run/#{redis}-server-#{title}/#{redis}\.sock})
+          end
         end
-
-        it { is_expected.to contain_file("/var/lib/#{redis}/#{redis}-server-app2") }
 
         it do
-          is_expected.to contain_file("/etc/systemd/system/#{redis}-server-app2.service")
-            .with_content(%r{ExecStart=/usr/bin/#{redis}-server #{config_file}})
+          case facts['os']['family']
+          when 'FreeBSD'
+            is_expected.to contain_file("/var/db/redis/#{redis}-server-#{title}")
+          else
+            is_expected.to contain_file("/var/lib/#{redis}/#{redis}-server-#{title}")
+          end
         end
 
-        it { is_expected.to contain_service("#{redis}-server-app2.service").with_ensure(true).with_enable(true) }
+        it do
+          case facts['os']['family']
+          when 'FreeBSD'
+            # skip systemd tests on FreeBSD
+          else
+            is_expected.to contain_file("/etc/systemd/system/#{redis}-server-#{title}.service")
+              .with_content(%r{ExecStart=/usr/bin/#{redis}-server #{config_file}})
+          end
+        end
+
+        it do
+          case facts['os']['family']
+          when 'FreeBSD'
+            # skip systemd tests on FreeBSD
+          else
+            is_expected.to contain_service("#{redis}-server-#{title}.service").with_ensure(true).with_enable(true)
+          end
+        end
       end
 
       context 'with custom options' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Set ulimit_managed class parameter to redis::params::ulimit_managed and set appropriate default per platform in params.pp
This avoids any systemd resource being triggered thus allowing the module to work again on FreeBSD

FWIW, I've ran the lint/tests on Ubuntu 24.04 (because of the Ruby 3.2 requirements during `bundle install` as per https://voxpupuli.org/docs/how_to_run_tests/ ) and observed no issues

```
$ bundle exec rake lint
$ bundle exec rake rubocop
...
24 files inspected, no offenses detected
Finished in 1.43773 seconds
$ bundle exec rake test
...
Finished in 10 minutes 50 seconds (files took 1.92 seconds to load)
2360 examples, 0 failures


2666 examples, 0 failures

```

#### This Pull Request (PR) fixes the following issues
No issue was filed for this PR, direct fix. However it is somewhat a continuation of #455 with the bare minimum of work to get it going again on FreeBSD
